### PR TITLE
#4 Optimize contract code serialization

### DIFF
--- a/evm_loader/program/src/executor_state.rs
+++ b/evm_loader/program/src/executor_state.rs
@@ -13,6 +13,7 @@ use crate::utils::{keccak256_h256, keccak256_h256_v};
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct ExecutorAccount {
     pub basic: Basic,
+    #[serde(with = "serde_bytes")]
     pub code: Option<Vec<u8>>,
     pub reset: bool,
 }


### PR DESCRIPTION
Use `serde_bytes` to enable optimized handling of `Vec<u8>`.