### PR TITLE
fixed clippy warnings #49

### DIFF
--- a/evm_loader/cli/src/account_storage.rs
+++ b/evm_loader/cli/src/account_storage.rs
@@ -37,7 +37,6 @@ struct SolanaAccount {
 }
 
 struct SolanaNewAccount {
-    #[allow(unused)]
     key: Pubkey,
     writable: bool,
     code_size: Option<usize>
@@ -51,7 +50,7 @@ impl SolanaAccount {
 }
 
 impl SolanaNewAccount {
-    pub fn new(key: Pubkey) -> Self {
+    pub const fn new(key: Pubkey) -> Self {
         Self{key, writable: false, code_size: None}
     }
 }
@@ -93,9 +92,9 @@ impl<'a> EmulatorAccountStorage<'a> {
         Self {
             accounts: RefCell::new(HashMap::new()),
             new_accounts: RefCell::new(HashMap::new()),
-            config: config,
-            contract_id: contract_id,
-            caller_id: caller_id,
+            config,
+            contract_id,
+            caller_id,
             block_number: slot,
             block_timestamp: timestamp,
         }
@@ -228,12 +227,11 @@ impl<'a> EmulatorAccountStorage<'a> {
 
         let new_accounts = self.new_accounts.borrow();
         for (address, acc) in new_accounts.iter() {
-            let solana_address = Pubkey::find_program_address(&[&address.to_fixed_bytes()], &self.config.evm_loader).0;
             arr.push(AccountJSON{
                     address: "0x".to_string() + &hex::encode(&address.to_fixed_bytes()),
                     writable: acc.writable,
                     new: true,
-                    account: solana_address.to_string(),
+                    account: acc.key.to_string(),
                     contract: None,
                     code_size: acc.code_size,
                 });

--- a/evm_loader/program/src/account_data.rs
+++ b/evm_loader/program/src/account_data.rs
@@ -81,10 +81,10 @@ impl AccountData {
     pub fn unpack(input: &[u8]) -> Result<Self, ProgramError> {
         let (&tag, rest) = input.split_first().ok_or(ProgramError::InvalidAccountData)?;
         Ok(match tag {
-            AccountData::EMPTY_TAG => AccountData::Empty,
-            AccountData::ACCOUNT_TAG => AccountData::Account( Account::unpack(rest) ),
-            AccountData::CONTRACT_TAG => AccountData::Contract( Contract::unpack(rest) ),
-            AccountData::STORAGE_TAG => AccountData::Storage( Storage::unpack(rest) ),
+            Self::EMPTY_TAG => Self::Empty,
+            Self::ACCOUNT_TAG => Self::Account( Account::unpack(rest) ),
+            Self::CONTRACT_TAG => Self::Contract( Contract::unpack(rest) ),
+            Self::STORAGE_TAG => Self::Storage( Storage::unpack(rest) ),
 
             _ => return Err(ProgramError::InvalidAccountData),
         })
@@ -104,38 +104,39 @@ impl AccountData {
     pub fn pack(&self, dst: &mut [u8]) -> Result<usize, ProgramError> {
         if dst.is_empty() { return Err(ProgramError::AccountDataTooSmall); }
         Ok(match self {
-            AccountData::Empty => {
+            Self::Empty => {
                 if dst.len() < self.size() { return Err(ProgramError::AccountDataTooSmall); }
-                dst[0] = AccountData::EMPTY_TAG;
-                (AccountData::Empty).size()
+                dst[0] = Self::EMPTY_TAG;
+                (Self::Empty).size()
             },
-            AccountData::Account(acc) => {
-                if dst[0] != AccountData::ACCOUNT_TAG && dst[0] != AccountData::EMPTY_TAG { return Err(ProgramError::InvalidAccountData); }
+            Self::Account(acc) => {
+                if dst[0] != Self::ACCOUNT_TAG && dst[0] != Self::EMPTY_TAG { return Err(ProgramError::InvalidAccountData); }
                 if dst.len() < self.size() { return Err(ProgramError::AccountDataTooSmall); }
-                dst[0] = AccountData::ACCOUNT_TAG;
+                dst[0] = Self::ACCOUNT_TAG;
                 Account::pack(acc, &mut dst[1..])
             },
-            AccountData::Contract(acc) => {
-                if dst[0] != AccountData::CONTRACT_TAG && dst[0] != AccountData::EMPTY_TAG { return Err(ProgramError::InvalidAccountData); }
+            Self::Contract(acc) => {
+                if dst[0] != Self::CONTRACT_TAG && dst[0] != Self::EMPTY_TAG { return Err(ProgramError::InvalidAccountData); }
                 if dst.len() < self.size() { return Err(ProgramError::AccountDataTooSmall); }
-                dst[0] = AccountData::CONTRACT_TAG;
+                dst[0] = Self::CONTRACT_TAG;
                 Contract::pack(acc, &mut dst[1..])
             },
-            AccountData::Storage(acc) => {
-                if dst[0] != AccountData::STORAGE_TAG && dst[0] != AccountData::EMPTY_TAG { return Err(ProgramError::InvalidAccountData); }
+            Self::Storage(acc) => {
+                if dst[0] != Self::STORAGE_TAG && dst[0] != Self::EMPTY_TAG { return Err(ProgramError::InvalidAccountData); }
                 if dst.len() < self.size() { return Err(ProgramError::AccountDataTooSmall); }
-                dst[0] = AccountData::STORAGE_TAG;
+                dst[0] = Self::STORAGE_TAG;
                 Storage::pack(acc, &mut dst[1..])
             },
         })
     }
 
     /// Get `AccountData` struct size
-    pub fn size(&self) -> usize {
+    #[must_use]
+    pub const fn size(&self) -> usize {
         match self {
-            AccountData::Account(acc) => acc.size() + 1,
-            AccountData::Contract(acc) => acc.size() + 1,
-            AccountData::Storage(acc) => acc.size() + 1,
+            Self::Account(_acc) => Account::size() + 1,
+            Self::Contract(_acc) => Contract::size() + 1,
+            Self::Storage(_acc) => Storage::size() + 1,
             _ => 1,
         }
     }
@@ -145,9 +146,9 @@ impl AccountData {
     ///
     /// Will return:
     /// `ProgramError::InvalidAccountData` if doesn't contain `Account` struct
-    pub fn get_account(&self) -> Result<&Account, ProgramError>  {
+    pub const fn get_account(&self) -> Result<&Account, ProgramError>  {
         match self {
-            AccountData::Account(ref acc) => Ok(acc),
+            Self::Account(ref acc) => Ok(acc),
             _ => Err(ProgramError::InvalidAccountData),
         }
     }
@@ -159,7 +160,7 @@ impl AccountData {
     /// `ProgramError::InvalidAccountData` if doesn't contain `Account` struct
     pub fn get_mut_account(&mut self) -> Result<&mut Account, ProgramError>  {
         match self {
-            AccountData::Account(ref mut acc) => Ok(acc),
+            Self::Account(ref mut acc) => Ok(acc),
             _ => Err(ProgramError::InvalidAccountData),
         }
     }
@@ -169,9 +170,9 @@ impl AccountData {
     ///
     /// Will return:
     /// `ProgramError::InvalidAccountData` if doesn't contain `Contract` struct
-    pub fn get_contract(&self) -> Result<&Contract, ProgramError>  {
+    pub const fn get_contract(&self) -> Result<&Contract, ProgramError>  {
         match self {
-            AccountData::Contract(ref acc) => Ok(acc),
+            Self::Contract(ref acc) => Ok(acc),
             _ => Err(ProgramError::InvalidAccountData),
         }
     }
@@ -183,7 +184,7 @@ impl AccountData {
     /// `ProgramError::InvalidAccountData` if doesn't contain `Contract` struct
     pub fn get_mut_contract(&mut self) -> Result<&mut Contract, ProgramError>  {
         match self {
-            AccountData::Contract(ref mut acc) => Ok(acc),
+            Self::Contract(ref mut acc) => Ok(acc),
             _ => Err(ProgramError::InvalidAccountData),
         }
     }
@@ -193,9 +194,9 @@ impl AccountData {
     ///
     /// Will return:
     /// `ProgramError::InvalidAccountData` if doesn't contain `Storage` struct
-    pub fn get_storage(&self) -> Result<&Storage, ProgramError>  {
+    pub const fn get_storage(&self) -> Result<&Storage, ProgramError>  {
         match self {
-            AccountData::Storage(ref acc) => Ok(acc),
+            Self::Storage(ref acc) => Ok(acc),
             _ => Err(ProgramError::InvalidAccountData),
         }
     }
@@ -207,7 +208,7 @@ impl AccountData {
     /// `ProgramError::InvalidAccountData` if doesn't contain `Storage` struct
     pub fn get_mut_storage(&mut self) -> Result<&mut Storage, ProgramError>  {
         match self {
-            AccountData::Storage(ref mut acc) => Ok(acc),
+            Self::Storage(ref mut acc) => Ok(acc),
             _ => Err(ProgramError::InvalidAccountData),
         }
     }
@@ -218,11 +219,13 @@ impl Account {
     pub const SIZE: usize = 20+1+8+32+1+32;
 
     /// Deserialize `Account` struct from input data
+    #[must_use]
     pub fn unpack(input: &[u8]) -> Self {
+        #[allow(clippy::use_self)]
         let data = array_ref![input, 0, Account::SIZE];
         let (ether, nonce, trx_count, code_account, is_blocked, blocked_by) = array_refs![data, 20, 1, 8, 32, 1, 32];
 
-        Account {
+        Self {
             ether: H160::from_slice(&*ether),
             nonce: nonce[0],
             trx_count: u64::from_le_bytes(*trx_count),
@@ -232,7 +235,8 @@ impl Account {
     }
 
     /// Serialize `Account` struct into given destination
-    pub fn pack(acc: &Account, dst: &mut [u8]) -> usize {
+    pub fn pack(acc: &Self, dst: &mut [u8]) -> usize {
+        #[allow(clippy::use_self)]
         let data = array_mut_ref![dst, 0, Account::SIZE];
         let (ether_dst, nonce_dst, trx_count_dst, code_account_dst, is_blocked_dst, blocked_by_dst) = 
                 mut_array_refs![data, 20, 1, 8, 32, 1, 32];
@@ -247,12 +251,13 @@ impl Account {
             is_blocked_dst[0] = 0;
         }
 
-        Account::SIZE
+        Self::SIZE
     }
 
     /// Get `Account` struct size
-    pub fn size(&self) -> usize {
-        Account::SIZE
+    #[must_use]
+    pub const fn size() -> usize {
+        Self::SIZE
     }
 }
 
@@ -261,29 +266,33 @@ impl Contract {
     pub const SIZE: usize = 32+4;
 
     /// Deserialize `Contract` struct from input data
+    #[must_use]
     pub fn unpack(input: &[u8]) -> Self {
+        #[allow(clippy::use_self)]
         let data = array_ref![input, 0, Contract::SIZE];
         let (owner, code_size) = array_refs![data, 32, 4];
 
-        Contract {
+        Self {
             owner: Pubkey::new_from_array(*owner),
             code_size: u32::from_le_bytes(*code_size),
         }
     }
 
     /// Serialize `Contract` struct into given destination
-    pub fn pack(acc: &Contract, dst: &mut [u8]) -> usize {
+    pub fn pack(acc: &Self, dst: &mut [u8]) -> usize {
+        #[allow(clippy::use_self)]
         let data = array_mut_ref![dst, 0, Contract::SIZE];
         let (owner_dst, code_size_dst) = 
                 mut_array_refs![data, 32, 4];
         owner_dst.copy_from_slice(acc.owner.as_ref());
         *code_size_dst = acc.code_size.to_le_bytes();
-        Contract::SIZE
+        Self::SIZE
     }
 
     /// Get `Contract` struct size
-    pub fn size(&self) -> usize {
-        Contract::SIZE
+    #[must_use]
+    pub const fn size() -> usize {
+        Self::SIZE
     }
 }
 
@@ -292,7 +301,9 @@ impl Storage {
     const SIZE: usize = 20+8+8+8+8;
 
     /// Deserialize `Storage` struct from input data
+    #[must_use]
     pub fn unpack(src: &[u8]) -> Self {
+        #[allow(clippy::use_self)]
         let data = array_ref![src, 0, Storage::SIZE];
         let (caller, nonce, accounts_len, executor_data_size, evm_data_size) = array_refs![data, 20, 8, 8, 8, 8];
         
@@ -307,6 +318,7 @@ impl Storage {
 
     /// Serialize `Storage` struct into given destination
     pub fn pack(&self, dst: &mut [u8]) -> usize {
+        #[allow(clippy::use_self)]
         let data = array_mut_ref![dst, 0, Storage::SIZE];
         let (caller, nonce, accounts_len, executor_data_size, evm_data_size) = mut_array_refs![data, 20, 8, 8, 8, 8];
         *caller = self.caller.to_fixed_bytes();
@@ -315,11 +327,12 @@ impl Storage {
         *executor_data_size = self.executor_data_size.to_le_bytes();
         *evm_data_size = self.evm_data_size.to_le_bytes();
 
-        Storage::SIZE
+        Self::SIZE
     }
 
     /// Get `Storage` struct size
-    pub fn size(&self) -> usize {
-        Storage::SIZE
+    #[must_use]
+    pub const fn size() -> usize {
+        Self::SIZE
     }
 }

--- a/evm_loader/program/src/account_storage.rs
+++ b/evm_loader/program/src/account_storage.rs
@@ -26,7 +26,6 @@ pub enum Sender {
 }
 
 /// `AccountStorage` for solana program realization
-#[allow(clippy::module_name_repetitions)]
 pub struct ProgramAccountStorage<'a> {
     accounts: Vec<SolidityAccount<'a>>,
     aliases: RefCell<Vec<(H160, usize)>>,
@@ -162,17 +161,17 @@ impl<'a> ProgramAccountStorage<'a> {
         aliases.sort_by_key(|v| v.0);
 
         Ok(Self {
-            accounts: accounts,
+            accounts,
             aliases: RefCell::new(aliases),
-            clock_account: clock_account,
-            account_metas: account_metas,
-            contract_id: contract_id,
-            sender: sender,
+            clock_account,
+            account_metas,
+            contract_id,
+            sender,
         })
     }
 
     /// Get sender address
-    pub fn get_sender(&self) -> &Sender {
+    pub const fn get_sender(&self) -> &Sender {
         &self.sender
     }
 

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -43,6 +43,8 @@ pub struct BumpAllocator;
 impl BumpAllocator {
     /// Get occupied memory
     #[inline]
+    #[must_use]
+    #[allow(clippy::missing_const_for_fn)]
     pub fn occupied() -> usize {
         const POS_PTR: *mut usize = HEAP_START_ADDRESS as *mut usize;
         const TOP_ADDRESS: usize = HEAP_START_ADDRESS + HEAP_LENGTH;

--- a/evm_loader/program/src/error.rs
+++ b/evm_loader/program/src/error.rs
@@ -1,4 +1,5 @@
 //! Error types
+#![allow(clippy::use_self)]
 
 use num_derive::FromPrimitive;
 use solana_program::{decode_error::DecodeError, program_error::ProgramError};
@@ -6,7 +7,6 @@ use thiserror::Error;
 
 /// Errors that may be returned by the EVM Loader program.
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
-#[allow(clippy::module_name_repetitions)]
 pub enum EvmLoaderError {
     /// Unknown Error.
     #[error("Unknown error. Attention required.")]
@@ -18,7 +18,7 @@ pub enum EvmLoaderError {
 
 impl From<EvmLoaderError> for ProgramError {
     fn from(e: EvmLoaderError) -> Self {
-        ProgramError::Custom(e as u32)
+        Self::Custom(e as u32)
     }
 }
 

--- a/evm_loader/program/src/executor.rs
+++ b/evm_loader/program/src/executor.rs
@@ -153,7 +153,7 @@ impl<'config, B: Backend> Handler for Executor<'config, B> {
         let balance = self.balance(address);
         let transfer = evm::Transfer {
             source: address,
-            target: target,
+            target,
             value: balance,
         };
 
@@ -336,7 +336,7 @@ impl<'config, B: Backend> Machine<'config, B> {
         self.executor.state.touch(code_address);
 
         let code = self.executor.code(code_address);
-        let context = evm::Context{address: code_address, caller: caller, apparent_value: U256::zero()};
+        let context = evm::Context{address: code_address, caller, apparent_value: U256::zero()};
 
         let runtime = evm::Runtime::new(code, input, context, self.executor.config);
 

--- a/evm_loader/program/src/executor_state.rs
+++ b/evm_loader/program/src/executor_state.rs
@@ -25,7 +25,7 @@ pub struct ExecutorMetadata {
 }
 
 impl ExecutorMetadata {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             // gasometer: Gasometer::new(gas_limit, config),
             is_static: false,
@@ -33,7 +33,7 @@ impl ExecutorMetadata {
         }
     }
 
-    #[allow(clippy::needless_pass_by_value)]
+    #[allow(clippy::needless_pass_by_value, clippy::unused_self)]
     pub fn swallow_commit(&mut self, _other: Self) -> Result<(), ExitError> {
         // self.gasometer.record_stipend(other.gasometer.gas())?;
         // self.gasometer
@@ -47,19 +47,19 @@ impl ExecutorMetadata {
         Ok(())
     }
 
-    #[allow(clippy::needless_pass_by_value)]
+    #[allow(clippy::needless_pass_by_value, clippy::unused_self)]
     pub fn swallow_revert(&mut self, _other: Self) -> Result<(), ExitError> {
         // self.gasometer.record_stipend(other.gasometer.gas())?;
 
         Ok(())
     }
 
-    #[allow(clippy::needless_pass_by_value)]
+    #[allow(clippy::needless_pass_by_value, clippy::unused_self)]
     pub fn swallow_discard(&mut self, _other: Self) -> Result<(), ExitError> {
         Ok(())
     }
 
-    pub fn spit_child(&self, _gas_limit: u64, is_static: bool) -> Self {
+    pub const fn spit_child(&self, _gas_limit: u64, is_static: bool) -> Self {
         Self {
             // gasometer: Gasometer::new(gas_limit, self.gasometer.config()),
             is_static: is_static || self.is_static,
@@ -79,11 +79,11 @@ impl ExecutorMetadata {
     // }
 
     #[allow(dead_code)]
-    pub fn is_static(&self) -> bool {
+    pub const fn is_static(&self) -> bool {
         self.is_static
     }
 
-    pub fn depth(&self) -> Option<usize> {
+    pub const fn depth(&self) -> Option<usize> {
         self.depth
     }
 }
@@ -99,6 +99,7 @@ pub struct ExecutorSubstate {
 }
 
 impl ExecutorSubstate {
+    #[allow(clippy::missing_const_for_fn)]
     pub fn new() -> Self {
         Self {
             metadata: ExecutorMetadata::new(),
@@ -110,7 +111,7 @@ impl ExecutorSubstate {
         }
     }
 
-    pub fn metadata(&self) -> &ExecutorMetadata {
+    pub const fn metadata(&self) -> &ExecutorMetadata {
         &self.metadata
     }
 

--- a/evm_loader/program/src/hamt.rs
+++ b/evm_loader/program/src/hamt.rs
@@ -47,14 +47,14 @@ impl<'a> Hamt<'a> {
             data[0..header_len].copy_from_slice(&vec![0_u8; header_len]);
             let last_used_ptr = array_mut_ref![data, 0, 4];
             *last_used_ptr = (header_len as u32).to_le_bytes();
-            Ok(Hamt {data: data, last_used: header_len as u32, used: 0, item_count: 0})
+            Ok(Hamt {data, last_used: header_len as u32, used: 0, item_count: 0})
         } else {
             let last_used_ptr = array_mut_ref![data, 0, 4];
             let last_used = u32::from_le_bytes(*last_used_ptr);
             if last_used < header_len as u32 {
                 return Err(ProgramError::InvalidAccountData);
             }
-            Ok(Hamt {data: data, last_used: last_used, used: 0, item_count: 0})
+            Ok(Hamt {data, last_used, used: 0, item_count: 0})
         }
     }
 
@@ -297,35 +297,35 @@ mod test {
 
     #[test]
     fn test_new() -> Result<(), ProgramError> {
-        let mut data = vec!(0u8; (1+32+32)*4 + 16*1024);
+        let mut data = vec!(0_u8; (1+32+32)*4 + 16*1024);
         let mut hamt = Hamt::new(&mut data, true).unwrap();
 
-        hamt.insert(U256::from(0x12345120u64), U256::from(0xabcdefu64))?;
-        hamt.insert(U256::from(0x22345120u64), U256::from(0xdeadbeafu64))?;
-        hamt.insert(U256::from(0x32445120u64), U256::from(0xeeeeeeeeeu64))?;
-//        let res = hamt.insert(U256::from(0x42345120u64), U256::from(0x555555555u64))?;
+        hamt.insert(U256::from(0x1234_5120_u64), U256::from(0xab_cdef_u64))?;
+        hamt.insert(U256::from(0x2234_5120_u64), U256::from(0xdead_beaf_u64))?;
+        hamt.insert(U256::from(0x3244_5120_u64), U256::from(0x000e_eeee_eeee_u64))?;
+//        let res = hamt.insert(U256::from(0x42345120_u64), U256::from(0x555555555_u64))?;
 //        println!("Second insert {:?}", res);
 
         for i in 0..32 {
-            hamt.insert(U256::from(0x32440002u64+i*32), U256::from(0x55500+i))?;
-            hamt.insert(U256::from(0x31423415u64+i*32), U256::from(0xeeee00+i))?;
-            hamt.insert(U256::from(0x31423415u64+i*32*0x60), U256::from(0xdead00+i))?;
+            hamt.insert(U256::from(0x3244_0002_u64+i*32), U256::from(0x55500+i))?;
+            hamt.insert(U256::from(0x3142_3415_u64+i*32), U256::from(0x00ee_ee00+i))?;
+            hamt.insert(U256::from(0x3142_3415_u64+i*32*0x60), U256::from(0x00de_ad00+i))?;
         }
 
         for i in 0..16 {
             hamt.insert(random_U256(), random_U256())?;
         }
 
-        println!("Find item: {:x?}", hamt.find(U256::from(0x32445121u64)));
-        println!("Find item: {:x}", hamt.find(U256::from(0x32445120u64)).unwrap());
+        println!("Find item: {:x?}", hamt.find(U256::from(0x3244_5121_u64)));
+        println!("Find item: {:x}", hamt.find(U256::from(0x3244_5120_u64)).unwrap());
 
         //println!("{:x?}", hamt.header);
         hamt.print();
 
         let item_size = hamt.item_count*(size_of::<U256>() as u32)*2;
         println!("items count {}, item_size {}, total size {}, used size {}", hamt.item_count, item_size, hamt.restore_u32(0), hamt.used);
-        println!("item size / total size = {}", 100f64 * hamt.restore_u32(0) as f64 / item_size as f64);
-        println!("item size / used size = {}", 100f64 * hamt.used as f64 / item_size as f64);
+        println!("item size / total size = {}", 100_f64 * hamt.restore_u32(0) as f64 / item_size as f64);
+        println!("item size / used size = {}", 100_f64 * hamt.used as f64 / item_size as f64);
 
 /*
         for i in 0..data.len()/(4*8) {

--- a/evm_loader/program/src/instruction.rs
+++ b/evm_loader/program/src/instruction.rs
@@ -11,7 +11,6 @@ fn serialize_h160<S>(value: &H160, s: S) -> Result<S::Ok, S::Error> where S: Ser
 
 /// `EvmInstruction` serialized in instruction data
 #[derive(Serialize, Debug, PartialEq, Eq, Clone)]
-#[allow(clippy::module_name_repetitions)]
 pub enum EvmInstruction<'a> {
     /// Write program data into an account
     ///
@@ -275,6 +274,7 @@ impl<'a> EvmInstruction<'a> {
 }
 
 /// Creates a `OnReturn` instruction.
+#[must_use]
 pub fn on_return(
     myself_program_id: &Pubkey,
     status: u8,
@@ -293,6 +293,7 @@ pub fn on_return(
 }
 
 /// Creates a `OnEvent` instruction.
+#[must_use]
 pub fn on_event(
     myself_program_id: &Pubkey,
     log: Log

--- a/evm_loader/program/src/lib.rs
+++ b/evm_loader/program/src/lib.rs
@@ -2,13 +2,7 @@
 //#![forbid(unsafe_code)]
 #![deny(warnings)]
 #![deny(clippy::all, clippy::pedantic, clippy::nursery)]
-#![allow(
-    clippy::redundant_field_names,
-    clippy::must_use_candidate,
-    clippy::unused_self,
-    clippy::use_self,
-    clippy::missing_const_for_fn
-)]
+#![allow(clippy::module_name_repetitions)]
 
 //! An ERC20-like Token program for the Solana blockchain
 #[macro_use]
@@ -27,29 +21,8 @@ mod executor;
 mod executor_state;
 pub mod utils;
 
-
 // Export current solana-sdk types for downstream users who may also be building with a different
 // solana-sdk version
 pub use solana_program;
 
-// Convert the UI representation of a token amount (using the decimals field defined in its mint)
-// to the raw amount
-//pub fn ui_amount_to_amount(ui_amount: f64, decimals: u8) -> u64 {
-//    (ui_amount * 10_usize.pow(decimals as u32) as f64) as u64
-//}
-
-// Convert a raw amount to its UI representation (using the decimals field defined in its mint)
-//pub fn amount_to_ui_amount(amount: u64, decimals: u8) -> f64 {
-//    amount as f64 / 10_usize.pow(decimals as u32) as f64
-//}
-
 //solana_sdk::declare_id!("EVM1111111111111111111111111111111111111111");
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_evm_integration() {
-    }
-}

--- a/evm_loader/program/src/solana_backend.rs
+++ b/evm_loader/program/src/solana_backend.rs
@@ -67,26 +67,31 @@ impl<'a, 's, S> SolanaBackend<'a, 's, S> where S: AccountStorage {
         Self { account_storage, account_infos }
     }
 
+    #[allow(clippy::unused_self)]
     fn is_solana_address(&self, code_address: &H160) -> bool {
         *code_address == Self::system_account()
     }
 
+    #[allow(clippy::unused_self)]
     fn is_ecrecover_address(&self, code_address: &H160) -> bool {
         *code_address == Self::system_account_ecrecover()
     }
 
     /// Get system account
+    #[must_use]
     pub fn system_account() -> H160 {
         H160::from_slice(&[0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
     }
 
     /// Get ecrecover system account
+    #[must_use]
     pub fn system_account_ecrecover() -> H160 {
         H160::from_slice(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01])
     }
 
     /// Call inner ecrecover
-    pub fn call_inner_ecrecover(&self,
+    #[must_use]
+    pub fn call_inner_ecrecover(
         input: &[u8],
     ) -> Option<Capture<(ExitReason, Vec<u8>), Infallible>> {
         debug_print!("ecrecover");
@@ -124,6 +129,7 @@ impl<'a, 's, S> SolanaBackend<'a, 's, S> where S: AccountStorage {
     }
 
     /// Get chain id
+    #[must_use]
     pub fn chain_id() -> U256 { U256::from(111) }
 }
 
@@ -183,7 +189,7 @@ impl<'a, 's, S> Backend for SolanaBackend<'a, 's, S> where S: AccountStorage {
         _take_stipend: bool,
     ) -> Option<Capture<(ExitReason, Vec<u8>), Infallible>> {
         if self.is_ecrecover_address(&code_address) {
-            return self.call_inner_ecrecover(&input);
+            return Self::call_inner_ecrecover(&input);
         }
 
         if !self.is_solana_address(&code_address) {
@@ -218,7 +224,7 @@ impl<'a, 's, S> Backend for SolanaBackend<'a, 's, S> where S: AccountStorage {
                     accounts.push(AccountMeta {
                         is_signer: signer[0] != 0,
                         is_writable: writable[0] != 0,
-                        pubkey: pubkey,
+                        pubkey,
                     });
                     debug_print!("Acc: {}", pubkey);
                 };
@@ -239,14 +245,14 @@ impl<'a, 's, S> Backend for SolanaBackend<'a, 's, S> where S: AccountStorage {
                     Some((sender_eth, sender_nonce)) => {
                         let sender_seeds = [sender_eth.as_bytes(), &[sender_nonce]];
                         result = invoke_signed(
-                            &Instruction{program_id, accounts: accounts, data: input.to_vec()},
+                            &Instruction{program_id, accounts, data: input.to_vec()},
                             self.account_infos.unwrap(), &[&sender_seeds[..], &contract_seeds[..]]
                         );
 
                     }
                     None => {
                         result = invoke_signed(
-                            &Instruction{program_id, accounts: accounts, data: input.to_vec()},
+                            &Instruction{program_id, accounts, data: input.to_vec()},
                             self.account_infos.unwrap(), &[&contract_seeds[..]]
                         );
                     }
@@ -331,14 +337,14 @@ mod test {
     
         fn get_owner() -> Vec<u8> {
             let mut v = Vec::new();
-            v.extend_from_slice(&0x893d20e8u32.to_be_bytes());
+            v.extend_from_slice(&0x893d_20e8_u32.to_be_bytes());
             v
         }
     
         fn change_owner(address: H160) -> Vec<u8> {
             let mut v = Vec::new();
-            v.extend_from_slice(&0xa6f9dae1u32.to_be_bytes());
-            v.extend_from_slice(&[0u8;12]);
+            v.extend_from_slice(&0xa6f9_dae1_u32.to_be_bytes());
+            v.extend_from_slice(&[0_u8;12]);
             v.extend_from_slice(&<[u8;20]>::from(address));
             v
         }
@@ -365,6 +371,7 @@ mod test {
 
     #[test]
     fn test_solidity_address() -> Result<(), ProgramError> {
+        use std::str::FromStr;
 //        let account = Pubkey::from_str("Bfj8CF5ywavXyqkkuKSXt5AVhMgxUJgHfQsQjPc1JKzj").unwrap();
         let account = Pubkey::from_str("SysvarRent111111111111111111111111111111111").unwrap();
         let account = Pubkey::from_str("6ghLBF2LZAooDnmUMVm8tdNK6jhcAQhtbQiC7TgVnQ2r").unwrap();
@@ -465,9 +472,9 @@ mod test {
                     Account::new(((i+2)*1000) as u64, 10*1024, &owner)
                 ) );
         }
-        accounts.push((Pubkey::new_rand(), false, Account::new(1234u64, 0, &owner)));
-        accounts.push((Pubkey::new_rand(), false, Account::new(5423u64, 1024, &Pubkey::new_rand())));
-        accounts.push((Pubkey::new_rand(), false, Account::new(1234u64, 0, &Pubkey::new_rand())));
+        accounts.push((Pubkey::new_rand(), false, Account::new(1234_u64, 0, &owner)));
+        accounts.push((Pubkey::new_rand(), false, Account::new(5423_u64, 1024, &Pubkey::new_rand())));
+        accounts.push((Pubkey::new_rand(), false, Account::new(1234_u64, 0, &Pubkey::new_rand())));
 
         for acc in &accounts {println!("{:x?}", acc);};
 

--- a/evm_loader/program/src/solidity_account.rs
+++ b/evm_loader/program/src/solidity_account.rs
@@ -32,6 +32,7 @@ impl<'a> SolidityAccount<'a> {
     /// account_data.get_account()?;
     /// let caller_acc = SolidityAccount::new(caller_info.key, caller_info.lamports(), account_data, None);
     /// ```
+    #[must_use]
     pub fn new(solana_address: &'a Pubkey, lamports: u64, account_data: AccountData, code_data: Option<(AccountData, Rc<RefCell<&'a mut [u8]>>)>) -> Self {
         debug_print!("  SolidityAccount::new");
         Self{account_data, solana_address, code_data, lamports}
@@ -41,12 +42,14 @@ impl<'a> SolidityAccount<'a> {
     /// # Panics
     ///
     /// Will panic `account_data` doesn't contain `Account` struct
+    #[must_use]
     pub fn get_ether(&self) -> H160 {AccountData::get_account(&self.account_data).unwrap().ether}
 
     /// Get ethereum account nonce
     /// # Panics
     ///
     /// Will panic `account_data` doesn't contain `Account` struct
+    #[must_use]
     pub fn get_nonce(&self) -> u64 {AccountData::get_account(&self.account_data).unwrap().trx_count}
 
     fn code<U, F>(&self, f: F) -> U
@@ -105,7 +108,8 @@ impl<'a> SolidityAccount<'a> {
     }
 
     /// Get solana address
-    pub fn get_solana_address(&self) -> Pubkey {
+    #[must_use]
+    pub const fn get_solana_address(&self) -> Pubkey {
         *self.solana_address
     }
 
@@ -113,12 +117,14 @@ impl<'a> SolidityAccount<'a> {
     /// # Panics
     ///
     /// Will panic `account_data` doesn't contain `Account` struct
+    #[must_use]
     pub fn get_seeds(&self) -> (H160, u8) { (AccountData::get_account(&self.account_data).unwrap().ether, AccountData::get_account(&self.account_data).unwrap().nonce) }
 
     /// Get ethereum account basic info
     /// # Panics
     ///
     /// Will panic `account_data` doesn't contain `Account` struct
+    #[must_use]
     pub fn basic(&self) -> Basic {
         Basic { 
             balance: self.lamports.into(), 
@@ -127,6 +133,7 @@ impl<'a> SolidityAccount<'a> {
     }
 
     /// Get code hash
+    #[must_use]
     pub fn code_hash(&self) -> H256 {
         self.code(|d| {
             debug_print!("{}", &hex::encode(&d[0..32]));
@@ -135,11 +142,13 @@ impl<'a> SolidityAccount<'a> {
     }
 
     /// Get code size
+    #[must_use]
     pub fn code_size(&self) -> usize {
         self.code(|d| d.len())
     }
 
     /// Get code data
+    #[must_use]
     pub fn get_code(&self) -> Vec<u8> {
         self.code(|d| d.into())
     }

--- a/evm_loader/program/src/transaction.rs
+++ b/evm_loader/program/src/transaction.rs
@@ -79,7 +79,6 @@ pub fn check_secp256k1_instruction(sysvar_info: &AccountInfo, message_len: usize
 
 
 #[derive(Debug)]
-#[allow(clippy::module_name_repetitions)]
 pub struct UnsignedTransaction {
     pub nonce: u64,
     pub gas_price: U256,

--- a/evm_loader/program/src/utils.rs
+++ b/evm_loader/program/src/utils.rs
@@ -5,21 +5,25 @@ use solana_program::pubkey::Pubkey;
 use solana_program::keccak::{hash, hashv};
 
 /// Get Keccak256 hash as `H256`
+#[must_use]
 pub fn keccak256_h256(data: &[u8]) -> H256 {
     H256::from(hash(data).to_bytes())
 }
 
 /// Get Keccak256 hash as `H256` from several slices
+#[must_use]
 pub fn keccak256_h256_v(data: &[&[u8]]) -> H256 {
     H256::from(hashv(data).to_bytes())
 }
 
 /// Get Keccak256 hash as Vec<u8>
+#[must_use]
 pub fn keccak256_digest(data: &[u8]) -> Vec<u8> {
     hash(data).to_bytes().to_vec()
 }
 
 /// Convert U256 to H256
+#[must_use]
 pub fn u256_to_h256(value: U256) -> H256 {
     let mut v = vec![0_u8; 32];
     value.to_big_endian(&mut v);
@@ -27,6 +31,7 @@ pub fn u256_to_h256(value: U256) -> H256 {
 }
 
 /// Get ethereum address from solana `Pubkey`
+#[must_use]
 pub fn solidity_address(key: &Pubkey) -> H160 {
     H256::from_slice(key.as_ref()).into()
 }


### PR DESCRIPTION
Removed clippy allowance for:
    clippy::redundant_field_names,
    clippy::must_use_candidate,
    clippy::missing_errors_doc,
    clippy::missing_panics_doc,
    clippy::missing_const_for_fn
    clippy::unused_self
    clippy::use_self,
And fixed following errors.