### PR TITLE
Detail error info

### DIFF
--- a/evm_loader/program/src/account_data.rs
+++ b/evm_loader/program/src/account_data.rs
@@ -88,7 +88,7 @@ impl AccountData {
             Self::CONTRACT_TAG => Self::Contract( Contract::unpack(rest) ),
             Self::STORAGE_TAG => Self::Storage( Storage::unpack(rest) ),
 
-            _ => return Err(ProgramError::InvalidAccountData),
+            _ => return Err!(ProgramError::InvalidAccountData; "tag={:?}", tag),
         })
     }
 
@@ -104,28 +104,32 @@ impl AccountData {
     /// `ProgramError::AccountDataTooSmall` if `dst` size not enough to store serialized `AccountData`
     /// `ProgramError::InvalidAccountData` if in `dst` stored incompatible `AccountData` struct
     pub fn pack(&self, dst: &mut [u8]) -> Result<usize, ProgramError> {
-        if dst.is_empty() { return Err(ProgramError::AccountDataTooSmall); }
+        if dst.is_empty() {return Err!(ProgramError::AccountDataTooSmall; "dst={:?}", dst);}
         Ok(match self {
             Self::Empty => {
-                if dst.len() < self.size() { return Err(ProgramError::AccountDataTooSmall); }
+                if dst.len() < self.size() {
+                    return Err!(ProgramError::AccountDataTooSmall; "dst.len()={:?}, self.size()={:?}", dst.len(), self.size());
+                }
                 dst[0] = Self::EMPTY_TAG;
                 (Self::Empty).size()
             },
             Self::Account(acc) => {
-                if dst[0] != Self::ACCOUNT_TAG && dst[0] != Self::EMPTY_TAG { return Err(ProgramError::InvalidAccountData); }
-                if dst.len() < self.size() { return Err(ProgramError::AccountDataTooSmall); }
+                if dst[0] != Self::ACCOUNT_TAG && dst[0] != Self::EMPTY_TAG {
+                    return Err!(ProgramError::InvalidAccountData; "dst[0]={:?}", dst[0]);
+                }
+                if dst.len() < self.size() { return Err!(ProgramError::AccountDataTooSmall; "dst.len()={:?} < self.size()={:?}", dst.len(), self.size()); }
                 dst[0] = Self::ACCOUNT_TAG;
                 Account::pack(acc, &mut dst[1..])
             },
             Self::Contract(acc) => {
-                if dst[0] != Self::CONTRACT_TAG && dst[0] != Self::EMPTY_TAG { return Err(ProgramError::InvalidAccountData); }
-                if dst.len() < self.size() { return Err(ProgramError::AccountDataTooSmall); }
+                if dst[0] != Self::CONTRACT_TAG && dst[0] != Self::EMPTY_TAG { return Err!(ProgramError::InvalidAccountData; "dst[0]={:?}", dst[0]); }
+                if dst.len() < self.size() { return Err!(ProgramError::AccountDataTooSmall; "dst.len()={:?} < self.size()={:?}", dst.len(), self.size()); }
                 dst[0] = Self::CONTRACT_TAG;
                 Contract::pack(acc, &mut dst[1..])
             },
             Self::Storage(acc) => {
-                if dst[0] != Self::STORAGE_TAG && dst[0] != Self::EMPTY_TAG { return Err(ProgramError::InvalidAccountData); }
-                if dst.len() < self.size() { return Err(ProgramError::AccountDataTooSmall); }
+                if dst[0] != Self::STORAGE_TAG && dst[0] != Self::EMPTY_TAG { return Err!(ProgramError::InvalidAccountData; "dst[0]={:?}", dst[0]); }
+                if dst.len() < self.size() { return Err!(ProgramError::AccountDataTooSmall; "dst.len()={:?} < self.size()={:?}", dst.len(), self.size()); }
                 dst[0] = Self::STORAGE_TAG;
                 Storage::pack(acc, &mut dst[1..])
             },
@@ -163,7 +167,7 @@ impl AccountData {
     pub fn get_mut_account(&mut self) -> Result<&mut Account, ProgramError>  {
         match self {
             Self::Account(ref mut acc) => Ok(acc),
-            _ => Err(ProgramError::InvalidAccountData),
+            _ => Err!(ProgramError::InvalidAccountData),
         }
     }
 
@@ -187,7 +191,7 @@ impl AccountData {
     pub fn get_mut_contract(&mut self) -> Result<&mut Contract, ProgramError>  {
         match self {
             Self::Contract(ref mut acc) => Ok(acc),
-            _ => Err(ProgramError::InvalidAccountData),
+            _ => Err!(ProgramError::InvalidAccountData),
         }
     }
 
@@ -211,7 +215,7 @@ impl AccountData {
     pub fn get_mut_storage(&mut self) -> Result<&mut Storage, ProgramError>  {
         match self {
             Self::Storage(ref mut acc) => Ok(acc),
-            _ => Err(ProgramError::InvalidAccountData),
+            _ => Err!(ProgramError::InvalidAccountData),
         }
     }
 }

--- a/evm_loader/program/src/account_storage.rs
+++ b/evm_loader/program/src/account_storage.rs
@@ -85,17 +85,14 @@ impl<'a> ProgramAccountStorage<'a> {
         let construct_contract_account = |account_info: &'a AccountInfo<'a>, token_info: &'a AccountInfo<'a>, code_info: &'a AccountInfo<'a>,| -> Result<SolidityAccount<'a>, ProgramError>
         {
             if account_info.owner != program_id || code_info.owner != program_id {
-                error_print!("Invalid owner for program info/code");
-                return Err(ProgramError::InvalidArgument);
+                return Err!(ProgramError::InvalidArgument; "Invalid owner! account_info.owner={:?}, code_info.owner={:?}, program_id={:?}", account_info.owner, code_info.owner, program_id);
             }
 
             let account_data = AccountData::unpack(&account_info.data.borrow())?;
             let account = account_data.get_account()?;
     
             if *code_info.key != account.code_account {
-                error_print!("code_info.key: {:?}", *code_info.key);
-                error_print!("account.code_account: {:?}", account.code_account);
-                return Err(ProgramError::InvalidAccountData)
+                return Err!(ProgramError::InvalidAccountData; "code_info.key={:?}, account.code_account={:?}", *code_info.key, account.code_account)
             }
     
             let code_data = code_info.data.clone();
@@ -143,10 +140,7 @@ impl<'a> ProgramAccountStorage<'a> {
                 Sender::Ethereum(caller_address)
             } else {
                 if !caller_info.is_signer {
-                    error_print!("Caller must be signer");
-                    error_print!("Caller pubkey: {}", &caller_info.key.to_string());
-
-                    return Err(ProgramError::InvalidArgument);
+                    return Err!(ProgramError::InvalidArgument; "Caller must be signer. Caller pubkey: {} ", &caller_info.key.to_string());
                 }
 
                 Sender::Solana(keccak256_h256(&caller_info.key.to_bytes()).into())
@@ -184,7 +178,7 @@ impl<'a> ProgramAccountStorage<'a> {
         let clock_account = if let Some(clock_acc) = clock_account {
             clock_acc
         } else {
-            return Err(ProgramError::NotEnoughAccountKeys);
+            return Err!(ProgramError::NotEnoughAccountKeys);
         };
 
 
@@ -264,8 +258,7 @@ impl<'a> ProgramAccountStorage<'a> {
                                 continue;
                             }
                         }
-                        error_print!("Apply can't be done. Not found account for address = {:?}.", address);
-                        return Err(ProgramError::NotEnoughAccountKeys);
+                        return Err!(ProgramError::NotEnoughAccountKeys; "Apply can't be done. Not found account for address = {:?}.", address);
                     }
                 },
                 Apply::Delete { address } => {
@@ -276,11 +269,10 @@ impl<'a> ProgramAccountStorage<'a> {
                         let code_info = if let Some(code_info) = code_info {
                             code_info
                         } else {
-                            error_print!("Only contract account could be deleted. account = {:?} -> {:?}.", address, account_info.key);
-                            return Err(ProgramError::InvalidAccountData);
+                            return Err!(ProgramError::InvalidAccountData; "Only contract account could be deleted. account = {:?} -> {:?}.", address, account_info.key);
                         };
 
-                        let caller_account_index = self.find_account(&self.origin()).ok_or(ProgramError::NotEnoughAccountKeys)?;
+                        let caller_account_index = self.find_account(&self.origin()).ok_or_else(||E!(ProgramError::NotEnoughAccountKeys))?;
                         let AccountMeta{ account: caller_info, token: _, code: _ } = &self.account_metas[caller_account_index];
 
                         debug_print!("Move funds from account");
@@ -297,8 +289,7 @@ impl<'a> ProgramAccountStorage<'a> {
                         let mut code_data = code_info.try_borrow_mut_data()?;
                         AccountData::pack(&AccountData::Empty, &mut code_data)?;
                     } else {
-                        error_print!("Apply can't be done. Not found account for address = {:?}.", address);
-                        return Err(ProgramError::NotEnoughAccountKeys);
+                        return Err!(ProgramError::NotEnoughAccountKeys; "Apply can't be done. Not found account for address = {:?}.", address);
                     }
                 }
             }
@@ -320,17 +311,17 @@ impl<'a> ProgramAccountStorage<'a> {
         debug_print!("apply_transfers {:?}", transfers);
 
         for transfer in transfers {
-            let source_account_index = self.find_account(&transfer.source).ok_or(ProgramError::NotEnoughAccountKeys)?;
+            let source_account_index = self.find_account(&transfer.source).ok_or_else(||E!(ProgramError::NotEnoughAccountKeys))?;
             let AccountMeta{ account: source_account, token: source_token_account, code: _ } = &self.account_metas[source_account_index];
             let source_solidity_account = &self.accounts[source_account_index];
             
-            let target_account_index = self.find_account(&transfer.target).ok_or(ProgramError::NotEnoughAccountKeys)?;
+            let target_account_index = self.find_account(&transfer.target).ok_or_else(||E!(ProgramError::NotEnoughAccountKeys))?;
             let AccountMeta{ account: _, token: target_token_account, code: _ } = &self.account_metas[target_account_index];
             
             let min_decimals = u32::from(eth_decimals() - token_mint::decimals());
             let min_value = U256::from(10_u64.pow(min_decimals));
             let value = transfer.value / min_value;
-            let value = u64::try_from(value).map_err(|_| ProgramError::InvalidInstructionData)?;
+            let value = u64::try_from(value).map_err(|s| E!(ProgramError::InvalidInstructionData; "s={:?}", s))?;
 
             debug_print!("Transfer ETH tokens from {} to {} value {}", source_token_account.key, target_token_account.key, value);
 

--- a/evm_loader/program/src/account_storage.rs
+++ b/evm_loader/program/src/account_storage.rs
@@ -85,7 +85,7 @@ impl<'a> ProgramAccountStorage<'a> {
         let construct_contract_account = |account_info: &'a AccountInfo<'a>, token_info: &'a AccountInfo<'a>, code_info: &'a AccountInfo<'a>,| -> Result<SolidityAccount<'a>, ProgramError>
         {
             if account_info.owner != program_id || code_info.owner != program_id {
-                debug_print!("Invalid owner for program info/code");
+                error_print!("Invalid owner for program info/code");
                 return Err(ProgramError::InvalidArgument);
             }
 
@@ -93,8 +93,8 @@ impl<'a> ProgramAccountStorage<'a> {
             let account = account_data.get_account()?;
     
             if *code_info.key != account.code_account {
-                debug_print!("code_info.key: {:?}", *code_info.key);
-                debug_print!("account.code_account: {:?}", account.code_account);
+                error_print!("code_info.key: {:?}", *code_info.key);
+                error_print!("account.code_account: {:?}", account.code_account);
                 return Err(ProgramError::InvalidAccountData)
             }
     
@@ -143,8 +143,8 @@ impl<'a> ProgramAccountStorage<'a> {
                 Sender::Ethereum(caller_address)
             } else {
                 if !caller_info.is_signer {
-                    debug_print!("Caller must be signer");
-                    debug_print!("Caller pubkey: {}", &caller_info.key.to_string());
+                    error_print!("Caller must be signer");
+                    error_print!("Caller pubkey: {}", &caller_info.key.to_string());
 
                     return Err(ProgramError::InvalidArgument);
                 }
@@ -264,7 +264,7 @@ impl<'a> ProgramAccountStorage<'a> {
                                 continue;
                             }
                         }
-                        debug_print!("Apply can't be done. Not found account for address = {:?}.", address);
+                        error_print!("Apply can't be done. Not found account for address = {:?}.", address);
                         return Err(ProgramError::NotEnoughAccountKeys);
                     }
                 },
@@ -276,7 +276,7 @@ impl<'a> ProgramAccountStorage<'a> {
                         let code_info = if let Some(code_info) = code_info {
                             code_info
                         } else {
-                            debug_print!("Only contract account could be deleted. account = {:?} -> {:?}.", address, account_info.key);
+                            error_print!("Only contract account could be deleted. account = {:?} -> {:?}.", address, account_info.key);
                             return Err(ProgramError::InvalidAccountData);
                         };
 
@@ -297,7 +297,7 @@ impl<'a> ProgramAccountStorage<'a> {
                         let mut code_data = code_info.try_borrow_mut_data()?;
                         AccountData::pack(&AccountData::Empty, &mut code_data)?;
                     } else {
-                        debug_print!("Apply can't be done. Not found account for address = {:?}.", address);
+                        error_print!("Apply can't be done. Not found account for address = {:?}.", address);
                         return Err(ProgramError::NotEnoughAccountKeys);
                     }
                 }

--- a/evm_loader/program/src/debug.rs
+++ b/evm_loader/program/src/debug.rs
@@ -13,3 +13,10 @@ macro_rules! debug_print {
 macro_rules! debug_print {
     ($( $args:expr ),*) => {}
 }
+
+macro_rules! error_print {
+    ($( $args:expr ),*) =>  {
+        solana_program::msg!("{}:{}", file!(), line!());
+        solana_program::msg!( $( $args ),* )
+    }
+}

--- a/evm_loader/program/src/debug.rs
+++ b/evm_loader/program/src/debug.rs
@@ -14,9 +14,3 @@ macro_rules! debug_print {
     ($( $args:expr ),*) => {}
 }
 
-macro_rules! error_print {
-    ($( $args:expr ),*) =>  {
-        solana_program::msg!("{}:{}", file!(), line!());
-        solana_program::msg!( $( $args ),* )
-    }
-}

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -122,16 +122,14 @@ fn process_instruction<'a>(
 
             let expected_address = Pubkey::create_program_address(&[ether.as_bytes(), &[nonce]], program_id)?;
             if expected_address != *account_info.key {
-                error_print!("expected_address != *program_info.key");
-                return Err(ProgramError::InvalidArgument);
+                return Err!(ProgramError::InvalidArgument; "expected_address<{:?}> != *account_info.key<{:?}>", expected_address, *account_info.key);
             };
 
             let code_account_key = {
                 let program_code = next_account_info(account_info_iter)?;
                 if program_code.owner == program_id {
                     if !rent.is_exempt(program_code.lamports(), program_code.data_len()) {
-                        error_print!("Code account is not rent exempt");
-                        return Err(ProgramError::InvalidArgument); 
+                        return Err!(ProgramError::InvalidArgument; "Code account is not rent exempt. lamports={:?}, data_len={:?}", program_code.lamports(), program_code.data_len());
                     }
 
                     let contract_data = AccountData::Contract( Contract {owner: *account_info.key, code_size: 0_u32} );
@@ -180,20 +178,20 @@ fn process_instruction<'a>(
             let base_info = next_account_info(account_info_iter)?;
 
             //debug_print!(&("Ether:".to_owned()+&(hex::encode(ether))+" "+&hex::encode([nonce])));
-            if base_info.owner != program_id {return Err(ProgramError::InvalidArgument);}
+            if base_info.owner != program_id {return Err!(ProgramError::InvalidArgument; "base_info.owner<{:?}> != program_id<{:?}>", base_info.owner, program_id);}
             let base_info_data = AccountData::unpack(&base_info.data.borrow())?;
             match base_info_data {
                 AccountData::Account(_) => (),
-                _ => return Err(ProgramError::InvalidAccountData),
+                _ => return Err!(ProgramError::InvalidAccountData),
             };
             let caller = SolidityAccount::new(base_info.key, base_info.lamports(), base_info_data, None);
 
-            let space_as_usize = usize::try_from(space).map_err(|_| ProgramError::InvalidArgument)?;
+            let space_as_usize = usize::try_from(space).map_err(|e| E!(ProgramError::InvalidArgument; "e={:?}", e))?;
             let account_lamports = rent.minimum_balance(space_as_usize) + lamports;
 
             let (caller_ether, caller_nonce) = caller.get_seeds();
             let program_seeds = [caller_ether.as_bytes(), &[caller_nonce]];
-            let seed = std::str::from_utf8(&seed).map_err(|_| ProgramError::InvalidArgument)?;
+            let seed = std::str::from_utf8(&seed).map_err(|e| E!(ProgramError::InvalidArgument; "Utf8Error={:?}", e))?;
             debug_print!("{}", account_lamports);
             debug_print!("{}", space);
             invoke_signed(
@@ -207,7 +205,7 @@ fn process_instruction<'a>(
         EvmInstruction::Write {offset, bytes} => {
             let account_info = next_account_info(account_info_iter)?;
             if account_info.owner != program_id {
-                return Err(ProgramError::InvalidArgument);
+                return Err!(ProgramError::InvalidArgument; "account_info.owner<{:?}> != program_id<{:?}>", account_info.owner, program_id);
             }
 
             do_write(account_info, offset, bytes)
@@ -220,8 +218,7 @@ fn process_instruction<'a>(
             if let Sender::Solana(_addr) = account_storage.get_sender() {
                 // Success execution
             } else {
-                error_print!("This method should used with Solana sender");
-                return Err(ProgramError::InvalidArgument);
+                return Err!(ProgramError::InvalidArgument; "This method should used with Solana sender");
             }
 
             do_call(program_id, &mut account_storage, accounts, bytes.to_vec(), U256::zero(), u64::MAX)
@@ -236,17 +233,17 @@ fn process_instruction<'a>(
             let holder_data = holder_info.data.borrow();
             let (unsigned_msg, signature) = get_transaction_from_data(&holder_data)?;
 
-            let trx: UnsignedTransaction = rlp::decode(unsigned_msg).map_err(|_| ProgramError::InvalidInstructionData)?;
+            let trx: UnsignedTransaction = rlp::decode(unsigned_msg).map_err(|e| E!(ProgramError::InvalidInstructionData; "DecoderError={:?}", e))?;
 
             let account_storage = ProgramAccountStorage::new(program_id, &accounts[1..])?;
-            let from_addr = verify_tx_signature(signature, unsigned_msg).map_err(|_| ProgramError::MissingRequiredSignature)?;
+            let from_addr = verify_tx_signature(signature, unsigned_msg).map_err(|e| E!(ProgramError::MissingRequiredSignature; "Error={:?}", e))?;
             check_ethereum_authority(
-                account_storage.get_caller_account().ok_or(ProgramError::InvalidArgument)?,
+                account_storage.get_caller_account().ok_or_else(||E!(ProgramError::InvalidArgument))?,
                 &from_addr, trx.nonce, &trx.chain_id)?;
 
             let mut storage = StorageAccount::new(storage_info, accounts, from_addr, trx.nonce)?;
 
-            let trx_gas_limit = u64::try_from(trx.gas_limit).map_err(|_| ProgramError::InvalidInstructionData)?;
+            let trx_gas_limit = u64::try_from(trx.gas_limit).map_err(|s| E!(ProgramError::InvalidInstructionData; "s={:?}", s))?;
             if trx.to.is_some() {
                 do_partial_call(&mut storage, step_count, &account_storage, accounts, trx.call_data, trx.value, trx_gas_limit)?;
             }
@@ -260,15 +257,15 @@ fn process_instruction<'a>(
         EvmInstruction::CallFromRawEthereumTX  {from_addr, sign: _, unsigned_msg} => {
             let sysvar_info = find_sysvar_info(accounts)?;
 
-            let trx: UnsignedTransaction = rlp::decode(unsigned_msg).map_err(|_| ProgramError::InvalidInstructionData)?;
+            let trx: UnsignedTransaction = rlp::decode(unsigned_msg).map_err(|e| E!(ProgramError::InvalidInstructionData; "DecoderError={:?}", e))?;
             let mut account_storage = ProgramAccountStorage::new(program_id, accounts)?;
 
             check_secp256k1_instruction(sysvar_info, unsigned_msg.len(), 1_u16)?;
             check_ethereum_authority(
-                account_storage.get_caller_account().ok_or(ProgramError::InvalidArgument)?,
+                account_storage.get_caller_account().ok_or_else(||E!(ProgramError::InvalidArgument))?,
                 &H160::from_slice(from_addr), trx.nonce, &trx.chain_id)?;
 
-            let trx_gas_limit = u64::try_from(trx.gas_limit).map_err(|_| ProgramError::InvalidInstructionData)?;
+            let trx_gas_limit = u64::try_from(trx.gas_limit).map_err(|s| E!(ProgramError::InvalidInstructionData; "s={:?}", s))?;
             do_call(program_id, &mut account_storage, accounts, trx.call_data, trx.value, trx_gas_limit)
         },
         EvmInstruction::OnReturn {status: _, bytes: _} => {
@@ -282,17 +279,17 @@ fn process_instruction<'a>(
             let sysvar_info = find_sysvar_info(accounts)?;
 
             let caller = H160::from_slice(from_addr);
-            let trx: UnsignedTransaction = rlp::decode(unsigned_msg).map_err(|_| ProgramError::InvalidInstructionData)?;
+            let trx: UnsignedTransaction = rlp::decode(unsigned_msg).map_err(|e| E!(ProgramError::InvalidInstructionData; "DecoderError={:?}", e))?;
 
             let mut storage = StorageAccount::new(storage_info, accounts, caller, trx.nonce)?;
             let account_storage = ProgramAccountStorage::new(program_id, &accounts[1..])?;
 
             check_secp256k1_instruction(sysvar_info, unsigned_msg.len(), 9_u16)?;
             check_ethereum_authority(
-                account_storage.get_caller_account().ok_or(ProgramError::InvalidArgument)?,
+                account_storage.get_caller_account().ok_or_else(||E!(ProgramError::InvalidArgument))?,
                 &caller, trx.nonce, &trx.chain_id)?;
 
-            let trx_gas_limit = u64::try_from(trx.gas_limit).map_err(|_| ProgramError::InvalidInstructionData)?;
+            let trx_gas_limit = u64::try_from(trx.gas_limit).map_err(|s| E!(ProgramError::InvalidInstructionData; "s={:?}", s))?;
             do_partial_call(&mut storage, step_count, &account_storage, &accounts[1..], trx.call_data, trx.value, trx_gas_limit)?;
 
             storage.block_accounts(program_id, accounts)
@@ -333,14 +330,14 @@ fn process_instruction<'a>(
                     AccountData::Account(ref mut acc) => {
                         let (caller, nonce) = storage.caller_and_nonce()?;
                         if acc.ether != caller {
-                            return Err(ProgramError::InvalidAccountData);
+                            return Err!(ProgramError::InvalidAccountData; "acc.ether<{:?}> != caller<{:?}>", acc.ether, caller);
                         }
                         if acc.trx_count != nonce {
-                            return Err(ProgramError::InvalidAccountData);
+                            return Err!(ProgramError::InvalidAccountData; "acc.trx_count<{:?}> != nonce<{:?}>", acc.trx_count, nonce);
                         }
                         acc.trx_count += 1;
                     },
-                    _ => return Err(ProgramError::InvalidAccountData),
+                    _ => return Err!(ProgramError::InvalidAccountData),
                 };
                 caller_info_data.pack(&mut caller_info.data.borrow_mut())?;
             }
@@ -362,14 +359,14 @@ fn get_transaction_from_data(
     let account_info_data = AccountData::unpack(data)?;
     match account_info_data {
         AccountData::Empty => (),
-            _ => return Err(ProgramError::InvalidAccountData),
+            _ => return Err!(ProgramError::InvalidAccountData),
     };
 
     let (_header, rest) = data.split_at(account_info_data.size());
     let (signature, rest) = rest.split_at(65);
     let (trx_len, rest) = rest.split_at(8);
     let trx_len = trx_len.try_into().ok().map(u64::from_le_bytes).unwrap();
-    let trx_len = usize::try_from(trx_len).map_err(|_| ProgramError::InvalidInstructionData)?;
+    let trx_len = usize::try_from(trx_len).map_err(|e| E!(ProgramError::InvalidInstructionData; "e={:?}", e))?;
     let (trx, _rest) = rest.split_at(trx_len as usize);
 
     Ok((trx, signature))
@@ -381,18 +378,17 @@ fn do_write(account_info: &AccountInfo, offset: u32, bytes: &[u8]) -> ProgramRes
     let account_data = AccountData::unpack(&data)?;
     match account_data {
         AccountData::Account(_) | AccountData::Storage(_) => {
-            return Err(ProgramError::InvalidAccountData);
+            return Err!(ProgramError::InvalidAccountData);
         },
         AccountData::Contract(acc) if acc.code_size != 0 => {
-            return Err(ProgramError::InvalidAccountData);
+            return Err!(ProgramError::InvalidAccountData);
         },
         AccountData::Contract(_) | AccountData::Empty => { },
     };
 
     let offset = account_data.size() + offset as usize;
     if data.len() < offset + bytes.len() {
-        error_print!("Account data too small");
-        return Err(ProgramError::AccountDataTooSmall);
+        return Err!(ProgramError::AccountDataTooSmall; "Account data too small data.len()={:?}, offset={:?}, bytes.len()={:?}", data.len(), offset, bytes.len());
     }
     data[offset .. offset+bytes.len()].copy_from_slice(bytes);
     Ok(())
@@ -416,13 +412,13 @@ fn do_finalize<'a>(program_id: &Pubkey, accounts: &'a [AccountInfo<'a>]) -> Prog
             let contract_info_data = AccountData::unpack(&data)?;
             match contract_info_data {
                 AccountData::Contract (..) => (),
-                _ => return Err(ProgramError::InvalidAccountData),
+                _ => return Err!(ProgramError::InvalidAccountData),
             };
 
             let (_contract_header, rest) = data.split_at(contract_info_data.size());
             let (code_len, rest) = rest.split_at(8);
             let code_len = code_len.try_into().ok().map(u64::from_le_bytes).unwrap();
-            let code_len = usize::try_from(code_len).map_err(|_| ProgramError::InvalidInstructionData)?;
+            let code_len = usize::try_from(code_len).map_err(|e| E!(ProgramError::InvalidInstructionData; "e={:?}", e))?;
             let (code, _rest) = rest.split_at(code_len);
             code.to_vec()
         };
@@ -549,7 +545,7 @@ fn do_partial_call<'a>(
         gas_limit,
     )?;
 
-    executor.execute_n_steps(step_count).map_err(|_| ProgramError::InvalidInstructionData)?;
+    executor.execute_n_steps(step_count).map_err(|e| E!(ProgramError::InvalidInstructionData; "e={:?}", e))?;
 
     debug_print!("save");
     executor.save_into(storage);
@@ -708,21 +704,15 @@ fn check_ethereum_authority<'a>(
 ) -> ProgramResult
 {
     if sender.get_ether() != *recovered_address {
-        error_print!("Invalid sender: actual {}, recovered {}",
-                sender.get_ether(), recovered_address);
-        return Err(ProgramError::InvalidArgument);
+        return Err!(ProgramError::InvalidArgument; "Invalid sender: actual {}, recovered {}", sender.get_ether(), recovered_address);
     }
 
     if sender.get_nonce() != trx_nonce {
-        error_print!("Invalid Ethereum transaction nonce: acc {}, trx {}",
-                sender.get_nonce(), trx_nonce);
-        return Err(ProgramError::InvalidArgument);
+        return Err!(ProgramError::InvalidArgument; "Invalid Ethereum transaction nonce: acc {}, trx {}", sender.get_nonce(), trx_nonce);
     }
 
     if SolanaBackend::<ProgramAccountStorage>::chain_id() != *chain_id {
-        error_print!("Invalid chain_id: actual {}, expected {}",
-                chain_id, SolanaBackend::<ProgramAccountStorage>::chain_id());
-        return Err(ProgramError::InvalidArgument);
+        return Err!(ProgramError::InvalidArgument; "Invalid chain_id: actual {}, expected {}", chain_id, SolanaBackend::<ProgramAccountStorage>::chain_id());
     }
 
     Ok(())
@@ -752,7 +742,7 @@ mod tests {
         let mut bad_utf8 = bytes;
         bad_utf8[3] = 0xFF; // Invalid UTF-8 byte
         assert_eq!(
-            Err(ProgramError::InvalidInstructionData),
+            Err!(ProgramError::InvalidInstructionData),
             process_instruction(&program_id, &[], &bad_utf8)
         );
     }

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -130,7 +130,7 @@ fn process_instruction<'a>(
                 let program_code = next_account_info(account_info_iter)?;
                 if program_code.owner == program_id {
                     if !rent.is_exempt(program_code.lamports(), program_code.data_len()) {
-                        debug_print!("Code account is not rent exempt");
+                        error_print!("Code account is not rent exempt");
                         return Err(ProgramError::InvalidArgument); 
                     }
 

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -117,7 +117,7 @@ fn process_instruction<'a>(
 
             let expected_address = Pubkey::create_program_address(&[ether.as_bytes(), &[nonce]], program_id)?;
             if expected_address != *account_info.key {
-                debug_print!("expected_address != *program_info.key");
+                error_print!("expected_address != *program_info.key");
                 return Err(ProgramError::InvalidArgument);
             };
 
@@ -202,7 +202,7 @@ fn process_instruction<'a>(
             if let Sender::Solana(_addr) = account_storage.get_sender() {
                 // Success execution
             } else {
-                debug_print!("This method should used with Solana sender");
+                error_print!("This method should used with Solana sender");
                 return Err(ProgramError::InvalidArgument);
             }
 
@@ -373,7 +373,7 @@ fn do_write(account_info: &AccountInfo, offset: u32, bytes: &[u8]) -> ProgramRes
 
     let offset = account_data.size() + offset as usize;
     if data.len() < offset + bytes.len() {
-        debug_print!("Account data too small");
+        error_print!("Account data too small");
         return Err(ProgramError::AccountDataTooSmall);
     }
     data[offset .. offset+bytes.len()].copy_from_slice(bytes);
@@ -690,19 +690,19 @@ fn check_ethereum_authority<'a>(
 ) -> ProgramResult
 {
     if sender.get_ether() != *recovered_address {
-        debug_print!("Invalid sender: actual {}, recovered {}",
+        error_print!("Invalid sender: actual {}, recovered {}",
                 sender.get_ether(), recovered_address);
         return Err(ProgramError::InvalidArgument);
     }
 
     if sender.get_nonce() != trx_nonce {
-        debug_print!("Invalid Ethereum transaction nonce: acc {}, trx {}",
+        error_print!("Invalid Ethereum transaction nonce: acc {}, trx {}",
                 sender.get_nonce(), trx_nonce);
         return Err(ProgramError::InvalidArgument);
     }
 
     if SolanaBackend::<ProgramAccountStorage>::chain_id() != *chain_id {
-        debug_print!("Invalid chain_id: actual {}, expected {}",
+        error_print!("Invalid chain_id: actual {}, expected {}",
                 chain_id, SolanaBackend::<ProgramAccountStorage>::chain_id());
         return Err(ProgramError::InvalidArgument);
     }

--- a/evm_loader/program/src/error.rs
+++ b/evm_loader/program/src/error.rs
@@ -27,3 +27,33 @@ impl<T> DecodeError<T> for EvmLoaderError {
         "EVMLoaderError"
     }
 }
+
+pub fn err_fn_without_info<T:>(err: ProgramError, fl: &str, ln: u32) -> Result<T, ProgramError> {
+    solana_program::msg!("{:?}:{:?}", fl, ln);
+    Err(err)
+}
+
+pub fn err_fn<T:>(err: ProgramError, fl: &str, ln: u32, info: &str) -> Result<T, ProgramError> {
+    solana_program::msg!("{:?}:{:?} : {}", fl, ln, info);
+    Err(err)
+}
+
+macro_rules! Err {
+    ( $n:expr; $($args:expr),* ) => ( crate::error::err_fn($n, file!(), line!(), &format!($($args),*)) );
+    ( $n:expr ) => ( crate::error::err_fn_without_info($n, file!(), line!()) )
+}
+
+pub fn e_fn_without_info(e: ProgramError, fl: &str, ln: u32) -> ProgramError {
+    solana_program::msg!("{:?}:{:?}", fl, ln);
+    e
+}
+
+pub fn e_fn(e: ProgramError, fl: &str, ln: u32, info: &str) -> ProgramError {
+    solana_program::msg!("{:?}:{:?} : {}", fl, ln, info);
+    e
+}
+
+macro_rules! E {
+    ( $n:expr; $($args:expr),* ) => ( crate::error::e_fn($n, file!(), line!(), &format!($($args),*)) );
+    ( $n:expr ) => ( crate::error::e_fn_without_info($n, file!(), line!()) )
+}

--- a/evm_loader/program/src/error.rs
+++ b/evm_loader/program/src/error.rs
@@ -29,12 +29,12 @@ impl<T> DecodeError<T> for EvmLoaderError {
 }
 
 pub fn err_fn_without_info<T:>(err: ProgramError, fl: &str, ln: u32) -> Result<T, ProgramError> {
-    solana_program::msg!("{:?}:{:?}", fl, ln);
+    solana_program::msg!("{}:{:?}", fl, ln);
     Err(err)
 }
 
 pub fn err_fn<T:>(err: ProgramError, fl: &str, ln: u32, info: &str) -> Result<T, ProgramError> {
-    solana_program::msg!("{:?}:{:?} : {}", fl, ln, info);
+    solana_program::msg!("{}:{:?} : {}", fl, ln, info);
     Err(err)
 }
 
@@ -44,12 +44,12 @@ macro_rules! Err {
 }
 
 pub fn e_fn_without_info(e: ProgramError, fl: &str, ln: u32) -> ProgramError {
-    solana_program::msg!("{:?}:{:?}", fl, ln);
+    solana_program::msg!("{}:{:?}", fl, ln);
     e
 }
 
 pub fn e_fn(e: ProgramError, fl: &str, ln: u32, info: &str) -> ProgramError {
-    solana_program::msg!("{:?}:{:?} : {}", fl, ln, info);
+    solana_program::msg!("{}:{:?} : {}", fl, ln, info);
     e
 }
 

--- a/evm_loader/program/src/error.rs
+++ b/evm_loader/program/src/error.rs
@@ -28,31 +28,57 @@ impl<T> DecodeError<T> for EvmLoaderError {
     }
 }
 
+/// Function for macro Err! to log an err.
 pub fn err_fn_without_info<T:>(err: ProgramError, fl: &str, ln: u32) -> Result<T, ProgramError> {
     solana_program::msg!("{}:{:?}", fl, ln);
     Err(err)
 }
 
+/// Function for macro Err! to log an err and add additional info.
 pub fn err_fn<T:>(err: ProgramError, fl: &str, ln: u32, info: &str) -> Result<T, ProgramError> {
     solana_program::msg!("{}:{:?} : {}", fl, ln, info);
     Err(err)
 }
 
+/// Macro to log a ProgramError in the current transaction log
+/// with the source file position like: file.rc:42
+/// and additional info if needed
+/// See https://github.com/neonlabsorg/neon-evm/issues/159
+///
+/// # Examples
+///
+/// ```
+/// #    map_err(|s| E!(ProgramError::InvalidArgument; "s={:?}", s))
+/// ```
+///
 macro_rules! Err {
     ( $n:expr; $($args:expr),* ) => ( crate::error::err_fn($n, file!(), line!(), &format!($($args),*)) );
     ( $n:expr ) => ( crate::error::err_fn_without_info($n, file!(), line!()) )
 }
 
+/// Function for macro E! to log an err.
 pub fn e_fn_without_info(e: ProgramError, fl: &str, ln: u32) -> ProgramError {
     solana_program::msg!("{}:{:?}", fl, ln);
     e
 }
 
+/// Function for macro E! to log an err and add additional info.
 pub fn e_fn(e: ProgramError, fl: &str, ln: u32, info: &str) -> ProgramError {
     solana_program::msg!("{}:{:?} : {}", fl, ln, info);
     e
 }
 
+/// Macro to log a ProgramError in the current transaction log.
+/// with the source file position like: file.rc:777
+/// and additional info if needed
+/// See https://github.com/neonlabsorg/neon-evm/issues/159
+///
+/// # Examples
+///
+/// ```
+/// #    return Err!(ProgramError::InvalidArgument; "Caller pubkey: {} ", &caller_info.key.to_string());
+/// ```
+///
 macro_rules! E {
     ( $n:expr; $($args:expr),* ) => ( crate::error::e_fn($n, file!(), line!(), &format!($($args),*)) );
     ( $n:expr ) => ( crate::error::e_fn_without_info($n, file!(), line!()) )

--- a/evm_loader/program/src/error.rs
+++ b/evm_loader/program/src/error.rs
@@ -48,7 +48,7 @@ pub fn err_fn<T:>(err: ProgramError, fl: &str, ln: u32, info: &str) -> Result<T,
 /// # Examples
 ///
 /// ```
-/// #    map_err(|s| E!(ProgramError::InvalidArgument; "s={:?}", s))
+/// #    return Err!(ProgramError::InvalidArgument; "Caller pubkey: {} ", &caller_info.key.to_string());
 /// ```
 ///
 macro_rules! Err {
@@ -76,7 +76,7 @@ pub fn e_fn(e: ProgramError, fl: &str, ln: u32, info: &str) -> ProgramError {
 /// # Examples
 ///
 /// ```
-/// #    return Err!(ProgramError::InvalidArgument; "Caller pubkey: {} ", &caller_info.key.to_string());
+/// #    map_err(|s| E!(ProgramError::InvalidArgument; "s={:?}", s))
 /// ```
 ///
 macro_rules! E {

--- a/evm_loader/program/src/executor.rs
+++ b/evm_loader/program/src/executor.rs
@@ -391,13 +391,13 @@ impl<'config, B: Backend> Machine<'config, B> {
 
         let transaction_cost = gasometer::call_transaction_cost(&input);
         self.executor.state.metadata_mut().gasometer_mut().record_transaction(transaction_cost)
-            .map_err(|_| ProgramError::InvalidInstructionData)?;
+            .map_err(|e| E!(ProgramError::InvalidInstructionData; "Error={:?}", e))?;
 
         let after_gas = self.executor.state.metadata().gasometer().gas();
         let gas_limit = core::cmp::min(gas_limit, after_gas);
 
         self.executor.state.metadata_mut().gasometer_mut().record_cost(gas_limit)
-            .map_err(|_| ProgramError::InvalidInstructionData)?;
+            .map_err(|e| E!(ProgramError::InvalidInstructionData; "Error={:?}", e))?;
 
 
         self.executor.state.inc_nonce(caller);
@@ -406,7 +406,7 @@ impl<'config, B: Backend> Machine<'config, B> {
         self.executor.state.touch(code_address);
 
         let transfer = evm::Transfer { source: caller, target: code_address, value: transfer_value };
-        self.executor.state.transfer(&transfer).map_err(|_| ProgramError::InsufficientFunds)?;
+        self.executor.state.transfer(&transfer).map_err(|e| E!(ProgramError::InsufficientFunds; "ExitError={:?}", e))?;
 
         let code = self.executor.code(code_address);
         let valids = self.executor.valids(code_address);
@@ -429,14 +429,13 @@ impl<'config, B: Backend> Machine<'config, B> {
         let transaction_cost = gasometer::create_transaction_cost(&code);
         self.executor.state.metadata_mut().gasometer_mut()
             .record_transaction(transaction_cost)
-            .map_err(|_| ProgramError::InvalidInstructionData)?;
+            .map_err(|e| E!(ProgramError::InvalidInstructionData; "ExitError={:?}", e))?;
 
         let scheme = evm::CreateScheme::Legacy { caller };
 
         match self.executor.create(caller, scheme, transfer_value, code, Some(gas_limit)) {
-            Capture::Exit(_) => {
-                error_print!("create_begin() error ");
-                return Err(ProgramError::InvalidInstructionData);
+            Capture::Exit(e) => {
+                return Err!(ProgramError::InvalidInstructionData; "create_begin() error={:?} ", e);
             },
             Capture::Trap(info) => {
                 self.executor.state.enter(info.gas_limit, false);
@@ -448,7 +447,7 @@ impl<'config, B: Backend> Machine<'config, B> {
                 }
 
                 if let Some(transfer) = info.transfer {
-                    self.executor.state.transfer(&transfer).map_err(|_| ProgramError::InsufficientFunds)?;
+                    self.executor.state.transfer(&transfer).map_err(|e| E!(ProgramError::InsufficientFunds; "ExitError={:?}", e))?;
                 }
 
                 let valids = Valids::compute(&info.init_code);

--- a/evm_loader/program/src/executor.rs
+++ b/evm_loader/program/src/executor.rs
@@ -435,7 +435,7 @@ impl<'config, B: Backend> Machine<'config, B> {
 
         match self.executor.create(caller, scheme, transfer_value, code, Some(gas_limit)) {
             Capture::Exit(_) => {
-                debug_print!("create_begin() error ");
+                error_print!("create_begin() error ");
                 return Err(ProgramError::InvalidInstructionData);
             },
             Capture::Trap(info) => {

--- a/evm_loader/program/src/hamt.rs
+++ b/evm_loader/program/src/hamt.rs
@@ -40,7 +40,7 @@ impl<'a> Hamt<'a> {
         let header_len = size_of::<u32>() * 32 * 2;
 
         if data.len() < header_len {
-            return Err(ProgramError::AccountDataTooSmall);
+            return Err!(ProgramError::AccountDataTooSmall; "data.len()={:?} < header_len={:?}", data.len(), header_len);
         }
 
         if reset {
@@ -52,7 +52,7 @@ impl<'a> Hamt<'a> {
             let last_used_ptr = array_mut_ref![data, 0, 4];
             let last_used = u32::from_le_bytes(*last_used_ptr);
             if last_used < header_len as u32 {
-                return Err(ProgramError::InvalidAccountData);
+                return Err!(ProgramError::InvalidAccountData; "last_used={:?} < header_len={:?}", last_used, header_len);
             }
             Ok(Hamt {data, last_used, used: 0, item_count: 0})
         }
@@ -74,7 +74,7 @@ impl<'a> Hamt<'a> {
             }
         }
         if (self.last_used + size) as usize > self.data.len() {
-            return Err(ProgramError::AccountDataTooSmall);
+            return Err!(ProgramError::AccountDataTooSmall; "(self.last_used + size)={:?} > self.data.len()={:?}; size={:?}", (self.last_used + size), self.data.len(), size);
         }
         let item_pos = self.last_used;
         self.last_used += size;

--- a/evm_loader/program/src/lib.rs
+++ b/evm_loader/program/src/lib.rs
@@ -7,6 +7,7 @@
 //! An ERC20-like Token program for the Solana blockchain
 #[macro_use]
 mod debug;
+#[macro_use]
 mod error;
 pub mod entrypoint;
 mod hamt;

--- a/evm_loader/program/src/solidity_account.rs
+++ b/evm_loader/program/src/solidity_account.rs
@@ -256,7 +256,7 @@ impl<'a> SolidityAccount<'a> {
                 debug_print!("Valids written");
             }
             else {
-                debug_print!("Expected code account");
+                error_print!("Expected code account");
                 return Err(ProgramError::NotEnoughAccountKeys);
             }
         }
@@ -284,7 +284,7 @@ impl<'a> SolidityAccount<'a> {
                 }
             }
             else {
-                debug_print!("Expected code account");
+                error_print!("Expected code account");
                 return Err(ProgramError::NotEnoughAccountKeys);
             }
         }

--- a/evm_loader/program/src/solidity_account.rs
+++ b/evm_loader/program/src/solidity_account.rs
@@ -116,9 +116,9 @@ impl<'a> SolidityAccount<'a> {
                 return Ok(f(&mut hamt));
             }
         }
-        Err(ProgramError::UninitializedAccount)*/
+        Err!(ProgramError::UninitializedAccount)*/
         if self.code_data.is_none() {
-            return Err(ProgramError::UninitializedAccount)
+            return Err!(ProgramError::UninitializedAccount)
         }
 
         let contract_data = &self.code_data.as_ref().unwrap().0;
@@ -132,7 +132,7 @@ impl<'a> SolidityAccount<'a> {
             let mut hamt = Hamt::new(&mut data[contract_data.size()+code_size+valids_size..], false)?;
             Ok(f(&mut hamt))
         } else {
-            Err(ProgramError::UninitializedAccount)
+            Err!(ProgramError::UninitializedAccount)
         }
     }
 
@@ -227,7 +227,7 @@ impl<'a> SolidityAccount<'a> {
             AccountData::Foreign => 0,
             AccountData::Account{code_size, ..} => code_size as usize,
         };*/
-        let nonce = u64::try_from(nonce).map_err(|_| ProgramError::InvalidArgument)?;
+        let nonce = u64::try_from(nonce).map_err(|s| E!(ProgramError::InvalidArgument; "s={:?}", s))?;
         AccountData::get_mut_account(&mut self.account_data)?.trx_count = nonce;
 
         if let Some((code, valids)) = code_and_valids {
@@ -237,9 +237,9 @@ impl<'a> SolidityAccount<'a> {
                 let contract = AccountData::get_mut_contract(contract_data)?;
     
                 if contract.code_size != 0 {
-                    return Err(ProgramError::AccountAlreadyInitialized);
+                    return Err!(ProgramError::AccountAlreadyInitialized; "contract.code_size={:?}", contract.code_size);
                 };
-                contract.code_size = code.len().try_into().map_err(|_| ProgramError::AccountDataTooSmall)?;
+                contract.code_size = code.len().try_into().map_err(|e| E!(ProgramError::AccountDataTooSmall; "TryFromIntError={:?}", e))?;
     
                 debug_print!("Write contract header");
                 contract_data.pack(&mut code_data)?;
@@ -256,8 +256,7 @@ impl<'a> SolidityAccount<'a> {
                 debug_print!("Valids written");
             }
             else {
-                error_print!("Expected code account");
-                return Err(ProgramError::NotEnoughAccountKeys);
+                return Err!(ProgramError::NotEnoughAccountKeys; "Expected code account");
             }
         }
 
@@ -272,7 +271,7 @@ impl<'a> SolidityAccount<'a> {
                 let mut code_data = code_data.borrow_mut();
     
                 let contract = AccountData::get_contract(contract_data)?;
-                if contract.code_size == 0 {return Err(ProgramError::UninitializedAccount);};
+                if contract.code_size == 0 {return Err!(ProgramError::UninitializedAccount; "contract.code_size={:?}", contract.code_size);};
                 let code_size = contract.code_size as usize;
                 let valids_size = (code_size / 8) + 1;
     
@@ -284,8 +283,7 @@ impl<'a> SolidityAccount<'a> {
                 }
             }
             else {
-                error_print!("Expected code account");
-                return Err(ProgramError::NotEnoughAccountKeys);
+                return Err!(ProgramError::NotEnoughAccountKeys; "Expected code account");
             }
         }
 

--- a/evm_loader/program/src/storage_account.rs
+++ b/evm_loader/program/src/storage_account.rs
@@ -25,8 +25,7 @@ impl<'a> StorageAccount<'a> {
             );
             Ok(Self { info, data })
         } else {
-            error_print!("storage account is not empty");
-            Err(ProgramError::InvalidAccountData)
+            Err!(ProgramError::InvalidAccountData; "storage account is not empty. account_data.len()={:?}", &account_data.len())
         }
     }
 
@@ -37,7 +36,7 @@ impl<'a> StorageAccount<'a> {
             let data = AccountData::Storage(data);
             Ok(Self { info, data })
         } else {
-            Err(ProgramError::InvalidAccountData)
+            Err!(ProgramError::InvalidAccountData)
         }
     }
 
@@ -66,7 +65,7 @@ impl<'a> StorageAccount<'a> {
 
         let account_data = self.info.try_borrow_data()?;
         if account_data.len() < end {
-            return Err(ProgramError::AccountDataTooSmall);
+            return Err!(ProgramError::AccountDataTooSmall; "account_data.len()={:?} < end={:?}", account_data.len(), end);
         }
 
         let keys_storage = &account_data[begin..end];
@@ -80,19 +79,19 @@ impl<'a> StorageAccount<'a> {
         let storage = AccountData::get_storage(&self.data)?;
         
         if storage.accounts_len != accounts.len() {
-            return Err(ProgramError::NotEnoughAccountKeys);
+            return Err!(ProgramError::NotEnoughAccountKeys; "storage.accounts_len={:?} != accounts.len()={:?}", storage.accounts_len, accounts.len());
         }
 
         let keys = accounts.iter().map(|a| *a.unsigned_key());
         if !self.accounts()?.into_iter().eq(keys) {
-            return Err(ProgramError::NotEnoughAccountKeys);
+            return Err!(ProgramError::NotEnoughAccountKeys);
         }
 
         for account_info in accounts.iter().filter(|a| a.owner == program_id) {
             let data = account_info.try_borrow_data()?;
             if let AccountData::Account(account) = AccountData::unpack(&data)? {
                 if Some(self.info.unsigned_key()) != account.blocked.as_ref() {
-                    return Err(ProgramError::NotEnoughAccountKeys);
+                    return Err!(ProgramError::NotEnoughAccountKeys);
                 }
             }
         }
@@ -104,14 +103,14 @@ impl<'a> StorageAccount<'a> {
         {
             let storage = AccountData::get_storage(&self.data)?;
             if storage.accounts_len != accounts.len() {
-                return Err(ProgramError::InvalidInstructionData);
+                return Err!(ProgramError::InvalidInstructionData; "storage.accounts_len={:?} != accounts.len()={:?}", storage.accounts_len, accounts.len());
             }
 
             let (begin, end) = self.accounts_region()?;
 
             let mut account_data = self.info.try_borrow_mut_data()?;
             if account_data.len() < end {
-                return Err(ProgramError::AccountDataTooSmall);
+                return Err!(ProgramError::AccountDataTooSmall; "account_data.len()={:?} < end={:?}", account_data.len(), end);
             }
 
             let keys_storage = &mut account_data[begin..end];
@@ -139,29 +138,29 @@ impl<'a> StorageAccount<'a> {
         {
             let storage = AccountData::get_mut_storage(&mut self.data)?;
             storage.evm_data_size = bincode::serialized_size(&evm_data)
-                .map_err(|_| ProgramError::InvalidInstructionData)?
+                .map_err(|e| E!(ProgramError::InvalidInstructionData; "Error={:?}", e))?
                 .try_into()
-                .map_err(|_| ProgramError::InvalidInstructionData)?;
+                .map_err(|e| E!(ProgramError::InvalidInstructionData; "TryFromIntError={:?}", e))?;
             storage.executor_data_size = bincode::serialized_size(&executor_data)
-                .map_err(|_| ProgramError::InvalidInstructionData)?
+                .map_err(|e| E!(ProgramError::InvalidInstructionData; "Error={:?}", e))?
                 .try_into()
-                .map_err(|_| ProgramError::InvalidInstructionData)?;
+                .map_err(|e| E!(ProgramError::InvalidInstructionData; "TryFromIntError={:?}", e))?;
         }
         
         let mut account_data = self.info.try_borrow_mut_data()?;
         {
             let (start, mid, end) = self.storage_region()?;
             if account_data.len() < end {
-                return Err(ProgramError::AccountDataTooSmall);
+                return Err!(ProgramError::AccountDataTooSmall; "account_data.len()={:?} < end={:?}", account_data.len(), end);
             }
 
             {
                 let buffer = &mut account_data[start..mid];
-                bincode::serialize_into(buffer, &evm_data).map_err(|_| ProgramError::InvalidInstructionData)?;
+                bincode::serialize_into(buffer, &evm_data).map_err(|e| E!(ProgramError::InvalidInstructionData; "Error={:?}", e))?;
             }
             {
                 let buffer = &mut account_data[mid..end];
-                bincode::serialize_into(buffer, &executor_data).map_err(|_| ProgramError::InvalidInstructionData)?;
+                bincode::serialize_into(buffer, &executor_data).map_err(|e| E!(ProgramError::InvalidInstructionData; "Error={:?}", e))?;
             }
         }
 
@@ -175,16 +174,16 @@ impl<'a> StorageAccount<'a> {
 
         let (start, mid, end) = self.storage_region()?;
         if account_data.len() < end {
-            return Err(ProgramError::AccountDataTooSmall);
+            return Err!(ProgramError::AccountDataTooSmall; "account_data.len()={:?}", account_data.len());
         }
 
         let evm_data: T = {
             let buffer = &account_data[start..mid];
-            bincode::deserialize_from(buffer).map_err(|_| ProgramError::InvalidInstructionData)?
+            bincode::deserialize_from(buffer).map_err(|e| E!(ProgramError::InvalidInstructionData; "Error={:?}", e))?
         };
         let executor_data: E = {
             let buffer = &account_data[mid..end];
-            bincode::deserialize_from(buffer).map_err(|_| ProgramError::InvalidInstructionData)?
+            bincode::deserialize_from(buffer).map_err(|e| E!(ProgramError::InvalidInstructionData; "Error={:?}", e))?
         };
 
         Ok((evm_data, executor_data))

--- a/evm_loader/program/src/storage_account.rs
+++ b/evm_loader/program/src/storage_account.rs
@@ -25,7 +25,7 @@ impl<'a> StorageAccount<'a> {
             );
             Ok(Self { info, data })
         } else {
-            debug_print!("storage account is not empty");
+            error_print!("storage account is not empty");
             Err(ProgramError::InvalidAccountData)
         }
     }

--- a/evm_loader/program/src/token.rs
+++ b/evm_loader/program/src/token.rs
@@ -55,7 +55,7 @@ pub fn create_associated_token_account(
 /// `ProgramError::IncorrectProgramId` if account is not token account
 pub fn get_token_account_balance(account: &AccountInfo) -> Result<u64, ProgramError> {
     if *account.owner != spl_token::id() {
-        return Err(ProgramError::IncorrectProgramId);
+        return Err!(ProgramError::IncorrectProgramId; "*account.owner<{:?}> != spl_token::id()<{:?}>", *account.owner,  spl_token::id());
     }
 
     let data = spl_token::state::Account::unpack(&account.data.borrow())?;
@@ -72,16 +72,14 @@ pub fn get_token_account_balance(account: &AccountInfo) -> Result<u64, ProgramEr
 pub fn check_token_account(token: &AccountInfo, account: &AccountInfo) -> Result<(), ProgramError> {
     debug_print!("check_token_account");
     if *token.owner != spl_token::id() {
-        error_print!("token.owner != spl_token::id() {}", token.owner);
-        return Err(ProgramError::IncorrectProgramId);
+        return Err!(ProgramError::IncorrectProgramId; "token.owner != spl_token::id() {}", token.owner);
     }
 
     let data = account.try_borrow_data()?;
     let data = AccountData::unpack(&data)?;
     let data = data.get_account()?;
     if data.eth_token_account != *token.key {
-        error_print!("data.eth_token_account != *token.key data.eth = {} token.key = {}", data.eth_token_account, *token.key);
-        return Err(ProgramError::IncorrectProgramId);
+        return Err!(ProgramError::IncorrectProgramId; "data.eth_token_account != *token.key data.eth = {} token.key = {}", data.eth_token_account, *token.key);
     }
 
     debug_print!("check_token_account success");

--- a/evm_loader/program/src/token.rs
+++ b/evm_loader/program/src/token.rs
@@ -72,7 +72,7 @@ pub fn get_token_account_balance(account: &AccountInfo) -> Result<u64, ProgramEr
 pub fn check_token_account(token: &AccountInfo, account: &AccountInfo) -> Result<(), ProgramError> {
     debug_print!("check_token_account");
     if *token.owner != spl_token::id() {
-        debug_print!("token.owner != spl_token::id() {}", token.owner);
+        error_print!("token.owner != spl_token::id() {}", token.owner);
         return Err(ProgramError::IncorrectProgramId);
     }
 
@@ -80,7 +80,7 @@ pub fn check_token_account(token: &AccountInfo, account: &AccountInfo) -> Result
     let data = AccountData::unpack(&data)?;
     let data = data.get_account()?;
     if data.eth_token_account != *token.key {
-        debug_print!("data.eth_token_account != *token.key data.eth = {} token.key = {}", data.eth_token_account, *token.key);
+        error_print!("data.eth_token_account != *token.key data.eth = {} token.key = {}", data.eth_token_account, *token.key);
         return Err(ProgramError::IncorrectProgramId);
     }
 

--- a/evm_loader/program/src/transaction.rs
+++ b/evm_loader/program/src/transaction.rs
@@ -50,28 +50,24 @@ pub fn make_secp256k1_instruction(instruction_index: u8, message_len: u16, data_
 
 pub fn check_secp256k1_instruction(sysvar_info: &AccountInfo, message_len: usize, data_offset: u16) -> ProgramResult
 {
-    let message_len = u16::try_from(message_len).map_err(|_| ProgramError::InvalidInstructionData)?;
+    let message_len = u16::try_from(message_len).map_err(|e| E!(ProgramError::InvalidInstructionData; "TryFromIntError={:?}", e))?;
 
     let current_instruction = load_current_index(&sysvar_info.try_borrow_data()?);
-    let current_instruction = u8::try_from(current_instruction).map_err(|_| ProgramError::InvalidInstructionData)?;
+    let current_instruction = u8::try_from(current_instruction).map_err(|e| E!(ProgramError::InvalidInstructionData; "TryFromIntError={:?}", e))?;
     let index = current_instruction - 1;
 
     if let Ok(instr) = load_instruction_at(index.into(), &sysvar_info.try_borrow_data()?) {
         if secp256k1_program::check_id(&instr.program_id) {
             let reference_instruction = make_secp256k1_instruction(current_instruction, message_len, data_offset);
             if reference_instruction != instr.data {
-                error_print!("wrong keccak instruction data");
-                error_print!("instruction: {}", &hex::encode(&instr.data));
-                error_print!("reference: {}", &hex::encode(&reference_instruction));
-                return Err(ProgramError::InvalidInstructionData);
+                return Err!(ProgramError::InvalidInstructionData; "wrong keccak instruction data, instruction={}, reference={}", &hex::encode(&instr.data), &hex::encode(&reference_instruction));
             }
         } else {
-            return Err(ProgramError::IncorrectProgramId);
+            return Err!(ProgramError::IncorrectProgramId; "index={:?}, sysvar_info={:?}, instr.program_id={:?}", index, sysvar_info, instr.program_id);
         }
     }
     else {
-        error_print!("ERR");
-        return Err(ProgramError::MissingRequiredSignature);
+        return Err!(ProgramError::MissingRequiredSignature; "index={:?}, sysvar_info={:?}", index, sysvar_info);
     }
 
     Ok(())
@@ -138,8 +134,7 @@ pub fn find_sysvar_info<'a>(accounts: &'a [AccountInfo<'a>]) -> Result<&'a Accou
         }
     }
 
-    error_print!("sysvar account not found");
-    Err(ProgramError::InvalidInstructionData)
+    Err!(ProgramError::InvalidInstructionData; "sysvar account not found in {:?}", accounts)
 }
 
 pub fn find_rent_info<'a>(accounts: &'a [AccountInfo<'a>]) -> Result<&'a AccountInfo<'a>, ProgramError> {
@@ -149,6 +144,5 @@ pub fn find_rent_info<'a>(accounts: &'a [AccountInfo<'a>]) -> Result<&'a Account
         }
     }
 
-    error_print!("rent account not found");
-    Err(ProgramError::InvalidInstructionData)
+    Err!(ProgramError::InvalidInstructionData; "rent account not found in {:?}",  accounts)
 }

--- a/evm_loader/program/src/transaction.rs
+++ b/evm_loader/program/src/transaction.rs
@@ -60,9 +60,9 @@ pub fn check_secp256k1_instruction(sysvar_info: &AccountInfo, message_len: usize
         if secp256k1_program::check_id(&instr.program_id) {
             let reference_instruction = make_secp256k1_instruction(current_instruction, message_len, data_offset);
             if reference_instruction != instr.data {
-                debug_print!("wrong keccak instruction data");
-                debug_print!("instruction: {}", &hex::encode(&instr.data));
-                debug_print!("reference: {}", &hex::encode(&reference_instruction));
+                error_print!("wrong keccak instruction data");
+                error_print!("instruction: {}", &hex::encode(&instr.data));
+                error_print!("reference: {}", &hex::encode(&reference_instruction));
                 return Err(ProgramError::InvalidInstructionData);
             }
         } else {
@@ -70,7 +70,7 @@ pub fn check_secp256k1_instruction(sysvar_info: &AccountInfo, message_len: usize
         }
     }
     else {
-        debug_print!("ERR");
+        error_print!("ERR");
         return Err(ProgramError::MissingRequiredSignature);
     }
 
@@ -138,6 +138,6 @@ pub fn find_sysvar_info<'a>(accounts: &'a [AccountInfo<'a>]) -> Result<&'a Accou
         }
     }
 
-    debug_print!("sysvar account not found");
+    error_print!("sysvar account not found");
     Err(ProgramError::InvalidInstructionData)
 }

--- a/evm_loader/program/src/transaction.rs
+++ b/evm_loader/program/src/transaction.rs
@@ -149,6 +149,6 @@ pub fn find_rent_info<'a>(accounts: &'a [AccountInfo<'a>]) -> Result<&'a Account
         }
     }
 
-    debug_print!("rent account not found");
+    error_print!("rent account not found");
     Err(ProgramError::InvalidInstructionData)
 }


### PR DESCRIPTION
Introduce macro **Err!**
Replace the following code:
```rust
    error_print!("Caller pubkey: {}", &caller_info.key.to_string());
    return Err(ProgramError::InvalidArgument);
```
To
```rust
    return Err!(ProgramError::InvalidArgument; "Caller pubkey: {} ", &caller_info.key.to_string());
```

Introduce macro **E!**
Replace the following code:
```rust
    map_err(|_| ProgramError::InvalidArgument)
```
To
```rust
    map_err(|s| E!(ProgramError::InvalidArgument; "s={:?}", s))
```