### PR TITLE
73 return solana accounts needed to execute external call

### DIFF
--- a/evm_loader/cli/src/account_storage.rs
+++ b/evm_loader/cli/src/account_storage.rs
@@ -327,6 +327,8 @@ impl<'a> AccountStorage for EmulatorAccountStorage<'a> {
         {
             let mut external_account_metas = self.external_account_metas.borrow_mut();
             external_account_metas.extend(instruction.accounts.iter().cloned());
+            let contract_meta = AccountMeta::new_readonly(instruction.program_id, false);
+            external_account_metas.insert(0,contract_meta);
         }
         eprintln!("external_call: external_account_metas: {:?}", self.external_account_metas);
 

--- a/evm_loader/cli/src/account_storage.rs
+++ b/evm_loader/cli/src/account_storage.rs
@@ -343,7 +343,7 @@ impl<'a> AccountStorage for EmulatorAccountStorage<'a> {
             let contract_meta = AccountMeta::new_readonly(instruction.program_id, false);
             external_account_metas.insert(0,contract_meta);
         }
-        eprintln!("external_call: external_account_metas: {:?}", self.solana_accounts);
+        eprintln!("external_call: solana_accounts: {:?}", self.solana_accounts);
 
         let (contract_eth, contract_nonce) = self.seeds(&self.contract()).unwrap();   // do_call already check existence of Ethereum account with such index
         let contract_seeds = [contract_eth.as_bytes(), &[contract_nonce]];

--- a/evm_loader/cli/src/account_storage.rs
+++ b/evm_loader/cli/src/account_storage.rs
@@ -8,6 +8,8 @@ use solana_sdk::{
     account_info::AccountInfo,
     entrypoint::ProgramResult,
     program::invoke_signed,
+    transaction::Transaction,
+    client_error,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap};
@@ -15,15 +17,26 @@ use evm_loader::{
     account_data::AccountData,
     solana_backend::AccountStorage,
     solidity_account::SolidityAccount,
+    solana_backend::SolanaBackend,
 };
-use std::borrow::BorrowMut;
-use std::cell::RefCell; 
-use std::rc::Rc;
+#[allow(unused)]
+use std::{
+    borrow::BorrowMut,
+    cell::RefCell,
+    rc::Rc
+};
 use crate::Config;
 #[allow(unused)]
-use solana_program::instruction::Instruction;
-use evm_loader::solana_backend::SolanaBackend;
-use solana_program::instruction::AccountMeta;
+use solana_program::{
+    instruction::Instruction,
+    instruction::AccountMeta,
+    message::Message,
+};
+#[allow(unused)]
+use solana_client::{
+    rpc_client::RpcClient,
+    rpc_config::RpcSimulateTransactionConfig,
+};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AccountJSON {
@@ -36,7 +49,7 @@ pub struct AccountJSON {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct AccountMetaJSON {
+pub struct SolanaAccountJSON {
     /// An account's public key
     pub pubkey: String,
     /// True if an Instruction requires a Transaction signature matching `pubkey`.
@@ -44,7 +57,7 @@ pub struct AccountMetaJSON {
     /// True if the `pubkey` can be loaded as a read-write account.
     pub is_writable: bool,
 }
-impl From<AccountMeta> for AccountMetaJSON {
+impl From<AccountMeta> for SolanaAccountJSON {
     fn from(account_meta: AccountMeta) -> Self {
         Self {
             pubkey: bs58::encode(&account_meta.pubkey).into_string(),
@@ -85,7 +98,7 @@ impl SolanaNewAccount {
 pub struct EmulatorAccountStorage<'a> {
     accounts: RefCell<HashMap<H160, SolanaAccount>>,
     new_accounts: RefCell<HashMap<H160, SolanaNewAccount>>,
-    pub external_account_metas: RefCell<Vec<AccountMeta>>,
+    pub solana_accounts: RefCell<Vec<AccountMeta>>,
     config: &'a Config,
     contract_id: H160,
     caller_id: H160,
@@ -119,7 +132,7 @@ impl<'a> EmulatorAccountStorage<'a> {
         Self {
             accounts: RefCell::new(HashMap::new()),
             new_accounts: RefCell::new(HashMap::new()),
-            external_account_metas: RefCell::new(vec![]),
+            solana_accounts: RefCell::new(vec![]),
             config,
             contract_id,
             caller_id,
@@ -325,12 +338,12 @@ impl<'a> AccountStorage for EmulatorAccountStorage<'a> {
     ) -> ProgramResult {
         eprintln!("emulate external_call");
         {
-            let mut external_account_metas = self.external_account_metas.borrow_mut();
+            let mut external_account_metas = self.solana_accounts.borrow_mut();
             external_account_metas.extend(instruction.accounts.iter().cloned());
             let contract_meta = AccountMeta::new_readonly(instruction.program_id, false);
             external_account_metas.insert(0,contract_meta);
         }
-        eprintln!("external_call: external_account_metas: {:?}", self.external_account_metas);
+        eprintln!("external_call: external_account_metas: {:?}", self.solana_accounts);
 
         let (contract_eth, contract_nonce) = self.seeds(&self.contract()).unwrap();   // do_call already check existence of Ethereum account with such index
         let contract_seeds = [contract_eth.as_bytes(), &[contract_nonce]];

--- a/evm_loader/cli/src/account_storage.rs
+++ b/evm_loader/cli/src/account_storage.rs
@@ -309,6 +309,7 @@ impl<'a> AccountStorage for EmulatorAccountStorage<'a> {
         match self.seeds(&self.origin()) {
             Some((sender_eth, sender_nonce)) => {
                 let sender_seeds = [sender_eth.as_bytes(), &[sender_nonce]];
+                // TODO: config.rpc_client.simulate_transaction(&solana_address, CommitmentConfig::processed()).unwrap().value {
                 invoke_signed(
                     instruction,
                     account_infos,

--- a/evm_loader/cli/src/account_storage.rs
+++ b/evm_loader/cli/src/account_storage.rs
@@ -9,7 +9,6 @@ use solana_sdk::{
     entrypoint::ProgramResult,
     program::invoke_signed,
     transaction::Transaction,
-    client_error,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap};

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -84,7 +84,7 @@ use secp256k1::SecretKey;
 use rlp::RlpStream;
 
 use log::{debug, error, info};
-use crate::account_storage::AccountMetaJSON;
+use crate::account_storage::SolanaAccountJSON;
 
 const DATA_CHUNK_SIZE: usize = 229; // Keep program chunks under PACKET_DATA_SIZE
 
@@ -148,16 +148,16 @@ fn command_emulate(config: &Config, contract_id: H160, caller_id: H160, data: Ve
 
     let accounts: Vec<AccountJSON> = account_storage.get_used_accounts();
 
-    let account_metas: Vec<AccountMetaJSON> = account_storage.external_account_metas
+    let solana_accounts: Vec<SolanaAccountJSON> = account_storage.solana_accounts
         .borrow()
         .iter()
         .cloned()
-        .map(AccountMetaJSON::from)
+        .map(SolanaAccountJSON::from)
         .collect();
 
     let js = json!({
         "accounts": accounts,
-        "account_metas": account_metas,
+        "solana_accounts": solana_accounts,
         "result": &hex::encode(&result),
         "exit_status": status
     }).to_string();

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -151,7 +151,8 @@ fn command_emulate(config: &Config, contract_id: H160, caller_id: H160, data: Ve
         .borrow()
         .iter()
         .cloned()
-        .map(|meta| AccountMetaJSON::from(meta)).collect();
+        .map(AccountMetaJSON::from)
+        .collect();
 
     let js = json!({
         "accounts": accounts,

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -84,6 +84,7 @@ use secp256k1::SecretKey;
 use rlp::RlpStream;
 
 use log::{debug, error, info};
+use crate::account_storage::AccountMetaJSON;
 
 const DATA_CHUNK_SIZE: usize = 229; // Keep program chunks under PACKET_DATA_SIZE
 
@@ -146,7 +147,18 @@ fn command_emulate(config: &Config, contract_id: H160, caller_id: H160, data: Ve
 
     let accounts: Vec<AccountJSON> = account_storage.get_used_accounts();
 
-    let js = json!({"accounts": accounts, "result": &hex::encode(&result), "exit_status": status}).to_string();
+    let account_metas: Vec<AccountMetaJSON> = account_storage.external_account_metas
+        .borrow()
+        .iter()
+        .cloned()
+        .map(|meta| AccountMetaJSON::from(meta)).collect();
+
+    let js = json!({
+        "accounts": accounts,
+        "account_metas": account_metas,
+        "result": &hex::encode(&result),
+        "exit_status": status
+    }).to_string();
 
     println!("{}", js);
 }

--- a/evm_loader/program/src/solana_backend.rs
+++ b/evm_loader/program/src/solana_backend.rs
@@ -229,8 +229,6 @@ impl<'a, 's, S> Backend for SolanaBackend<'a, 's, S> where S: AccountStorage {
                     let data = array_ref![input, 35*i as usize, 35];
                     let (translate, signer, writable, pubkey) = array_refs![data, 1, 1, 1, 32];
                     let pubkey = if translate[0] == 0 {
-                        debug_print!("Detect no translate account: {}-{:?}", i, pubkey);
-                        //     Add to AccountStorege as a solana account to return in AccountJson list
                         Pubkey::new(pubkey)
                     } else {
                         match self.account_storage.get_account_solana_address(&H160::from_slice(&pubkey[12..])) {

--- a/evm_loader/program/src/solana_backend.rs
+++ b/evm_loader/program/src/solana_backend.rs
@@ -229,6 +229,8 @@ impl<'a, 's, S> Backend for SolanaBackend<'a, 's, S> where S: AccountStorage {
                     let data = array_ref![input, 35*i as usize, 35];
                     let (translate, signer, writable, pubkey) = array_refs![data, 1, 1, 1, 32];
                     let pubkey = if translate[0] == 0 {
+                        debug_print!("Detect no translate account: {}-{:?}", i, pubkey);
+                        //     Add to AccountStorege as a solana account to return in AccountJson list
                         Pubkey::new(pubkey)
                     } else {
                         match self.account_storage.get_account_solana_address(&H160::from_slice(&pubkey[12..])) {

--- a/evm_loader/test_cli_emulate.py
+++ b/evm_loader/test_cli_emulate.py
@@ -66,6 +66,7 @@ class ExternalCall:
             print("ERR: transfer_ext: {}".format(err))
         return result
 
+
 def emulate_external_call(sender, contract, trx_data):
     print('\nEmulate external call:')
     print('sender:', sender)
@@ -200,6 +201,11 @@ class EmulateTest(unittest.TestCase):
         tmpl_json = {
             "account_metas": [
                 {
+                    "pubkey": '' + tokenkeg,
+                    "is_signer": False,
+                    "is_writable": False,
+                },
+                {
                     "pubkey": '' + self.token,
                     "is_signer": False,
                     "is_writable": False,
@@ -242,13 +248,13 @@ class EmulateTest(unittest.TestCase):
             "result": ""
         }
 
-        trx_data = abi.function_signature_to_4byte_selector('transferExt(uint256,uint256,uint256,uint256,uint256)')\
-                    + bytes.fromhex(base58.b58decode(self.token).hex()
-                                    + base58.b58decode(self.token_acc1).hex()
-                                    + base58.b58decode(self.token_acc2).hex()
-                                    + "%064x" % (transfer_amount * (10 ** 9))
-                                    + bytes(self.acc.public_key()).hex()
-                                    )
+        trx_data = abi.function_signature_to_4byte_selector('transferExt(uint256,uint256,uint256,uint256,uint256)') \
+                   + bytes.fromhex(base58.b58decode(self.token).hex()
+                                   + base58.b58decode(self.token_acc1).hex()
+                                   + base58.b58decode(self.token_acc2).hex()
+                                   + "%064x" % (transfer_amount * (10 ** 9))
+                                   + bytes(self.acc.public_key()).hex()
+                                   )
 
         emulate_result = emulate_external_call(self.ethereum_caller.hex(),
                                                self.contract.ethereum_id.hex(),
@@ -275,52 +281,53 @@ class EmulateTest(unittest.TestCase):
         self.assertEqual(self.spl_token.balance(self.token_acc1), balance1 + mint_amount - 2 * transfer_amount)
         self.assertEqual(self.spl_token.balance(self.token_acc2), balance2 + 2 * transfer_amount)
 
+
 def test_unsuccessful_cli_emulate(self):
-        balance1 = self.spl_token.balance(self.token_acc1)
-        balance2 = self.spl_token.balance(self.token_acc2)
-        mint_amount = 100
-        self.spl_token.mint(self.token, self.token_acc1, mint_amount)
-        self.assertEqual(self.spl_token.balance(self.token_acc1), balance1 + mint_amount)
-        self.assertEqual(self.spl_token.balance(self.token_acc2), balance2)
+    balance1 = self.spl_token.balance(self.token_acc1)
+    balance2 = self.spl_token.balance(self.token_acc2)
+    mint_amount = 100
+    self.spl_token.mint(self.token, self.token_acc1, mint_amount)
+    self.assertEqual(self.spl_token.balance(self.token_acc1), balance1 + mint_amount)
+    self.assertEqual(self.spl_token.balance(self.token_acc2), balance2)
 
-        transfer_amount = self.spl_token.balance(self.token_acc1) + 1
-        (trx_data, result) \
-            = self.contract.transfer_ext(self.ethereum_caller,
-                                         self.token, self.token_acc1, self.token_acc2, transfer_amount * (10 ** 9),
-                                         self.acc.public_key()._key)
-        self.assertEqual(result, None)
+    transfer_amount = self.spl_token.balance(self.token_acc1) + 1
+    (trx_data, result) \
+        = self.contract.transfer_ext(self.ethereum_caller,
+                                     self.token, self.token_acc1, self.token_acc2, transfer_amount * (10 ** 9),
+                                     self.acc.public_key()._key)
+    self.assertEqual(result, None)
 
-        emulate_result = emulate_external_call(self.ethereum_caller.hex(),
-                                               self.contract.ethereum_id.hex(),
-                                               trx_data.hex())
-        tmpl_json = {
-            "accounts": [
-                {
-                    "account": '' + self.contract.contract_account,
-                    "address": '0x' + self.contract.ethereum_id.hex(),
-                    "code_size": None,
-                    "contract": '' + self.contract.contract_code_account,
-                    "new": False,
-                    "writable": True
-                },
-                {
-                    "account": '' + self.caller,
-                    "address": '0x' + self.ethereum_caller.hex(),
-                    "code_size": None,
-                    "contract": None,
-                    "new": False,
-                    "writable": True
-                }
-            ],
-            "exit_status": "succeed",
-            "result": ""
-        }
+    emulate_result = emulate_external_call(self.ethereum_caller.hex(),
+                                           self.contract.ethereum_id.hex(),
+                                           trx_data.hex())
+    tmpl_json = {
+        "accounts": [
+            {
+                "account": '' + self.contract.contract_account,
+                "address": '0x' + self.contract.ethereum_id.hex(),
+                "code_size": None,
+                "contract": '' + self.contract.contract_code_account,
+                "new": False,
+                "writable": True
+            },
+            {
+                "account": '' + self.caller,
+                "address": '0x' + self.ethereum_caller.hex(),
+                "code_size": None,
+                "contract": None,
+                "new": False,
+                "writable": True
+            }
+        ],
+        "exit_status": "succeed",
+        "result": ""
+    }
 
-        self.compare_tmpl_and_emulate_result(tmpl_json, emulate_result)
+    self.compare_tmpl_and_emulate_result(tmpl_json, emulate_result)
 
-        # no changes after the emulation
-        self.assertEqual(self.spl_token.balance(self.token_acc1), balance1 + mint_amount)
-        self.assertEqual(self.spl_token.balance(self.token_acc2), balance2)
+    # no changes after the emulation
+    self.assertEqual(self.spl_token.balance(self.token_acc1), balance1 + mint_amount)
+    self.assertEqual(self.spl_token.balance(self.token_acc2), balance2)
 
 
 if __name__ == '__main__':

--- a/evm_loader/test_cli_emulate.py
+++ b/evm_loader/test_cli_emulate.py
@@ -264,8 +264,6 @@ class EmulateTest(unittest.TestCase):
                                      is_writable=item['is_writable'])
                          for item in emulate_result['account_metas']]
 
-        # TODO: emulator should return this AccountMeta too?
-        account_metas.append(AccountMeta(pubkey=PublicKey(tokenkeg), is_signer=False, is_writable=False))
         print('account_metas:', account_metas)
 
         result = self.contract.call(self.ethereum_caller, trx_data, account_metas)

--- a/evm_loader/test_cli_emulate.py
+++ b/evm_loader/test_cli_emulate.py
@@ -126,8 +126,8 @@ class EmulateTest(unittest.TestCase):
         self.assertSetEqual(set(left), set(right))
 
     def compare_account_metas(self, left_json, right_json):
-        left = map(lambda item: (item['pubkey'], item['is_signer'], item['is_writable']), left_json['account_metas'])
-        right = map(lambda item: (item['pubkey'], item['is_signer'], item['is_writable']), right_json['account_metas'])
+        left = map(lambda item: (item['pubkey'], item['is_signer'], item['is_writable']), left_json['solana_accounts'])
+        right = map(lambda item: (item['pubkey'], item['is_signer'], item['is_writable']), right_json['solana_accounts'])
 
         self.assertCountEqual(left, right)
         self.assertSetEqual(set(left), set(right))
@@ -199,7 +199,7 @@ class EmulateTest(unittest.TestCase):
         self.assertEqual(self.spl_token.balance(self.token_acc2), balance2 + transfer_amount)
 
         tmpl_json = {
-            "account_metas": [
+            "solana_accounts": [
                 {
                     "pubkey": '' + tokenkeg,
                     "is_signer": False,
@@ -265,14 +265,14 @@ class EmulateTest(unittest.TestCase):
         self.assertEqual(self.spl_token.balance(self.token_acc1), balance1 + mint_amount - transfer_amount)
         self.assertEqual(self.spl_token.balance(self.token_acc2), balance2 + transfer_amount)
 
-        account_metas = [AccountMeta(pubkey=item['pubkey'],
+        solana_accounts = [AccountMeta(pubkey=item['pubkey'],
                                      is_signer=item['is_signer'],
                                      is_writable=item['is_writable'])
-                         for item in emulate_result['account_metas']]
+                         for item in emulate_result['solana_accounts']]
 
-        print('account_metas:', account_metas)
+        print('solana_accounts:', solana_accounts)
 
-        result = self.contract.call(self.ethereum_caller, trx_data, account_metas)
+        result = self.contract.call(self.ethereum_caller, trx_data, solana_accounts)
 
         src_data = result['result']['meta']['innerInstructions'][-1]['instructions'][-1]['data']
         self.assertEqual(base58.b58decode(src_data)[0], 6)  # 6 means OnReturn
@@ -330,7 +330,7 @@ def test_unsuccessful_cli_emulate(self):
     self.assertEqual(self.spl_token.balance(self.token_acc2), balance2)
 
     tmpl_json = {
-        "account_metas": [
+        "solana_accounts": [
             {
                 "pubkey": '' + tokenkeg,
                 "is_signer": False,
@@ -396,14 +396,14 @@ def test_unsuccessful_cli_emulate(self):
     self.assertEqual(self.spl_token.balance(self.token_acc1), balance1 + mint_amount)
     self.assertEqual(self.spl_token.balance(self.token_acc2), balance2)
 
-    account_metas = [AccountMeta(pubkey=item['pubkey'],
+    solana_accounts = [AccountMeta(pubkey=item['pubkey'],
                                  is_signer=item['is_signer'],
                                  is_writable=item['is_writable'])
-                     for item in emulate_result['account_metas']]
+                     for item in emulate_result['solana_accounts']]
 
-    print('account_metas:', account_metas)
+    print('solana_accounts:', solana_accounts)
 
-    result = self.contract.call(self.ethereum_caller, trx_data, account_metas)
+    result = self.contract.call(self.ethereum_caller, trx_data, solana_accounts)
 
     self.assertEqual(result, None)
 

--- a/evm_loader/test_cli_emulate.py
+++ b/evm_loader/test_cli_emulate.py
@@ -54,6 +54,17 @@ class ExternalCall:
             print("ERR: transfer_ext: {}".format(err))
         return ether_trx.trx_data, result
 
+    def call(self, ether_caller, trx_data, account_metas):
+        ether_trx = EthereumTransaction(
+            ether_caller, self.contract_account, self.contract_code_account, trx_data, account_metas)
+        result = None
+        try:
+            result = self.neon_evm_client.send_ethereum_trx_single(ether_trx)
+            print(result)
+        except solana.rpc.api.SendTransactionError as err:
+            import sys
+            print("ERR: transfer_ext: {}".format(err))
+        return result
 
 def emulate_external_call(sender, contract, trx_data):
     print('\nEmulate external call:')
@@ -106,6 +117,20 @@ class EmulateTest(unittest.TestCase):
         cls.token_acc2 = cls.spl_token.create_token_account(cls.token, RandomAccount().get_path())
         print("token_acc2:", cls.token_acc2)
 
+    def compare_accounts(self, left_json, right_json):
+        left = map(lambda item: (item['account'], item['address'], item['contract']), left_json['accounts'])
+        right = map(lambda item: (item['account'], item['address'], item['contract']), right_json['accounts'])
+
+        self.assertCountEqual(left, right)
+        self.assertSetEqual(set(left), set(right))
+
+    def compare_account_metas(self, left_json, right_json):
+        left = map(lambda item: (item['pubkey'], item['is_signer'], item['is_writable']), left_json['account_metas'])
+        right = map(lambda item: (item['pubkey'], item['is_signer'], item['is_writable']), right_json['account_metas'])
+
+        self.assertCountEqual(left, right)
+        self.assertSetEqual(set(left), set(right))
+
     def compare_tmpl_and_emulate_result(self, tmpl_json, emulate_result):
         print('tmpl_json:', json.dumps(tmpl_json, sort_keys=True, indent=2, separators=(',', ': ')))
         print('emulate_result:', json.dumps(emulate_result, sort_keys=True, indent=2, separators=(',', ': ')))
@@ -113,11 +138,11 @@ class EmulateTest(unittest.TestCase):
         self.assertEqual(tmpl_json["exit_status"], emulate_result["exit_status"])
         self.assertEqual(tmpl_json['result'], emulate_result['result'])
 
-        left = map(lambda item: (item['account'], item['address'], item['contract']), tmpl_json['accounts'])
-        right = map(lambda item: (item['account'], item['address'], item['contract']), emulate_result['accounts'])
+        self.compare_accounts(tmpl_json, emulate_result)
 
-        self.assertCountEqual(left, right)
-        self.assertSetEqual(set(left), set(right))
+    def compare_tmpl_and_emulate_result_2(self, tmpl_json, emulate_result):
+        self.compare_tmpl_and_emulate_result(tmpl_json, emulate_result)
+        self.compare_account_metas(tmpl_json, emulate_result)
 
     def test_successful_cli_emulate(self):
         balance1 = self.spl_token.balance(self.token_acc1)
@@ -139,37 +164,32 @@ class EmulateTest(unittest.TestCase):
         self.assertEqual(self.spl_token.balance(self.token_acc1), balance1 + mint_amount - transfer_amount)
         self.assertEqual(self.spl_token.balance(self.token_acc2), balance2 + transfer_amount)
 
-        emulate_result = emulate_external_call(self.ethereum_caller.hex(),
-                                               self.contract.ethereum_id.hex(),
-                                               trx_data.hex())
-        tmpl = """ {
+        tmpl_json = {
             "accounts": [
                 {
-                    "account": "CONTRACT_ACCOUNT",
-                    "address": "CONTRACT_ETHEREUM_ID",
-                    "code_size": null,
-                    "contract": "CONTRACT_CODE_ACCOUNT",
-                    "new": false,
-                    "writable": true
+                    "account": '' + self.contract.contract_account,
+                    "address": '0x' + self.contract.ethereum_id.hex(),
+                    "code_size": None,
+                    "contract": '' + self.contract.contract_code_account,
+                    "new": False,
+                    "writable": True
                 },
                 {
-                    "account": "ETHEREUM_CALLER_ACCOUNT",
-                    "address": "ETHEREUM_CALLER_ID",
-                    "code_size": null,
-                    "contract": null,
-                    "new": false,
-                    "writable": true
+                    "account": '' + self.caller,
+                    "address": '0x' + self.ethereum_caller.hex(),
+                    "code_size": None,
+                    "contract": None,
+                    "new": False,
+                    "writable": True
                 }
             ],
             "exit_status": "succeed",
             "result": ""
-        }"""
-        tmpl = tmpl.replace('CONTRACT_ACCOUNT', self.contract.contract_account)
-        tmpl = tmpl.replace('CONTRACT_ETHEREUM_ID', '0x' + self.contract.ethereum_id.hex())
-        tmpl = tmpl.replace('CONTRACT_CODE_ACCOUNT', self.contract.contract_code_account)
-        tmpl = tmpl.replace('ETHEREUM_CALLER_ACCOUNT', self.caller)
-        tmpl = tmpl.replace('ETHEREUM_CALLER_ID', '0x' + self.ethereum_caller.hex())
-        tmpl_json = json.loads(tmpl)
+        }
+
+        emulate_result = emulate_external_call(self.ethereum_caller.hex(),
+                                               self.contract.ethereum_id.hex(),
+                                               trx_data.hex())
 
         self.compare_tmpl_and_emulate_result(tmpl_json, emulate_result)
 
@@ -177,7 +197,87 @@ class EmulateTest(unittest.TestCase):
         self.assertEqual(self.spl_token.balance(self.token_acc1), balance1 + mint_amount - transfer_amount)
         self.assertEqual(self.spl_token.balance(self.token_acc2), balance2 + transfer_amount)
 
-    def test_unsuccessful_cli_emulate(self):
+        tmpl_json = {
+            "account_metas": [
+                {
+                    "pubkey": '' + self.token,
+                    "is_signer": False,
+                    "is_writable": False,
+                },
+                {
+                    "pubkey": '' + self.token_acc1,
+                    "is_signer": False,
+                    "is_writable": True,
+                },
+                {
+                    "pubkey": '' + self.token_acc2,
+                    "is_signer": False,
+                    "is_writable": True,
+                },
+                {
+                    "pubkey": str(self.acc.public_key()),
+                    "is_signer": True,
+                    "is_writable": False,
+                },
+            ],
+            "accounts": [
+                {
+                    "account": '' + self.contract.contract_account,
+                    "address": '0x' + self.contract.ethereum_id.hex(),
+                    "code_size": None,
+                    "contract": '' + self.contract.contract_code_account,
+                    "new": False,
+                    "writable": True,
+                },
+                {
+                    "account": '' + self.caller,
+                    "address": '0x' + self.ethereum_caller.hex(),
+                    "code_size": None,
+                    "contract": None,
+                    "new": False,
+                    "writable": True,
+                },
+            ],
+            "exit_status": "succeed",
+            "result": ""
+        }
+
+        trx_data = abi.function_signature_to_4byte_selector('transferExt(uint256,uint256,uint256,uint256,uint256)')\
+                    + bytes.fromhex(base58.b58decode(self.token).hex()
+                                    + base58.b58decode(self.token_acc1).hex()
+                                    + base58.b58decode(self.token_acc2).hex()
+                                    + "%064x" % (transfer_amount * (10 ** 9))
+                                    + bytes(self.acc.public_key()).hex()
+                                    )
+
+        emulate_result = emulate_external_call(self.ethereum_caller.hex(),
+                                               self.contract.ethereum_id.hex(),
+                                               trx_data.hex())
+
+        self.compare_tmpl_and_emulate_result_2(tmpl_json, emulate_result)
+        # no changes after the emulation
+        self.assertEqual(self.spl_token.balance(self.token_acc1), balance1 + mint_amount - transfer_amount)
+        self.assertEqual(self.spl_token.balance(self.token_acc2), balance2 + transfer_amount)
+
+        account_metas = [AccountMeta(pubkey=item['pubkey'],
+                                     is_signer=item['is_signer'],
+                                     is_writable=item['is_writable'])
+                         for item in emulate_result['account_metas']]
+
+        # TODO: emulator should return this AccountMeta too?
+        account_metas.append(AccountMeta(pubkey=PublicKey(tokenkeg), is_signer=False, is_writable=False))
+        print('account_metas:', account_metas)
+
+        result = self.contract.call(self.ethereum_caller, trx_data, account_metas)
+
+        src_data = result['result']['meta']['innerInstructions'][-1]['instructions'][-1]['data']
+        self.assertEqual(base58.b58decode(src_data)[0], 6)  # 6 means OnReturn
+        self.assertLess(base58.b58decode(src_data)[1], 0xd0)  # less 0xd0 - success
+
+        self.assertEqual(self.spl_token.balance(self.token_acc1), balance1 + mint_amount - 2 * transfer_amount)
+        self.assertEqual(self.spl_token.balance(self.token_acc2), balance2 + 2 * transfer_amount)
+
+def test_unsuccessful_cli_emulate(self):
         balance1 = self.spl_token.balance(self.token_acc1)
         balance2 = self.spl_token.balance(self.token_acc2)
         mint_amount = 100
@@ -186,7 +286,7 @@ class EmulateTest(unittest.TestCase):
         self.assertEqual(self.spl_token.balance(self.token_acc2), balance2)
 
         transfer_amount = self.spl_token.balance(self.token_acc1) + 1
-        (trx_data, result)\
+        (trx_data, result) \
             = self.contract.transfer_ext(self.ethereum_caller,
                                          self.token, self.token_acc1, self.token_acc2, transfer_amount * (10 ** 9),
                                          self.acc.public_key()._key)
@@ -195,34 +295,28 @@ class EmulateTest(unittest.TestCase):
         emulate_result = emulate_external_call(self.ethereum_caller.hex(),
                                                self.contract.ethereum_id.hex(),
                                                trx_data.hex())
-        tmpl = """ {
+        tmpl_json = {
             "accounts": [
                 {
-                    "account": "CONTRACT_ACCOUNT",
-                    "address": "CONTRACT_ETHEREUM_ID",
-                    "code_size": null,
-                    "contract": "CONTRACT_CODE_ACCOUNT",
-                    "new": false,
-                    "writable": true
+                    "account": '' + self.contract.contract_account,
+                    "address": '0x' + self.contract.ethereum_id.hex(),
+                    "code_size": None,
+                    "contract": '' + self.contract.contract_code_account,
+                    "new": False,
+                    "writable": True
                 },
                 {
-                    "account": "ETHEREUM_CALLER_ACCOUNT",
-                    "address": "ETHEREUM_CALLER_ID",
-                    "code_size": null,
-                    "contract": null,
-                    "new": false,
-                    "writable": true
+                    "account": '' + self.caller,
+                    "address": '0x' + self.ethereum_caller.hex(),
+                    "code_size": None,
+                    "contract": None,
+                    "new": False,
+                    "writable": True
                 }
             ],
             "exit_status": "succeed",
             "result": ""
-        }"""
-        tmpl = tmpl.replace('CONTRACT_ACCOUNT', self.contract.contract_account)
-        tmpl = tmpl.replace('CONTRACT_ETHEREUM_ID', '0x' + self.contract.ethereum_id.hex())
-        tmpl = tmpl.replace('CONTRACT_CODE_ACCOUNT', self.contract.contract_code_account)
-        tmpl = tmpl.replace('ETHEREUM_CALLER_ACCOUNT', self.caller)
-        tmpl = tmpl.replace('ETHEREUM_CALLER_ID', '0x' + self.ethereum_caller.hex())
-        tmpl_json = json.loads(tmpl)
+        }
 
         self.compare_tmpl_and_emulate_result(tmpl_json, emulate_result)
 


### PR DESCRIPTION
To create a transaction with external calls by our proxy we need to emulate it to determine what solana accounts should be added when the transaction is executed on neon-evm.
So neon-cli returns account_meta on **emulate** command.
For example:

Run emulate:

 neon-cli  --commitment=recent --evm_loader 6xbcAxGEhFtqAgBJ4bq1qpJDhSykBiheLEg7eSvAawr5 --url http://127.0.0.1:8899 **emulate** 96465ad728b26947051a46ac6c05be40f7137a1a b8e469b16644fec9ae5890cf9f852877885d3112 8661b298d1c318ef238cc8835e5e33cd5e903d8849134c18caf1da783cd5d4dcf577e5d6f0aa7040e130ff0bab458e379cc15b51434d11ec2154adda96f67d24c97b7d091325ee06925cb8a3258caaf6941349859f706c869122fae8f3998572268c698d00000000000000000000000000000000000000000000000000000003f5476a004269b26957c682b073163ab306589975a622aa9e298104370d1489feb44d06ce  

Emulate result:

{
  "**solana_accounts**": [
    {
      "is_signer": false,
      "is_writable": false,
      "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
    },
    {
      "is_signer": false,
      "is_writable": true,
      "pubkey": "HCTat1EoHqThBKooigzvjUkMorpssx6VuroNfVifnAHW"
    },
    {
      "is_signer": false,
      "is_writable": false,
      "pubkey": "F7pkjKo4kAYnCXuJp6jsPPPqe9kvxmgrTPLDkG766c4d"
    },
    {
      "is_signer": false,
      "is_writable": true,
      "pubkey": "2HkHunhHUnZW1tQ1pEKBuZ9znAjdqT2ijqHaB9Fn2xTv"
    },
    {
      "is_signer": true,
      "is_writable": false,
      "pubkey": "5UFPSgRVwDuPh5wPMBj5WLQCQ2AFhjiKaQzeqV2xD4Zs"
    }
  ],
  "accounts": [
    {
      "account": "EU2trC5TMHW4usnQMxddn1Uaz9mxUbdL1czQ7sb54zx1",
      "address": "0xb8e469b16644fec9ae5890cf9f852877885d3112",
      "code_size": null,
      "contract": "D5pcEoyHXHK1HgPgbHU9UX45afXnFMV4YAJGDZVjWFjX",
      "new": false,
      "writable": true
    },
    {
      "account": "9J5CceTC71VLyTfTxkV9EbfVETZranUF442sx8mfytya",
      "address": "0x96465ad728b26947051a46ac6c05be40f7137a1a",
      "code_size": null,
      "contract": null,
      "new": false,
      "writable": true
    }
  ],
  "exit_status": "succeed",
  "result": ""
}

Proxy should add these solana accounts to execute the transaction on neon-evm.

The test **test_cli_emulate.py** was changed to check this new behavior.

Implementation details:
  the function **_external_call_** in neon_cli::account_storage impl<'a> AccountStorage for EmulatorAccountStorage<'a>
  detects solana accounts and added them to the new field
  neon_cli::account_storage::EmulatorAccountStorage pub _**solana_accounts**_: RefCell<Vec<AccountMeta>>
  neon-cli adds them to the result of the emulation