### PR TITLE
Fix CI tests

### DIFF
--- a/evm_loader/deploy-test.sh
+++ b/evm_loader/deploy-test.sh
@@ -24,6 +24,8 @@ if [ ${#EVM_LOADER} -eq 0 ]; then
   exit 1
 fi
 
+sleep 25   # Wait while evm_loader deploy finalized
+
 python3 -m unittest discover -v -p 'test*.py'
 
 echo "Deploy test success"

--- a/evm_loader/test.py
+++ b/evm_loader/test.py
@@ -25,35 +25,6 @@ class SolanaCliTests(unittest.TestCase):
     def test_solana_cli(self):
         print(solana_cli().call('--version'))
 
-    def test_solana_deploy(self):
-        contract = so_dir+'spl_memo.so'
-        result = solana_cli(self.acc).call('deploy --commitment max {}'.format(contract))
-        substr = "Program Id: "
-        if result.startswith(substr):
-            programId = result[len(substr):].strip()
-        else:
-            raise Exception("solana deploy error: ", result)
-
-        def send_memo_trx(data):
-            trx = Transaction()
-            trx.add(
-                TransactionInstruction(program_id=programId, data=data, keys=[
-                    AccountMeta(pubkey=self.acc.get_acc().public_key(), is_signer=True, is_writable=False),
-                ]))
-            res = http_client.send_transaction(trx, self.acc.get_acc())
-            return res["result"]
-
-        trxId = send_memo_trx('hello')
-        # confirm_transaction(http_client, trxId)
-
-        err = "Transaction simulation failed: Error processing Instruction 0: invalid instruction data"
-        with self.assertRaisesRegex(Exception, err):
-            try:
-              send_memo_trx(b'\xF0\x9F\x90\xff')
-            except Exception as e:
-                print("Exception:", e)
-                raise
-
 def checkAccount(self, account):
     info = http_client.get_account_info(account)
     print("checkAccount({}): {}".format(account, info))


### PR DESCRIPTION
Remove tests that used solana-program-library artifacts.
 - spl_memo.so - used only to verify that deploy works correctly
 - token-cli - used in ERC20 tests. Can be replaced with Python library (https://github.com/michaelhly/solana-py)