### PR TITLE
18 gasometer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "evm_loader/rust-evm"]
 	path = evm_loader/rust-evm
 	url = https://github.com/neonlabsorg/evm.git
-	branch = 18-gasometer
+	branch = develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "evm_loader/rust-evm"]
 	path = evm_loader/rust-evm
 	url = https://github.com/neonlabsorg/evm.git
-	branch = evm_integration
+	branch = 18-gasometer

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM builder AS evm-loader-builder
 COPY ./evm_loader/ /opt/evm_loader/
 WORKDIR /opt/evm_loader/program
 RUN cargo clippy
-RUN cargo build-bpf
+RUN cargo build-bpf --features no-logs
 WORKDIR /opt/evm_loader/cli
 RUN cargo clippy
 RUN cargo build --release
@@ -46,7 +46,7 @@ FROM cybercoredev/solana:v1.6.9-resources AS solana
 FROM ubuntu:20.04 AS base
 WORKDIR /opt
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates curl python3 python3-pip && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install vim less openssl ca-certificates curl python3 python3-pip && \
     rm -rf /var/lib/apt/lists/*
 
 COPY evm_loader/test_requirements.txt solana-py.patch /tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM builder AS evm-loader-builder
 COPY ./evm_loader/ /opt/evm_loader/
 WORKDIR /opt/evm_loader/program
 RUN cargo clippy
-RUN cargo build-bpf --release
+RUN cargo build-bpf
 WORKDIR /opt/evm_loader/cli
 RUN cargo clippy
 RUN cargo build --release

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM builder AS evm-loader-builder
 COPY ./evm_loader/ /opt/evm_loader/
 WORKDIR /opt/evm_loader/program
 RUN cargo clippy
-RUN cargo build-bpf --features no-logs
+RUN cargo build-bpf --release
 WORKDIR /opt/evm_loader/cli
 RUN cargo clippy
 RUN cargo build --release

--- a/evm_loader/ERC20/test/test_erc20.py
+++ b/evm_loader/ERC20/test/test_erc20.py
@@ -43,7 +43,7 @@ class ERC20:
         instruction = data[0]
         assert (instruction == 6)  # 6 means OnReturn
         assert (data[1] < 0xd0)  # less 0xd0 - success
-        value = data[2:]
+        value = data[10:]
         balance_address = base58.b58encode(value)
         return balance_address
 
@@ -58,7 +58,7 @@ class ERC20:
         instruction = data[0]
         assert (instruction == 6)  # 6 means OnReturn
         assert (data[1] < 0xd0)  # less 0xd0 - success
-        value = data[2:]
+        value = data[10:]
         mint_id = base58.b58encode(value)
         return mint_id
 
@@ -74,7 +74,7 @@ class ERC20:
         instruction = data[0]
         assert (instruction == 6)  # 6 means OnReturn
         assert (data[1] < 0xd0)  # less 0xd0 - success
-        value = data[2:]
+        value = data[10:]
         balance = int.from_bytes(value, "big")
         return balance
 
@@ -99,7 +99,7 @@ class ERC20:
         instruction = data[0]
         assert (instruction == 6)  # 6 means OnReturn
         assert (data[1] < 0xd0)  # less 0xd0 - success
-        value = data[2:]
+        value = data[10:]
         ret = int.from_bytes(value, "big")
         assert 0 != ret, 'erc20.deposit: FAIL'
         return ether_trx.trx_data
@@ -123,7 +123,7 @@ class ERC20:
         instruction = data[0]
         assert (instruction == 6)  # 6 means OnReturn
         assert (data[1] < 0xd0)  # less 0xd0 - success
-        value = data[2:]
+        value = data[10:]
         ret = int.from_bytes(value, "big")
         assert ret != 0, 'erc20.withdraw: FAIL'
         return ret
@@ -142,7 +142,7 @@ class ERC20:
         instruction = data[0]
         assert (instruction == 6)  # 6 means OnReturn
         assert (data[1] < 0xd0)  # less 0xd0 - success
-        value = data[2:]
+        value = data[10:]
         ret = int.from_bytes(value, "big")
         print('erc20.transfer:', 'OK' if ret != 0 else 'FAIL')
         return ret

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -416,7 +416,7 @@ fn make_deploy_ethereum_transaction(
         let tx = UnsignedTransaction {
             to: None,
             nonce: trx_count,
-            gas_limit: 9999999.into(),
+            gas_limit: 9_999_999.into(),
             gas_price: 1.into(),
             value: 0.into(),
             data: program_data.to_owned(),

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -106,9 +106,9 @@ fn command_emulate(config: &Config, contract_id: H160, caller_id: H160, data: Ve
     let (exit_reason, result, applies_logs) = {
         let backend = SolanaBackend::new(&account_storage, None);
         let config = evm::Config::istanbul();
-        let mut executor = StackExecutor::new(&backend, usize::MAX, &config);
+        let mut executor = StackExecutor::new(&backend, u64::MAX, &config);
     
-        let (exit_reason, result) = executor.transact_call(caller_id, contract_id, U256::zero(), data, usize::MAX);
+        let (exit_reason, result) = executor.transact_call(caller_id, contract_id, U256::zero(), data, u64::MAX);
     
         debug!("Call done");
         
@@ -269,7 +269,7 @@ fn send_and_confirm_transactions_with_spinner<T: Signers>(
         // Collect statuses for all the transactions, drop those that are confirmed
         loop {
             let mut slot = 0;
-            let pending_signatures = pending_transactions.keys().cloned().collect::<Vec<_>>();
+            let pending_signatures = pending_transactions.keys().copied().collect::<Vec<_>>();
             for pending_signatures_chunk in
                 pending_signatures.chunks(MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS)
             {

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -124,6 +124,7 @@ fn command_emulate(config: &Config, contract_id: H160, caller_id: H160, data: Ve
 
     debug!("Call done");
     let status = match exit_reason {
+        ExitReason::StepLimitReached => unreachable!(),
         ExitReason::Succeed(_) => {
             let (applies, _logs) = applies_logs.unwrap();
     

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -416,7 +416,7 @@ fn make_deploy_ethereum_transaction(
         let tx = UnsignedTransaction {
             to: None,
             nonce: trx_count,
-            gas_limit: 1.into(),
+            gas_limit: 9999999.into(),
             gas_price: 1.into(),
             value: 0.into(),
             data: program_data.to_owned(),

--- a/evm_loader/program/Cargo.toml
+++ b/evm_loader/program/Cargo.toml
@@ -26,7 +26,6 @@ remove_dir_all = "=0.5.0"
 thiserror = "1.0"
 arrayref = "0.3.6"
 num_enum = "0.5.1"
-evm = { path = "../rust-evm", version = "0.18.0", default_features = false, features = ["with-serde"] }
 hex = "0.4.2"
 bs58 = "0.3.1"
 getrandom = { version = "0.1.16", default_features = false, features = ["dummy"] }
@@ -38,8 +37,8 @@ serde_derive = "1.0.103"
 impl-serde = "0.1"
 rlp = "0.5"
 bincode = ""
+evm = { version = "0.18.0", path = "../rust-evm", default_features = false, features = ["with-serde"] }
 evm-runtime = { version = "0.18", path = "../rust-evm/runtime", default-features = false }
-
 
 [dev-dependencies]
 rand = { version = "0.7.0"}

--- a/evm_loader/program/src/account_data.rs
+++ b/evm_loader/program/src/account_data.rs
@@ -89,7 +89,7 @@ impl AccountData {
             AccountData::Account(acc) => acc.size() + 1,
             AccountData::Contract(acc) => acc.size() + 1,
             AccountData::Storage(acc) => acc.size() + 1,
-            _ => 1,
+            AccountData::Empty => 1,
         }
     }
 

--- a/evm_loader/program/src/account_storage.rs
+++ b/evm_loader/program/src/account_storage.rs
@@ -15,6 +15,7 @@ use solana_program::{
 use std::{
     cell::RefCell,
 };
+use std::convert::TryFrom;
 
 pub enum Sender {
     Ethereum (H160),
@@ -204,7 +205,8 @@ impl<'a> ProgramAccountStorage<'a> {
                     if let Some(pos) = self.find_account(&address) {
                         let account = &mut self.accounts[pos];
                         let account_info = &self.account_metas[pos];
-                        account.update(account_info, address, basic.nonce, basic.balance.as_u64(), &code, storage, reset_storage)?;
+                        let basic_balance = u64::try_from(basic.balance).map_err(|_| ProgramError::InvalidAccountData)?;
+                        account.update(account_info, address, basic.nonce, basic_balance, &code, storage, reset_storage)?;
                     }
                     else {
                         if let Sender::Solana(addr) = self.sender {

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -445,16 +445,18 @@ fn do_call<'a>(
 	    let config = evm::Config::default();
         let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit, &config), backend);
         let mut executor = Machine::new(executor_state);
+
         debug_print!("Executor initialized");
 
-	    if let Err(_) = executor.call_begin(
+	    if let Err(e) = executor.call_begin(
             account_storage.origin(),
             account_storage.contract(),
             instruction_data,
             gas_limit,
-            true, // take_l64
+            false, // take_l64
             false, // estimate
         ) {
+            debug_print!("{:?}", e);
             return Err(ProgramError::InvalidInstructionData);
         }
 
@@ -511,8 +513,14 @@ fn do_partial_call<'a>(
     debug_print!("   caller: {}", account_storage.origin());
     debug_print!(" contract: {}", account_storage.contract());
 
-    let r = executor.call_begin(account_storage.origin(), account_storage.contract(), instruction_data, gas_limit, false, false);
-    if let Err(e) = r {
+    if let Err(e) = executor.call_begin(
+        account_storage.origin(),
+        account_storage.contract(),
+        instruction_data,
+        gas_limit,
+        false, // take_l64
+        false, // estimate
+    ) {
         debug_print!("{:?}", e);
         return Err(ProgramError::InvalidInstructionData);
     }

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -616,7 +616,7 @@ fn invoke_on_return<'a>(
 ) -> ProgramResult
 {
     let exit_status = match exit_reason {
-        ExitReason::StepLimitReached => { unreachable!() },
+        ExitReason::StepLimitReached => unreachable!(),
         ExitReason::Succeed(success_code) => {
             debug_print!("Succeed");
             match success_code {

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -397,7 +397,7 @@ fn do_finalize<'a>(program_id: &Pubkey, accounts: &'a [AccountInfo<'a>]) -> Prog
 
         let gas_limit = usize::MAX;
 	    let config = evm::Config::default();
-        let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit, &config), backend);
+        let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit, config), backend);
         let mut executor = Machine::new(executor_state);
 
         debug_print!("Executor initialized");
@@ -445,7 +445,7 @@ fn do_call<'a>(
         debug_print!("  backend initialized");
 
 	    let config = evm::Config::default();
-        let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit, &config), backend);
+        let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit, config), backend);
         let mut executor = Machine::new(executor_state);
 
         debug_print!("Executor initialized");
@@ -507,7 +507,7 @@ fn do_partial_call<'a>(
     debug_print!("  backend initialized");
 
     let config = evm::Config::default();
-    let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit, &config), backend);
+    let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit, config), backend);
     let mut executor = Machine::new(executor_state);
 
     debug_print!("Executor initialized");
@@ -552,7 +552,7 @@ fn do_partial_create<'a>(
     debug_print!("  backend initialized");
 
     let config = evm::Config::default();
-    let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit, &config), backend);
+    let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit, config), backend);
     let mut executor = Machine::new(executor_state);
 
     debug_print!("Executor initialized");

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -456,7 +456,7 @@ fn do_call<'a>(
             account_storage.contract(),
             instruction_data,
             gas_limit,
-        ).map_err(|_| ProgramError::InvalidInstructionData)?;
+        )?;
 
         let (result, exit_reason) = executor.execute();
 
@@ -512,7 +512,7 @@ fn do_partial_call<'a>(
         account_storage.contract(),
         instruction_data,
         gas_limit,
-    ).map_err(|_| ProgramError::InvalidInstructionData)?;
+    )?;
 
     executor.execute_n_steps(step_count).map_err(|_| ProgramError::InvalidInstructionData)?;
 

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -532,7 +532,7 @@ fn do_partial_create<'a>(
     gas_limit: u64,
 ) -> ProgramResult
 {
-    debug_print!("do_partial_create");
+    debug_print!("do_partial_create gas_limit={}", gas_limit);
 
     let backend = SolanaBackend::new(account_storage, Some(accounts));
     debug_print!("  backend initialized");

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -400,7 +400,7 @@ fn do_finalize<'a>(program_id: &Pubkey, accounts: &'a [AccountInfo<'a>]) -> Prog
         let mut executor = Machine::new(executor_state);
 
         debug_print!("Executor initialized");
-        executor.create_begin(account_storage.origin(), code_data, u64::MAX)?;
+        executor.create_begin(account_storage.origin(), code_data, u64::MAX, true, true)?;
         let exit_reason = executor.execute();
         let result = executor.return_value();
         debug_print!("Call done");
@@ -547,7 +547,7 @@ fn do_partial_create<'a>(
 
     debug_print!("Executor initialized");
 
-    executor.create_begin(account_storage.origin(), instruction_data, gas_limit)?;
+    executor.create_begin(account_storage.origin(), instruction_data, gas_limit, true, true)?;
     executor.execute_n_steps(step_count).unwrap();
 
     debug_print!("save");

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -406,14 +406,14 @@ fn do_finalize<'a>(program_id: &Pubkey, accounts: &'a [AccountInfo<'a>]) -> Prog
         let (result, exit_reason) = executor.execute();
         debug_print!("Call done");
 
+        let executor_state = executor.into_state();
+        let used_gas = executor_state.substate().metadata().gasometer().used_gas();
         if exit_reason.is_succeed() {
             debug_print!("Succeed execution");
-            let executor_state = executor.into_state();
-            let used_gas = executor_state.substate().metadata().gasometer().used_gas();
             let (_, (applies, logs)) = executor_state.deconstruct();
             (exit_reason, used_gas, result, Some((applies, logs)))
         } else {
-            (exit_reason, 0, result, None)
+            (exit_reason, used_gas, result, None)
         }
     };
 
@@ -462,14 +462,14 @@ fn do_call<'a>(
 
         debug_print!("Call done");
 
+        let executor_state = executor.into_state();
+        let used_gas = executor_state.substate().metadata().gasometer().used_gas();
         if exit_reason.is_succeed() {
             debug_print!("Succeed execution");
-            let executor_state = executor.into_state();
-            let used_gas = executor_state.substate().metadata().gasometer().used_gas();
             let (_, (applies, logs)) = executor_state.deconstruct();
             (exit_reason, used_gas, result, Some((applies, logs)))
         } else {
-            (exit_reason, 0, result, None)
+            (exit_reason, used_gas, result, None)
         }
     };
 

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -580,14 +580,14 @@ fn do_continue<'a>(
 
         debug_print!("Call done");
 
+        let executor_state = executor.into_state();
+        let used_gas = executor_state.substate().metadata().gasometer().used_gas();
         if exit_reason.is_succeed() {
             debug_print!("Succeed execution");
-            let executor_state = executor.into_state();
-            let used_gas = executor_state.substate().metadata().gasometer().used_gas();
             let (_, (applies, logs)) = executor_state.deconstruct();
             (exit_reason, used_gas, result, Some((applies, logs)))
         } else {
-            (exit_reason, 0, result, None)
+            (exit_reason, used_gas, result, None)
         }
     };
 

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -211,11 +211,12 @@ fn process_instruction<'a>(
 
             let mut storage = StorageAccount::new(storage_info, accounts, from_addr, trx.nonce)?;
 
+            let trx_gas_limit = u64::try_from(trx.gas_limit).map_err(|_| ProgramError::InvalidInstructionData)?;
             if trx.to.is_some() {
-                do_partial_call(&mut storage, step_count, &account_storage, accounts, trx.call_data, trx.gas_limit.as_u64())?;
+                do_partial_call(&mut storage, step_count, &account_storage, accounts, trx.call_data, trx_gas_limit)?;
             }
-            else{
-                do_partial_create(&mut storage, step_count, &account_storage, accounts, trx.call_data, trx.gas_limit.as_u64())?;
+            else {
+                do_partial_create(&mut storage, step_count, &account_storage, accounts, trx.call_data, trx_gas_limit)?;
             }
 
             storage.block_accounts(program_id, accounts)
@@ -235,7 +236,8 @@ fn process_instruction<'a>(
                 account_storage.get_caller_account().ok_or(ProgramError::InvalidArgument)?,
                 &H160::from_slice(from_addr), trx.nonce, &trx.chain_id)?;
 
-            do_call(program_id, &mut account_storage, accounts, trx.call_data, trx.gas_limit.as_u64())
+            let trx_gas_limit = u64::try_from(trx.gas_limit).map_err(|_| ProgramError::InvalidInstructionData)?;
+            do_call(program_id, &mut account_storage, accounts, trx.call_data, trx_gas_limit)
         },
         EvmInstruction::OnReturn {status: _, bytes: _} => {
             Ok(())
@@ -261,7 +263,8 @@ fn process_instruction<'a>(
                 account_storage.get_caller_account().ok_or(ProgramError::InvalidArgument)?,
                 &caller, trx.nonce, &trx.chain_id)?;
 
-            do_partial_call(&mut storage, step_count, &account_storage, &accounts[1..], trx.call_data, trx.gas_limit.as_u64())?;
+            let trx_gas_limit = u64::try_from(trx.gas_limit).map_err(|_| ProgramError::InvalidInstructionData)?;
+            do_partial_call(&mut storage, step_count, &account_storage, &accounts[1..], trx.call_data, trx_gas_limit)?;
 
             storage.block_accounts(program_id, accounts)
         },

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -396,13 +396,11 @@ fn do_finalize<'a>(program_id: &Pubkey, accounts: &'a [AccountInfo<'a>]) -> Prog
             code.to_vec()
         };
 
-        let gas_limit = u64::MAX;
-	    let config = evm::Config::default();
-        let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit, config), backend);
+        let executor_state = ExecutorState::new(ExecutorSubstate::new(u64::MAX), backend);
         let mut executor = Machine::new(executor_state);
 
         debug_print!("Executor initialized");
-        executor.create_begin(account_storage.origin(), code_data, gas_limit)?;
+        executor.create_begin(account_storage.origin(), code_data, u64::MAX)?;
         let exit_reason = executor.execute();
         let result = executor.return_value();
         debug_print!("Call done");
@@ -445,8 +443,7 @@ fn do_call<'a>(
         let backend = SolanaBackend::new(account_storage, Some(accounts));
         debug_print!("  backend initialized");
 
-	    let config = evm::Config::default();
-        let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit, config), backend);
+        let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit), backend);
         let mut executor = Machine::new(executor_state);
 
         debug_print!("Executor initialized");
@@ -504,8 +501,7 @@ fn do_partial_call<'a>(
     let backend = SolanaBackend::new(account_storage, Some(accounts));
     debug_print!("  backend initialized");
 
-    let config = evm::Config::default();
-    let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit, config), backend);
+    let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit), backend);
     let mut executor = Machine::new(executor_state);
 
     debug_print!("Executor initialized");
@@ -546,8 +542,7 @@ fn do_partial_create<'a>(
     let backend = SolanaBackend::new(account_storage, Some(accounts));
     debug_print!("  backend initialized");
 
-    let config = evm::Config::default();
-    let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit, config), backend);
+    let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit), backend);
     let mut executor = Machine::new(executor_state);
 
     debug_print!("Executor initialized");

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -399,7 +399,7 @@ fn do_finalize<'a>(program_id: &Pubkey, accounts: &'a [AccountInfo<'a>]) -> Prog
         let mut executor = Machine::new(executor_state);
 
         debug_print!("Executor initialized");
-        executor.create_begin(account_storage.origin(), code_data, u64::max_value())?;
+        executor.create_begin(account_storage.origin(), code_data, gas_limit)?;
         let exit_reason = executor.execute();
         let result = executor.return_value();
         debug_print!("Call done");
@@ -555,7 +555,7 @@ fn do_partial_create<'a>(
 
     debug_print!("Executor initialized");
 
-    executor.create_begin(account_storage.origin(), instruction_data, gas_limit as u64)?;
+    executor.create_begin(account_storage.origin(), instruction_data, gas_limit)?;
     executor.execute_n_steps(step_count).unwrap();
 
     debug_print!("save");

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -400,9 +400,7 @@ fn do_finalize<'a>(program_id: &Pubkey, accounts: &'a [AccountInfo<'a>]) -> Prog
         let mut executor = Machine::new(executor_state);
 
         debug_print!("Executor initialized");
-        executor.create_begin(account_storage.origin(), code_data, u64::MAX,
-                              false, // estimate
-        )?;
+        executor.create_begin(account_storage.origin(), code_data, u64::MAX)?;
         let exit_reason = executor.execute();
         let result = executor.return_value();
         debug_print!("Call done");
@@ -455,7 +453,6 @@ fn do_call<'a>(
             account_storage.contract(),
             instruction_data,
             gas_limit,
-            false, // estimate
         ).map_err(|_| ProgramError::InvalidInstructionData)?;
 
         let exit_reason = match executor.execute_n_steps(u64::MAX) {
@@ -515,7 +512,6 @@ fn do_partial_call<'a>(
         account_storage.contract(),
         instruction_data,
         gas_limit,
-        false, // estimate
     ).map_err(|_| ProgramError::InvalidInstructionData)?;
 
     executor.execute_n_steps(step_count).map_err(|_| ProgramError::InvalidInstructionData)?;
@@ -547,9 +543,7 @@ fn do_partial_create<'a>(
 
     debug_print!("Executor initialized");
 
-    executor.create_begin(account_storage.origin(), instruction_data, gas_limit,
-                          false, // estimate
-    )?;
+    executor.create_begin(account_storage.origin(), instruction_data, gas_limit)?;
     executor.execute_n_steps(step_count).unwrap();
 
     debug_print!("save");

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -453,8 +453,8 @@ fn do_call<'a>(
             account_storage.contract(),
             instruction_data,
             gas_limit,
-            false, // take_l64
-            false, // estimate
+            true, // take_l64
+            true, // estimate
         ).map_err(|_| ProgramError::InvalidInstructionData)?;
 
         let exit_reason = match executor.execute_n_steps(u64::MAX) {
@@ -514,8 +514,8 @@ fn do_partial_call<'a>(
         account_storage.contract(),
         instruction_data,
         gas_limit,
-        false, // take_l64
-        false, // estimate
+        true, // take_l64
+        true, // estimate
     ).map_err(|_| ProgramError::InvalidInstructionData)?;
 
     executor.execute_n_steps(step_count).map_err(|_| ProgramError::InvalidInstructionData)?;

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -448,15 +448,14 @@ fn do_call<'a>(
 
         debug_print!("Executor initialized");
 
-	    if let Err(e) = executor.call_begin(
+	    if executor.call_begin(
             account_storage.origin(),
             account_storage.contract(),
             instruction_data,
             gas_limit,
             false, // take_l64
             false, // estimate
-        ) {
-            debug_print!("{:?}", e);
+        ).is_err() {
             return Err(ProgramError::InvalidInstructionData);
         }
 
@@ -513,15 +512,14 @@ fn do_partial_call<'a>(
     debug_print!("   caller: {}", account_storage.origin());
     debug_print!(" contract: {}", account_storage.contract());
 
-    if let Err(e) = executor.call_begin(
+    if executor.call_begin(
         account_storage.origin(),
         account_storage.contract(),
         instruction_data,
         gas_limit,
         false, // take_l64
         false, // estimate
-    ) {
-        debug_print!("{:?}", e);
+    ).is_err() {
         return Err(ProgramError::InvalidInstructionData);
     }
 

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -400,7 +400,9 @@ fn do_finalize<'a>(program_id: &Pubkey, accounts: &'a [AccountInfo<'a>]) -> Prog
         let mut executor = Machine::new(executor_state);
 
         debug_print!("Executor initialized");
-        executor.create_begin(account_storage.origin(), code_data, u64::MAX, true)?;
+        executor.create_begin(account_storage.origin(), code_data, u64::MAX,
+                              false, // estimate
+        )?;
         let exit_reason = executor.execute();
         let result = executor.return_value();
         debug_print!("Call done");
@@ -453,7 +455,7 @@ fn do_call<'a>(
             account_storage.contract(),
             instruction_data,
             gas_limit,
-            true, // estimate
+            false, // estimate
         ).map_err(|_| ProgramError::InvalidInstructionData)?;
 
         let exit_reason = match executor.execute_n_steps(u64::MAX) {
@@ -513,7 +515,7 @@ fn do_partial_call<'a>(
         account_storage.contract(),
         instruction_data,
         gas_limit,
-        true, // estimate
+        false, // estimate
     ).map_err(|_| ProgramError::InvalidInstructionData)?;
 
     executor.execute_n_steps(step_count).map_err(|_| ProgramError::InvalidInstructionData)?;
@@ -545,7 +547,9 @@ fn do_partial_create<'a>(
 
     debug_print!("Executor initialized");
 
-    executor.create_begin(account_storage.origin(), instruction_data, gas_limit, true)?;
+    executor.create_begin(account_storage.origin(), instruction_data, gas_limit,
+                          false, // estimate
+    )?;
     executor.execute_n_steps(step_count).unwrap();
 
     debug_print!("save");

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -31,8 +31,6 @@ use evm::{
 };
 use std::{alloc::Layout, mem::size_of, ptr::null_mut, usize};
 
-
-
 const HEAP_LENGTH: usize = 1024*1024;
 
 /// Developers can implement their own heap by defining their own
@@ -191,7 +189,7 @@ fn process_instruction<'a>(
                 return Err(ProgramError::InvalidArgument);
             }
 
-            do_call(program_id, &mut account_storage, accounts, bytes.to_vec(), usize::MAX)
+            do_call(program_id, &mut account_storage, accounts, bytes.to_vec(), u64::MAX)
         },
         EvmInstruction::ExecuteTrxFromAccountDataIterative{step_count} =>{
             debug_print!("Execute iterative transaction from account data");
@@ -214,10 +212,10 @@ fn process_instruction<'a>(
             let mut storage = StorageAccount::new(storage_info, accounts, from_addr, trx.nonce)?;
 
             if trx.to.is_some() {
-                do_partial_call(&mut storage, step_count, &account_storage, accounts, trx.call_data, trx.gas_limit.as_usize())?;
+                do_partial_call(&mut storage, step_count, &account_storage, accounts, trx.call_data, trx.gas_limit.as_u64())?;
             }
             else{
-                do_partial_create(&mut storage, step_count, &account_storage, accounts, trx.call_data, trx.gas_limit.as_usize())?;
+                do_partial_create(&mut storage, step_count, &account_storage, accounts, trx.call_data, trx.gas_limit.as_u64())?;
             }
 
             storage.block_accounts(program_id, accounts)
@@ -237,7 +235,7 @@ fn process_instruction<'a>(
                 account_storage.get_caller_account().ok_or(ProgramError::InvalidArgument)?,
                 &H160::from_slice(from_addr), trx.nonce, &trx.chain_id)?;
 
-            do_call(program_id, &mut account_storage, accounts, trx.call_data, trx.gas_limit.as_usize())
+            do_call(program_id, &mut account_storage, accounts, trx.call_data, trx.gas_limit.as_u64())
         },
         EvmInstruction::OnReturn {status: _, bytes: _} => {
             Ok(())
@@ -263,7 +261,7 @@ fn process_instruction<'a>(
                 account_storage.get_caller_account().ok_or(ProgramError::InvalidArgument)?,
                 &caller, trx.nonce, &trx.chain_id)?;
 
-            do_partial_call(&mut storage, step_count, &account_storage, &accounts[1..], trx.call_data, trx.gas_limit.as_usize())?;
+            do_partial_call(&mut storage, step_count, &account_storage, &accounts[1..], trx.call_data, trx.gas_limit.as_u64())?;
 
             storage.block_accounts(program_id, accounts)
         },
@@ -395,7 +393,7 @@ fn do_finalize<'a>(program_id: &Pubkey, accounts: &'a [AccountInfo<'a>]) -> Prog
             code.to_vec()
         };
 
-        let gas_limit = usize::MAX;
+        let gas_limit = u64::MAX;
 	    let config = evm::Config::default();
         let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit, config), backend);
         let mut executor = Machine::new(executor_state);
@@ -432,7 +430,7 @@ fn do_call<'a>(
     account_storage: &mut ProgramAccountStorage,
     accounts: &'a [AccountInfo<'a>],
     instruction_data: Vec<u8>,
-    gas_limit: usize,
+    gas_limit: u64,
 ) -> ProgramResult
 {
     debug_print!("do_call");
@@ -498,7 +496,7 @@ fn do_partial_call<'a>(
     account_storage: &ProgramAccountStorage,
     accounts: &'a [AccountInfo<'a>],
     instruction_data: Vec<u8>,
-    gas_limit: usize,
+    gas_limit: u64,
 ) -> ProgramResult
 {
     debug_print!("do_partial_call");
@@ -543,7 +541,7 @@ fn do_partial_create<'a>(
     account_storage: &ProgramAccountStorage,
     accounts: &'a [AccountInfo<'a>],
     instruction_data: Vec<u8>,
-    gas_limit: usize,
+    gas_limit: u64,
 ) -> ProgramResult
 {
     debug_print!("do_partial_create");

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -448,16 +448,14 @@ fn do_call<'a>(
 
         debug_print!("Executor initialized");
 
-	    if executor.call_begin(
+	    executor.call_begin(
             account_storage.origin(),
             account_storage.contract(),
             instruction_data,
             gas_limit,
             false, // take_l64
             false, // estimate
-        ).is_err() {
-            return Err(ProgramError::InvalidInstructionData);
-        }
+        ).map_err(|_| ProgramError::InvalidInstructionData)?;
 
         let exit_reason = match executor.execute_n_steps(u64::MAX) {
             Ok(()) => return Err(ProgramError::InvalidInstructionData),
@@ -512,16 +510,14 @@ fn do_partial_call<'a>(
     debug_print!("   caller: {}", account_storage.origin());
     debug_print!(" contract: {}", account_storage.contract());
 
-    if executor.call_begin(
+    executor.call_begin(
         account_storage.origin(),
         account_storage.contract(),
         instruction_data,
         gas_limit,
         false, // take_l64
         false, // estimate
-    ).is_err() {
-        return Err(ProgramError::InvalidInstructionData);
-    }
+    ).map_err(|_| ProgramError::InvalidInstructionData)?;
 
     executor.execute_n_steps(step_count).map_err(|_| ProgramError::InvalidInstructionData)?;
 

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -603,7 +603,7 @@ fn do_continue<'a>(
         }
     }
 
-    invoke_on_return(program_id, accounts, exit_reason.clone(), &result)?;
+    invoke_on_return(program_id, accounts, exit_reason, &result)?;
 
     Ok(Some(exit_reason))
 }
@@ -616,6 +616,7 @@ fn invoke_on_return<'a>(
 ) -> ProgramResult
 {
     let exit_status = match exit_reason {
+        ExitReason::StepLimitReached => { unreachable!() },
         ExitReason::Succeed(success_code) => {
             debug_print!("Succeed");
             match success_code {
@@ -640,7 +641,6 @@ fn invoke_on_return<'a>(
                 ExitError::OutOfFund => { debug_print!("Not enough fund to start the execution (runtime)."); 0xeb},
                 ExitError::PCUnderflow => { debug_print!("PC underflowed (unused)."); 0xec},
                 ExitError::CreateEmpty => { debug_print!("Attempt to create an empty account (runtime, unused)."); 0xed},
-                ExitError::Other(_) => { debug_print!("Other normal errors."); 0xee},
             }
         },
         ExitReason::Revert(_) => { debug_print!("Revert"); 0xd0},
@@ -650,7 +650,6 @@ fn invoke_on_return<'a>(
                 ExitFatal::NotSupported => { debug_print!("The operation is not supported."); 0xf1},
                 ExitFatal::UnhandledInterrupt => { debug_print!("The trap (interrupt) is unhandled."); 0xf2},
                 ExitFatal::CallErrorAsFatal(_) => { debug_print!("The environment explictly set call errors as fatal error."); 0xf3},
-                ExitFatal::Other(_) => { debug_print!("Other fatal errors."); 0xf4},
             }
         },
     };

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -400,7 +400,7 @@ fn do_finalize<'a>(program_id: &Pubkey, accounts: &'a [AccountInfo<'a>]) -> Prog
         let mut executor = Machine::new(executor_state);
 
         debug_print!("Executor initialized");
-        executor.create_begin(account_storage.origin(), code_data, u64::MAX, true, true)?;
+        executor.create_begin(account_storage.origin(), code_data, u64::MAX, true)?;
         let exit_reason = executor.execute();
         let result = executor.return_value();
         debug_print!("Call done");
@@ -453,7 +453,6 @@ fn do_call<'a>(
             account_storage.contract(),
             instruction_data,
             gas_limit,
-            true, // take_l64
             true, // estimate
         ).map_err(|_| ProgramError::InvalidInstructionData)?;
 
@@ -514,7 +513,6 @@ fn do_partial_call<'a>(
         account_storage.contract(),
         instruction_data,
         gas_limit,
-        true, // take_l64
         true, // estimate
     ).map_err(|_| ProgramError::InvalidInstructionData)?;
 
@@ -547,7 +545,7 @@ fn do_partial_create<'a>(
 
     debug_print!("Executor initialized");
 
-    executor.create_begin(account_storage.origin(), instruction_data, gas_limit, true, true)?;
+    executor.create_begin(account_storage.origin(), instruction_data, gas_limit, true)?;
     executor.execute_n_steps(step_count).unwrap();
 
     debug_print!("save");

--- a/evm_loader/program/src/executor.rs
+++ b/evm_loader/program/src/executor.rs
@@ -3,7 +3,7 @@ use std::mem;
 
 use evm::{
     backend::Backend, Capture, ExitError, ExitFatal, ExitReason,
-    gasometer, gasometer::Gasometer, H160, H256, Handler, Resolve, U256,
+    gasometer, H160, H256, Handler, Resolve, U256,
 };
 use evm_runtime::{Control, save_created_address, save_return_value};
 use solana_program::entrypoint::ProgramResult;
@@ -18,22 +18,6 @@ use crate::utils::{keccak256_h256, keccak256_h256_v};
 const fn l64(gas: u64) -> u64 {
     gas - gas / 64
 }
-
-#[allow(unused)]
-#[allow(clippy::cast_sign_loss)]
-fn gas_used(gm: &Gasometer) -> u64 {
-    let tug = gm.total_used_gas();
-    let rg = gm.refunded_gas() as u64;
-    tug - core::cmp::min(tug / 2, rg)
-}
-
-//fn total_gas_used(gm: &Gasometer) -> u64 {
-//    gm.total_used_gas()
-//}
-
-//fn refunded_gas(gm: &Gasometer) -> i64 {
-//    gm.refunded_gas()
-//}
 
 struct CallInterrupt {
     context: evm::Context,
@@ -347,7 +331,6 @@ impl<'config, B: Backend> Handler for Executor<'config, B> {
             self.state.metadata_mut().gasometer_mut().record_dynamic_cost(gas_cost, memory_cost)?;
         }
 
-        debug_print!("Gas used: {}", gas_used(self.state.metadata().gasometer()));
         Ok(())
     }
 }
@@ -413,7 +396,6 @@ impl<'config, B: Backend> Machine<'config, B> {
 
         self.runtime.push((runtime, CreateReason::Call));
 
-        debug_print!("Gas used: {}", gas_used(self.executor.state.metadata().gasometer()));
         Ok(())
     }
 
@@ -459,7 +441,6 @@ impl<'config, B: Backend> Machine<'config, B> {
             },
         }
 
-        debug_print!("Gas used: {}", gas_used(self.executor.state.metadata().gasometer()));
         Ok(())
     }
 

--- a/evm_loader/program/src/executor.rs
+++ b/evm_loader/program/src/executor.rs
@@ -177,9 +177,8 @@ impl<'config, B: Backend> Handler for Executor<'config, B> {
         //     return Capture::Exit((ExitError::OutOfFund.into(), None, Vec::new()))
         // }
 
-        let estimate = false;
         let after_gas = if self.config.call_l64_after_gas {
-            if estimate {
+            if self.config.estimate {
                 let initial_after_gas = self.state.metadata().gasometer().gas();
                 let diff = initial_after_gas - l64(initial_after_gas);
                 if let Err(e) = self.state.metadata_mut().gasometer_mut().record_cost(diff) {
@@ -257,9 +256,8 @@ impl<'config, B: Backend> Handler for Executor<'config, B> {
             }
         }
 
-        let estimate = false;
         let after_gas = if self.config.call_l64_after_gas {
-            if estimate {
+            if self.config.estimate {
                 let initial_after_gas = self.state.metadata().gasometer().gas();
                 let diff = initial_after_gas - l64(initial_after_gas);
                 if let Err(e) = self.state.metadata_mut().gasometer_mut().record_cost(diff) {
@@ -363,7 +361,6 @@ impl<'config, B: Backend> Machine<'config, B> {
         code_address: H160,
         input: Vec<u8>,
         gas_limit: u64,
-        estimate: bool,
     ) -> Result<(), ExitError> {
         debug_print!("call_begin gas_limit={}", gas_limit);
         let transaction_cost = gasometer::call_transaction_cost(&input);
@@ -372,7 +369,7 @@ impl<'config, B: Backend> Machine<'config, B> {
         self.executor.state.inc_nonce(caller);
 
 	    let after_gas = if self.executor.config.call_l64_after_gas {
-            if estimate {
+            if self.executor.config.estimate {
                 let initial_after_gas = self.executor.state.metadata().gasometer().gas();
                 let diff = initial_after_gas - l64(initial_after_gas);
                 self.executor
@@ -409,7 +406,6 @@ impl<'config, B: Backend> Machine<'config, B> {
                         caller: H160,
                         code: Vec<u8>,
                         gas_limit: u64,
-                        estimate: bool,
     ) -> ProgramResult {
         debug_print!("create_begin gas_limit={}", gas_limit);
         let transaction_cost = gasometer::create_transaction_cost(&code);
@@ -418,7 +414,7 @@ impl<'config, B: Backend> Machine<'config, B> {
             .map_err(|_| ProgramError::InvalidInstructionData)?;
 
         let after_gas = if self.executor.config.call_l64_after_gas {
-            if estimate {
+            if self.executor.config.estimate {
                 let initial_after_gas = self.executor.state.metadata().gasometer().gas();
                 let diff = initial_after_gas - l64(initial_after_gas);
                 self.executor

--- a/evm_loader/program/src/executor.rs
+++ b/evm_loader/program/src/executor.rs
@@ -18,6 +18,7 @@ const fn l64(gas: u64) -> u64 {
     gas - gas / 64
 }
 
+#[allow(unused)]
 #[allow(clippy::cast_sign_loss)]
 fn gas_used(gm: &Gasometer) -> u64 {
     let tug = gm.total_used_gas();
@@ -172,15 +173,16 @@ impl<'config, B: Backend> Handler for Executor<'config, B> {
         Ok(())
     }
 
+    #[allow(unused)]
     fn create(
         &mut self,
         caller: H160,
         scheme: evm::CreateScheme,
         value: U256,
         init_code: Vec<u8>,
-        _target_gas: Option<u64>,
+        target_gas: Option<u64>,
     ) -> Capture<(ExitReason, Option<H160>, Vec<u8>), Self::CreateInterrupt> {
-        //debug_print!("create target_gas={:?}", target_gas);
+        debug_print!("create target_gas={:?}", target_gas);
         if let Some(depth) = self.state.metadata().depth() {
             if depth + 1 > self.config.call_stack_limit {
                 return Capture::Exit((ExitError::CallTooDeep.into(), None, Vec::new()));

--- a/evm_loader/program/src/executor.rs
+++ b/evm_loader/program/src/executor.rs
@@ -178,9 +178,9 @@ impl<'config, B: Backend> Handler for Executor<'config, B> {
         scheme: evm::CreateScheme,
         value: U256,
         init_code: Vec<u8>,
-        target_gas: Option<u64>,
+        _target_gas: Option<u64>,
     ) -> Capture<(ExitReason, Option<H160>, Vec<u8>), Self::CreateInterrupt> {
-        debug_print!("create target_gas={:?}", target_gas);
+        //debug_print!("create target_gas={:?}", target_gas);
         if let Some(depth) = self.state.metadata().depth() {
             if depth + 1 > self.config.call_stack_limit {
                 return Capture::Exit((ExitError::CallTooDeep.into(), None, Vec::new()));

--- a/evm_loader/program/src/executor.rs
+++ b/evm_loader/program/src/executor.rs
@@ -421,12 +421,11 @@ impl<'config, B: Backend> Machine<'config, B> {
 
     #[allow(clippy::too_many_lines)]
     pub fn step(&mut self) -> Result<(), ExitReason> {
-        let gas_limit = self.executor.state.block_gas_limit().as_u64();
         match self.step_opcode(){
             RuntimeApply::Continue => { Ok(()) },
             RuntimeApply::Call(info) => {
                 let code = self.executor.code(info.code_address);
-                self.executor.state.enter(gas_limit, false);
+                self.executor.state.enter(u64::MAX, false);
                 self.executor.state.touch(info.code_address);
 
                 let instance = evm::Runtime::new(
@@ -439,7 +438,7 @@ impl<'config, B: Backend> Machine<'config, B> {
                 Ok(())
             },
             RuntimeApply::Create(info) => {
-                self.executor.state.enter(gas_limit, false);
+                self.executor.state.enter(u64::MAX, false);
                 self.executor.state.touch(info.address);
                 self.executor.state.reset_storage(info.address);
                 if self.executor.config.create_increase_nonce {

--- a/evm_loader/program/src/executor_state.rs
+++ b/evm_loader/program/src/executor_state.rs
@@ -35,11 +35,11 @@ impl<'config> ExecutorMetadata<'config> {
     }
 
     pub fn swallow_commit(&mut self, other: Self) -> Result<(), ExitError> {
-	self.gasometer.record_stipend(other.gasometer.gas())?;
+	    self.gasometer.record_stipend(other.gasometer.gas())?;
         self.gasometer
             .record_refund(other.gasometer.refunded_gas())?;
 
-	// The following fragment deleted in the mainstream code:
+    	// The following fragment deleted in the mainstream code:
         // if let Some(runtime) = self.runtime.borrow_mut().as_ref() {
         //     let return_value = other.borrow().runtime().unwrap().machine().return_value();
         //     runtime.set_return_data(return_value);

--- a/evm_loader/program/src/executor_state.rs
+++ b/evm_loader/program/src/executor_state.rs
@@ -61,9 +61,9 @@ impl<'config> ExecutorMetadata<'config> {
         Ok(())
     }
 
-    pub fn spit_child(&self, gas_limit: u64, is_static: bool) -> Self {
+    pub fn spit_child(&self, gas_limit: usize, is_static: bool) -> Self {
         Self {
-            gasometer: Gasometer::new(gas_limit as usize, self.gasometer.config()),
+            gasometer: Gasometer::new(gas_limit, self.gasometer.config()),
             is_static: is_static || self.is_static,
             depth: match self.depth {
                 None => Some(0),
@@ -175,7 +175,7 @@ impl<'config> ExecutorSubstate<'config> {
         (applies, self.logs)
     }
 
-    pub fn enter(&mut self, gas_limit: u64, is_static: bool) {
+    pub fn enter(&mut self, gas_limit: usize, is_static: bool) {
         let mut entering = Self {
             metadata: self.metadata.spit_child(gas_limit, is_static),
             parent: None,
@@ -428,7 +428,7 @@ pub trait StackState : Backend {
     fn metadata(&self) -> &ExecutorMetadata;
     fn metadata_mut(&mut self) -> &mut ExecutorMetadata;
 
-    fn enter(&mut self, gas_limit: u64, is_static: bool);
+    fn enter(&mut self, gas_limit: usize, is_static: bool);
     fn exit_commit(&mut self) -> Result<(), ExitError>;
     fn exit_revert(&mut self) -> Result<(), ExitError>;
     fn exit_discard(&mut self) -> Result<(), ExitError>;
@@ -548,7 +548,7 @@ impl<'config, B: Backend> StackState for ExecutorState<'config, B> {
         self.substate.metadata_mut()
     }
 
-    fn enter(&mut self, gas_limit: u64, is_static: bool) {
+    fn enter(&mut self, gas_limit: usize, is_static: bool) {
         self.substate.enter(gas_limit, is_static)
     }
 

--- a/evm_loader/program/src/executor_state.rs
+++ b/evm_loader/program/src/executor_state.rs
@@ -26,7 +26,7 @@ pub struct ExecutorMetadata<'config> {
 }
 
 impl<'config> ExecutorMetadata<'config> {
-    pub fn new(gas_limit: usize, config: &'config evm::Config) -> Self {
+    pub fn new(gas_limit: u64, config: &'config evm::Config) -> Self {
         Self {
             gasometer: Gasometer::new(gas_limit, config),
             is_static: false,
@@ -61,7 +61,7 @@ impl<'config> ExecutorMetadata<'config> {
         Ok(())
     }
 
-    pub fn split_child(&self, gas_limit: usize, is_static: bool) -> Self {
+    pub fn split_child(&self, gas_limit: u64, is_static: bool) -> Self {
         Self {
             gasometer: Gasometer::new(gas_limit, self.gasometer.config()),
             is_static: is_static || self.is_static,
@@ -101,7 +101,7 @@ pub struct ExecutorSubstate<'config> {
 }
 
 impl<'config> ExecutorSubstate<'config> {
-    pub fn new(gas_limit: usize, config: &'config evm::Config) -> Self {
+    pub fn new(gas_limit: u64, config: &'config evm::Config) -> Self {
         Self {
             metadata: ExecutorMetadata::new(gas_limit, config),
             parent: None,
@@ -175,7 +175,7 @@ impl<'config> ExecutorSubstate<'config> {
         (applies, self.logs)
     }
 
-    pub fn enter(&mut self, gas_limit: usize, is_static: bool) {
+    pub fn enter(&mut self, gas_limit: u64, is_static: bool) {
         let mut entering = Self {
             metadata: self.metadata.split_child(gas_limit, is_static),
             parent: None,
@@ -426,7 +426,7 @@ pub trait StackState : Backend {
     fn metadata(&self) -> &ExecutorMetadata;
     fn metadata_mut(&mut self) -> &mut ExecutorMetadata;
 
-    fn enter(&mut self, gas_limit: usize, is_static: bool);
+    fn enter(&mut self, gas_limit: u64, is_static: bool);
     fn exit_commit(&mut self) -> Result<(), ExitError>;
     fn exit_revert(&mut self) -> Result<(), ExitError>;
     fn exit_discard(&mut self) -> Result<(), ExitError>;
@@ -520,7 +520,7 @@ impl<'config, B: Backend> Backend for ExecutorState<'config, B> {
         code_address: H160,
         transfer: Option<evm::Transfer>,
         input: Vec<u8>,
-        target_gas: Option<usize>,
+        target_gas: Option<u64>,
         is_static: bool,
         take_l64: bool,
         take_stipend: bool,
@@ -546,7 +546,7 @@ impl<'config, B: Backend> StackState for ExecutorState<'config, B> {
         self.substate.metadata_mut()
     }
 
-    fn enter(&mut self, gas_limit: usize, is_static: bool) {
+    fn enter(&mut self, gas_limit: u64, is_static: bool) {
         self.substate.enter(gas_limit, is_static)
     }
 

--- a/evm_loader/program/src/executor_state.rs
+++ b/evm_loader/program/src/executor_state.rs
@@ -61,7 +61,7 @@ impl<'config> ExecutorMetadata<'config> {
         Ok(())
     }
 
-    pub fn spit_child(&self, gas_limit: usize, is_static: bool) -> Self {
+    pub fn split_child(&self, gas_limit: usize, is_static: bool) -> Self {
         Self {
             gasometer: Gasometer::new(gas_limit, self.gasometer.config()),
             is_static: is_static || self.is_static,
@@ -177,7 +177,7 @@ impl<'config> ExecutorSubstate<'config> {
 
     pub fn enter(&mut self, gas_limit: usize, is_static: bool) {
         let mut entering = Self {
-            metadata: self.metadata.spit_child(gas_limit, is_static),
+            metadata: self.metadata.split_child(gas_limit, is_static),
             parent: None,
             logs: Vec::new(),
             accounts: BTreeMap::new(),

--- a/evm_loader/program/src/executor_state.rs
+++ b/evm_loader/program/src/executor_state.rs
@@ -101,9 +101,9 @@ pub struct ExecutorSubstate<'config> {
 }
 
 impl<'config> ExecutorSubstate<'config> {
-    pub fn new(gas_limit: u64, config: &'config evm::Config) -> Self {
+    pub fn new(gas_limit: u64) -> Self {
         Self {
-            metadata: ExecutorMetadata::new(gas_limit, config),
+            metadata: ExecutorMetadata::new(gas_limit, evm::Config::default()),
             parent: None,
             logs: Vec::new(),
             accounts: BTreeMap::new(),

--- a/evm_loader/program/src/executor_state.rs
+++ b/evm_loader/program/src/executor_state.rs
@@ -26,7 +26,8 @@ pub struct ExecutorMetadata<'config> {
 }
 
 impl<'config> ExecutorMetadata<'config> {
-    pub const fn new(gas_limit: u64, config: &'config evm::Config) -> Self {
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn new(gas_limit: u64, config: &'config evm::Config) -> Self {
         Self {
             gasometer: Gasometer::new(gas_limit, config),
             is_static: false,
@@ -61,7 +62,8 @@ impl<'config> ExecutorMetadata<'config> {
         Ok(())
     }
 
-    pub const fn spit_child(&self, gas_limit: u64, is_static: bool) -> Self {
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn spit_child(&self, gas_limit: u64, is_static: bool) -> Self {
         Self {
             gasometer: Gasometer::new(gas_limit, self.gasometer.config()),
             is_static: is_static || self.is_static,

--- a/evm_loader/program/src/instruction.rs
+++ b/evm_loader/program/src/instruction.rs
@@ -284,7 +284,7 @@ pub fn on_return(
 ) -> Instruction {
     use core::mem;
 
-    let cap = mem::size_of::<u8>() + mem::size_of::<u64>() + result.len();
+    let cap = 2 * mem::size_of::<u8>() + mem::size_of::<u64>() + result.len();
     let mut data = Vec::with_capacity(cap);
     data.push(6_u8);
     data.push(status);

--- a/evm_loader/program/src/instruction.rs
+++ b/evm_loader/program/src/instruction.rs
@@ -1,4 +1,5 @@
-//! `EvmInstruction` serrialization/deserrialization
+//! `EvmInstruction` serialization/deserialization
+
 use serde::{Serialize, Serializer};
 use solana_program::{program_error::ProgramError, pubkey::Pubkey, instruction::Instruction};
 use std::convert::{TryInto, TryFrom};
@@ -278,11 +279,16 @@ impl<'a> EvmInstruction<'a> {
 pub fn on_return(
     myself_program_id: &Pubkey,
     status: u8,
+    used_gas: u64,
     result: &[u8]
 ) -> Instruction {
-    let mut data = Vec::with_capacity(2 + result.len());
+    use core::mem;
+
+    let cap = mem::size_of::<u8>() + mem::size_of::<u64>() + result.len();
+    let mut data = Vec::with_capacity(cap);
     data.push(6_u8);
     data.push(status);
+    data.extend(&used_gas.to_le_bytes());
     data.extend(result);
 
     Instruction {

--- a/evm_loader/program/src/solana_backend.rs
+++ b/evm_loader/program/src/solana_backend.rs
@@ -367,7 +367,7 @@ mod test {
 
         let mut backend = SolanaBackend::new(&owner, &infos[..]).unwrap();
 
-        let config = evm::Config::istanbul();
+        let config = evm::Config::default();
         let mut executor = StackExecutor::new(&backend, usize::max_value(), &config);
 
         assert_eq!(backend.exists(solidity_address(&owner)), false);
@@ -447,7 +447,7 @@ mod test {
 
         let mut backend = SolanaBackend::new(&owner, &infos[..]).unwrap();
 
-        let config = evm::Config::istanbul();
+        let config = evm::Config::default();
         let mut executor = StackExecutor::new(&backend, usize::max_value(), &config);
 
         assert_eq!(backend.exists(solidity_address(&owner)), false);

--- a/evm_loader/program/src/solana_backend.rs
+++ b/evm_loader/program/src/solana_backend.rs
@@ -168,7 +168,7 @@ impl<'a, 's, S> Backend for SolanaBackend<'a, 's, S> where S: AccountStorage {
         } else {
             debug_print!("Call create");
         }
-    /*    let account = if let CreateScheme::Create2{salt,..} = scheme
+        /* let account = if let CreateScheme::Create2{salt,..} = scheme
                 {Pubkey::new(&salt.to_fixed_bytes())} else {Pubkey::default()};
         self.add_alias(address, &account);*/
     }

--- a/evm_loader/program/src/solana_backend.rs
+++ b/evm_loader/program/src/solana_backend.rs
@@ -117,7 +117,7 @@ impl<'a, 's, S> Backend for SolanaBackend<'a, 's, S> where S: AccountStorage {
         self.account_storage.block_timestamp()
     }
     fn block_difficulty(&self) -> U256 { U256::zero() }
-    fn block_gas_limit(&self) -> U256 { U256::from(usize::MAX) }
+    fn block_gas_limit(&self) -> U256 { U256::from(u64::MAX) }
     fn chain_id(&self) -> U256 { Self::chain_id() }
 
     fn exists(&self, address: H160) -> bool {
@@ -155,7 +155,7 @@ impl<'a, 's, S> Backend for SolanaBackend<'a, 's, S> where S: AccountStorage {
         code_address: H160,
         _transfer: Option<Transfer>,
         input: Vec<u8>,
-        _target_gas: Option<usize>,
+        _target_gas: Option<u64>,
         _is_static: bool,
         _take_l64: bool,
         _take_stipend: bool,
@@ -377,7 +377,7 @@ mod test {
         let mut backend = SolanaBackend::new(&owner, &infos[..]).unwrap();
 
         let config = evm::Config::default();
-        let mut executor = StackExecutor::new(&backend, usize::max_value(), &config);
+        let mut executor = StackExecutor::new(&backend, u64::MAX, &config);
 
         assert_eq!(backend.exists(solidity_address(&owner)), false);
         assert_eq!(backend.exists(solidity_address(infos[1].key)), true);
@@ -387,7 +387,7 @@ mod test {
         executor.deposit(creator, U256::exp10(18));
 
         let contract = executor.create_address(CreateScheme::Create2{caller: creator, code_hash: keccak256_digest(&TestContract::code()), salt: infos[0].key.to_bytes().into()});
-        let exit_reason = executor.transact_create2(creator, U256::zero(), TestContract::code(), infos[0].key.to_bytes().into(), usize::max_value());
+        let exit_reason = executor.transact_create2(creator, U256::zero(), TestContract::code(), infos[0].key.to_bytes().into(), u64::MAX);
         println!("Create contract {:?}: {:?}", contract, exit_reason);
 
         let (applies, logs) = executor.deconstruct();
@@ -398,7 +398,7 @@ mod test {
 
         println!();
 //        let mut backend = SolanaBackend::new(&infos).unwrap();
-        let mut executor = StackExecutor::new(&backend, usize::max_value(), &config);
+        let mut executor = StackExecutor::new(&backend, u64::MAX, &config);
         println!("======================================");
         println!("Contract: {:x}", contract);
         println!("{:x?}", backend.exists(contract));
@@ -418,7 +418,7 @@ mod test {
         println!("storage value: {:x}", backend.storage(H160::zero(), H256::default()));
 
         let (exit_reason, result) = executor.transact_call(
-                creator, contract, U256::zero(), TestContract::get_owner(), usize::max_value());
+                creator, contract, U256::zero(), TestContract::get_owner(), u64::MAX);
         println!("Call: {:?}, {}", exit_reason, hex::encode(&result));
 
         let (applies, logs) = executor.deconstruct();
@@ -457,7 +457,7 @@ mod test {
         let mut backend = SolanaBackend::new(&owner, &infos[..]).unwrap();
 
         let config = evm::Config::default();
-        let mut executor = StackExecutor::new(&backend, usize::max_value(), &config);
+        let mut executor = StackExecutor::new(&backend, u64::MAX, &config);
 
         assert_eq!(backend.exists(solidity_address(&owner)), false);
         assert_eq!(backend.exists(solidity_address(infos[1].key)), true);
@@ -467,11 +467,11 @@ mod test {
         executor.deposit(creator, U256::exp10(18));
 
         let contract = executor.create_address(CreateScheme::Create2{caller: creator, code_hash: keccak256_digest(&ERC20Contract::wrapper_code()), salt: infos[0].key.to_bytes().into()});
-        let exit_reason = executor.transact_create2(creator, U256::zero(), ERC20Contract::wrapper_code(), infos[0].key.to_bytes().into(), usize::max_value());
+        let exit_reason = executor.transact_create2(creator, U256::zero(), ERC20Contract::wrapper_code(), infos[0].key.to_bytes().into(), u64::MAX);
         println!("Create contract {:?}: {:?}", contract, exit_reason);
 
         contract = executor.create_address(CreateScheme::Create2{caller: creator, code_hash: keccak256_digest(&ERC20Contract::code()), salt: infos[0].key.to_bytes().into()});
-        exit_reason = executor.transact_create2(creator, U256::zero(), ERC20Contract::code(), infos[0].key.to_bytes().into(), usize::max_value());
+        exit_reason = executor.transact_create2(creator, U256::zero(), ERC20Contract::code(), infos[0].key.to_bytes().into(), u64::MAX);
         println!("Create contract {:?}: {:?}", contract, exit_reason);
 
         let (applies, logs) = executor.deconstruct();
@@ -482,7 +482,7 @@ mod test {
 
         println!();
 //        let mut backend = SolanaBackend::new(&infos).unwrap();
-        let mut executor = StackExecutor::new(&backend, usize::max_value(), &config);
+        let mut executor = StackExecutor::new(&backend, u64::MAX, &config);
         println!("======================================");
         println!("Contract: {:x}", contract);
         println!("{:x?}", backend.exists(contract));
@@ -502,11 +502,11 @@ mod test {
         println!("storage value: {:x}", backend.storage(H160::zero(), H256::default()));
 
         let (exit_reason, result) = executor.transact_call(
-                creator, contract, U256::zero(), ERC20Contract::donate(), usize::max_value());
+                creator, contract, U256::zero(), ERC20Contract::donate(), u64::MAX);
         println!("Call: {:?}, {}", exit_reason, hex::encode(&result));
 
         let (exit_reason, result) = executor.transact_call(
-                creator, contract, U256::zero(), ERC20Contract::donateFrom(), usize::max_value());
+                creator, contract, U256::zero(), ERC20Contract::donateFrom(), u64::MAX);
         println!("Call: {:?}, {}", exit_reason, hex::encode(&result));
 
         let (applies, logs) = executor.deconstruct();

--- a/evm_loader/program/src/solidity_account.rs
+++ b/evm_loader/program/src/solidity_account.rs
@@ -12,8 +12,7 @@ use solana_program::{
 };
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::convert::TryInto;
-
+use std::convert::{TryInto, TryFrom};
 
 #[derive(Debug, Clone)]
 pub struct SolidityAccount<'a> {
@@ -145,7 +144,8 @@ impl<'a> SolidityAccount<'a> {
             AccountData::Foreign => 0,
             AccountData::Account{code_size, ..} => code_size as usize,
         };*/
-        AccountData::get_mut_account(&mut self.account_data)?.trx_count = nonce.as_u64();
+        let nonce = u64::try_from(nonce).map_err(|_| ProgramError::InvalidArgument)?;
+        AccountData::get_mut_account(&mut self.account_data)?.trx_count = nonce;
 
         if let Some(code) = code {
             debug_print!("Write contract");

--- a/evm_loader/solana_utils.py
+++ b/evm_loader/solana_utils.py
@@ -180,7 +180,7 @@ class NeonEvmClient:
         self.__create_solana_ether_caller(ethereum_transaction)
         caller_trx_cnt = getTransactionCount(client, ethereum_transaction._solana_ether_caller)
         trx_raw = {'to': solana2ether(ethereum_transaction.contract_account),
-                   'value': 1, 'gas': 1, 'gasPrice': 1, 'nonce': caller_trx_cnt,
+                   'value': 1, 'gas': 9999999, 'gasPrice': 1, 'nonce': caller_trx_cnt,
                    'data': ethereum_transaction.trx_data, 'chainId': 111}
         return make_instruction_data_from_tx(trx_raw, self.solana_wallet.secret_key())
 

--- a/evm_loader/test_cli_emulate.py
+++ b/evm_loader/test_cli_emulate.py
@@ -12,7 +12,6 @@ solana_url = os.environ.get("SOLANA_URL", "http://localhost:8899")
 evm_loader_id = os.environ.get("EVM_LOADER")
 CONTRACTS_DIR = os.environ.get("CONTRACTS_DIR", "evm_loader/ERC20/src")
 
-
 class ExternalCall:
     """Encapsulate the all data of the ExternalCall ethereum contract."""
 
@@ -161,6 +160,7 @@ class EmulateTest(unittest.TestCase):
         src_data = result['result']['meta']['innerInstructions'][-1]['instructions'][-1]['data']
         self.assertEqual(base58.b58decode(src_data)[0], 6)  # 6 means OnReturn
         self.assertLess(base58.b58decode(src_data)[1], 0xd0)  # less 0xd0 - success
+        self.assertEqual(int().from_bytes(base58.b58decode(src_data)[2:10], 'little'), 9844306) # used_gas
 
         self.assertEqual(self.spl_token.balance(self.token_acc1), balance1 + mint_amount - transfer_amount)
         self.assertEqual(self.spl_token.balance(self.token_acc2), balance2 + transfer_amount)
@@ -277,6 +277,7 @@ class EmulateTest(unittest.TestCase):
         src_data = result['result']['meta']['innerInstructions'][-1]['instructions'][-1]['data']
         self.assertEqual(base58.b58decode(src_data)[0], 6)  # 6 means OnReturn
         self.assertLess(base58.b58decode(src_data)[1], 0xd0)  # less 0xd0 - success
+        self.assertEqual(int().from_bytes(base58.b58decode(src_data)[2:10], 'little'), 9844306) # used_gas
 
         self.assertEqual(self.spl_token.balance(self.token_acc1), balance1 + mint_amount - 2 * transfer_amount)
         self.assertEqual(self.spl_token.balance(self.token_acc2), balance2 + 2 * transfer_amount)

--- a/evm_loader/test_deploy.py
+++ b/evm_loader/test_deploy.py
@@ -122,7 +122,7 @@ class DeployTest(unittest.TestCase):
         tx = {
             'to': None,
             'value': 0,
-            'gas': 1,
+            'gas': 9999999,
             'gasPrice': 1,
             'nonce': trx_count,
             'data': content,

--- a/evm_loader/test_nested_call.py
+++ b/evm_loader/test_nested_call.py
@@ -135,7 +135,7 @@ class EventTest(unittest.TestCase):
         return storage
 
     def call_partial_signed(self, input, contract, code):
-        tx = {'to': solana2ether(contract), 'value': 1, 'gas': 1, 'gasPrice': 1,
+        tx = {'to': solana2ether(contract), 'value': 1, 'gas': 9999999, 'gasPrice': 1,
             'nonce': getTransactionCount(client, self.caller), 'data': input, 'chainId': 111}
 
         (from_addr, sign, msg) = make_instruction_data_from_tx(tx, self.acc.secret_key())
@@ -198,7 +198,7 @@ class EventTest(unittest.TestCase):
         self.assertEqual(data[157:189], bytes.fromhex("%062x" %0x0 + hex(124)[2:]))
 
     def test_ecrecover(self):
-        tx = {'to': solana2ether(self.reId_caller), 'value': 1, 'gas': 1, 'gasPrice': 1,
+        tx = {'to': solana2ether(self.reId_caller), 'value': 1, 'gas': 9999999, 'gasPrice': 1,
               'nonce': getTransactionCount(client, self.caller), 'data': bytes().fromhex("001122"), 'chainId': 111}
 
         signed_tx = w3.eth.account.sign_transaction(tx, self.acc.secret_key())

--- a/evm_loader/test_transaction.py
+++ b/evm_loader/test_transaction.py
@@ -49,7 +49,7 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
         tx_1 = {
             'to': solana2ether(self.owner_contract),
             'value': 1,
-            'gas': 1,
+            'gas': 9999999,
             'gasPrice': 1,
             'nonce': getTransactionCount(client, self.caller),
             'data': '3917b3df',


### PR DESCRIPTION
Enabled gasometer. 

Note: return value in the proxy's function eth_estimateGas should be increased to pass tests, like so:
```Python
    def eth_estimateGas(self, param):
          if param.get('to'):
            call_emulated(param['to'], param['from'], param['data'])
        return 9999999
```

This change and other needed present in the branch 18-gasometer in the proxy-model.py repository.