### PR TITLE
Remove clock account

### DIFF
--- a/evm_loader/cli/Cargo.lock
+++ b/evm_loader/cli/Cargo.lock
@@ -977,7 +977,6 @@ dependencies = [
  "getrandom 0.1.16",
  "hex",
  "impl-serde 0.1.1",
- "num-bigint",
  "num-derive",
  "num-traits",
  "num_enum",
@@ -990,7 +989,6 @@ dependencies = [
  "solana-program",
  "spl-associated-token-account",
  "spl-token",
- "tbn",
  "thiserror",
 ]
 
@@ -2005,17 +2003,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2497,15 +2484,6 @@ dependencies = [
  "rand_core 0.3.1",
  "rdrand",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3138,9 +3116,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c520a92d87d9a9ea6240d022d8bbd13aac78ddab0754d037c16d03522e5a26"
+checksum = "4035d75479ba479cc36a15100c9c2786f8c12cb567a81444a3d8b6e4aba75712"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -3161,9 +3139,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bce44af56179ac1afea505509820b821663b32113ce806d7b2cbc67d1976fd"
+checksum = "cd114962f06220e800c35e190362f499a5eacbe5f0e0be5da7b84b14aa8b358b"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3182,9 +3160,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228ab5c61da8d77979845b093ebdeb80b52e5a8ef2511a4d4b7aee6d4a8e18e4"
+checksum = "511ec69f7913a01987dc3421724c847fa4f7bcbc30c281ea7246f0f0e7495768"
 dependencies = [
  "chrono",
  "clap",
@@ -3199,9 +3177,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2040c3f77570d49b8cf60f6e00eab7be8050edfaf09547f9d205b36fb10bd9"
+checksum = "3f777b09740e16132d27309099a7a9d46ad7be93d78dec7f39711b7e2428787e"
 dependencies = [
  "Inflector",
  "bincode",
@@ -3246,9 +3224,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001baf2fe05f3425e1eb88d2037df3f5cc1d09e2cb15ddf0d06010b195dc8750"
+checksum = "5dd0a63bd98f787d09c54f60d09d5814a821bc566dc7296571c8eb33d1c674aa"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -3260,13 +3238,14 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5fb041ab754367f960167440c0898566fde3839f691969064f0eb8f9584b04"
+checksum = "8500202ab73730c07b6a9e8a47fd823e5e407f6daeced22117382beacf02672d"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
  "chrono",
+ "clap",
  "console 0.14.1",
  "humantime",
  "indicatif",
@@ -3284,9 +3263,9 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af95fabdc6cb99c175c6c8e0a84cd50e683b107dbbbf6f5e6b1b6040700a20"
+checksum = "8ebde9efaa90db1b5653a367d7d2789fcaf88a9299650cd901f9939c510babd3"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -3318,9 +3297,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2245383e19e40a01451563cab7a27215293492371f1730c4a0e83403dac101"
+checksum = "edbfc87161a8231c009bcb15573cba8c1a84ea012caed3b5192989150398e66e"
 dependencies = [
  "bincode",
  "chrono",
@@ -3333,9 +3312,9 @@ dependencies = [
 
 [[package]]
 name = "solana-crate-features"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff6b42fb8897e49b55abaf7d1ce0c3d5f2b5d03aa55c9b22dfb1b586a6813b9"
+checksum = "993fdca281d4ff75c10dab9725a9d9f3e4e5d293cc4a3a89b50a5a1430503d95"
 dependencies = [
  "backtrace",
  "bytes 0.4.12",
@@ -3358,9 +3337,9 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993b4144d72fbc4a08cd5feab0cb5400c04811432ed446bc88db3341f09c5dfb"
+checksum = "2d8cb0f4c332566ee8bcebca00caeb65b70a85f06b2d192f9fa4ba466fa75e3e"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3381,9 +3360,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b98d31e0662fedf3a1ee30919c655713874d578e19e65affe46109b1b927f9"
+checksum = "dbee6969ad41585a93c1669c9b4417cefff4ff52957a45f6c579a1f66f84bb03"
 dependencies = [
  "bs58 0.3.1",
  "bv",
@@ -3401,9 +3380,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceac6e8ad1a784c92ff5f3d6ad68a8d664d389b08055b674c38b2b9abb69e6d4"
+checksum = "24fefced09f5cf4a8bb6b3d475a08992f28215c1bc5c05a2657a85c0e80e8cfd"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
@@ -3413,9 +3392,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7c514fe57f8c5042fa88c19f5711c67f264db723d9d79379fcb78dd1f09bbf"
+checksum = "46823a4af30167a864e38258c2ae803cebac0b19bde9575dc1bdd0e3453c8ccd"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -3424,9 +3403,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e339122713d9bbf6626e6be31d3b8d95b4ae9da717fada96ddd83bf64e6d61"
+checksum = "30d4738c2c946fcfa1563e7dc388c5e70c4d49ae9bded62b586b826ced9f0480"
 dependencies = [
  "log",
  "solana-metrics",
@@ -3435,9 +3414,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31a2edbe81e02bc04ad7476e053be0d6632883ee2ca4178b7b1e27fb5112f535"
+checksum = "41c69913f6b2848ca3383a64f660c66657ff22728969829b35bd0fcb538851a2"
 dependencies = [
  "env_logger",
  "gethostname",
@@ -3449,9 +3428,9 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5198edc8640c5a08d36285de66708f552eb122b43f831809d04b7cf12b63d04e"
+checksum = "017812555b0ff4eba97848e845658317cdc9b70e0ea352f30f1db59d3a923c64"
 dependencies = [
  "bincode",
  "clap",
@@ -3471,9 +3450,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bfe6a5dfc5372c0a946018ecdd8115e38af78cea8275bac48cf3d105c6b1fb3"
+checksum = "ff4d4caae58d145ddf277a5e6b1316d9aa727269e3a5e443f5faa90532e9db22"
 dependencies = [
  "bincode",
  "blake3",
@@ -3506,9 +3485,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef72f4eaea1cb614c7f87f41468013ec30589161df35ac97e8c7bc04c5bc335"
+checksum = "02da652f0b386a1948b263336b1f5f78d209dc845ad9418a8d21b09c62baf597"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -3516,9 +3495,9 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d306e9aacee606f21ec1a019b75507700da4fa2a21ac7d2fe2933c4c7a33f69f"
+checksum = "91ce4eb2da88c2a830fa09a33392bedcfdc74a1872ec1086bdbb43a52b146de9"
 dependencies = [
  "base32",
  "console 0.14.1",
@@ -3537,9 +3516,9 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4c53d0fee304eca12b988b2ab4869ea150657b88a092288bd73877b0f19c35"
+checksum = "6ec9351f7406a9bfe220d87edd44e37dc8817a29b8d9ff46d4a0533f29550368"
 dependencies = [
  "arrayref",
  "bincode",
@@ -3588,9 +3567,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1337d6ffccb86c325289ce2dc763990423713e004d9829227eeb1bb9d097415"
+checksum = "258e8fa995b28bfe53a90dea7cb3d17c80f022b352349b05b81ef92fa760380c"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -3637,9 +3616,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84710ce45a21cccd9f2b09d8e9aad529080bb2540f27b1253874b6e732b465b9"
+checksum = "64e988d7938720ca3090cc02caafa7952a98e28d153c5ecc7661208d5adfd520"
 dependencies = [
  "bs58 0.3.1",
  "proc-macro2 1.0.27",
@@ -3650,18 +3629,18 @@ dependencies = [
 
 [[package]]
 name = "solana-secp256k1-program"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c80a486e9b24009dd69f202b3a9de0a503cc96117de61a6ff3e4a422bc350e"
+checksum = "d4ba307591b7e8e7fada2f4f7f2f7024a9ca3ab2894a09ce05e7ce4fa1387a46"
 dependencies = [
  "solana-sdk",
 ]
 
 [[package]]
 name = "solana-stake-program"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76995cab8160e4dceed310f25ea47e4db6e136604b58aeb0d3dc5c5cf4734700"
+checksum = "4e26bfb4c52fed2c2c2dc3f140a1ac4f871d0c969a2a0526394729c076be1199"
 dependencies = [
  "bincode",
  "log",
@@ -3681,9 +3660,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7876d0bf36d29b998f0ed0846af9c40a137e5aa00f02f37da13c5bff69504a2b"
+checksum = "8d655a6382393c0e80ccd433cf9ddea73f1364a02c5e39db050751dd20a74421"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -3705,9 +3684,9 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cbe19fd461f730821c284797dc40c17863b245f040c06392a25f60ed79c05f0"
+checksum = "852243e0a70048295b838fd36ff9c9123149dc1b8ae1373e24f0e788108c38a1"
 dependencies = [
  "log",
  "rustc_version 0.2.3",
@@ -3721,9 +3700,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32818e9d7b76500c30a9ac7451052d4e529a8f59f2e4c31b611bc543e7a368b"
+checksum = "80cbea1e2874bc829356d423cd546da1c341b2c1e69b20b6f7096aad0825bcd0"
 dependencies = [
  "bincode",
  "log",
@@ -3767,9 +3746,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spl-associated-token-account"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adc47eebe5d2b662cbaaba1843719c28a67e5ec5d0460bc3ca60900a51f74e2"
+checksum = "393e2240d521c3dd770806bff25c2c00d761ac962be106e14e22dd912007f428"
 dependencies = [
  "solana-program",
  "spl-token",
@@ -3786,9 +3765,9 @@ dependencies = [
 
 [[package]]
 name = "spl-token"
-version = "3.1.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbfa8fd791aeb4d7ad5fedb7872478de9f4e8b4fcb02dfd9e7f2f9ae3f3ddd73"
+checksum = "93bfdd5bd7c869cb565c7d7635c4fafe189b988a0bdef81063cd9585c6b8dc01"
 dependencies = [
  "arrayref",
  "num-derive",
@@ -3896,19 +3875,6 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
-]
-
-[[package]]
-name = "tbn"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5ed04ba9e7938c1af3174aee638301027de8c0617e6b8373b254f308e40d40b"
-dependencies = [
- "byteorder",
- "crunchy",
- "lazy_static",
- "rand 0.5.6",
- "rustc-hex",
 ]
 
 [[package]]

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -30,7 +30,6 @@ use solana_sdk::{
     system_program,
     sysvar,
     system_instruction,
-    sysvar::{clock, rent},
 };
 use serde_json::json;
 use std::{
@@ -931,8 +930,6 @@ fn command_deploy(
                         AccountMeta::new_readonly(config.evm_loader, false),
                         AccountMeta::new_readonly(evm_loader::token::token_mint::id(), false),
                         AccountMeta::new_readonly(spl_token::id(), false),
-                        AccountMeta::new(rent::id(), false),
-                        AccountMeta::new(clock::id(), false),
                         ];
 
     // Send trx_from_account_data_instruction
@@ -963,8 +960,6 @@ fn command_deploy(
                             AccountMeta::new_readonly(config.evm_loader, false),
                             AccountMeta::new_readonly(evm_loader::token::token_mint::id(), false),
                             AccountMeta::new_readonly(spl_token::id(), false),
-                            AccountMeta::new(rent::id(), false),
-                            AccountMeta::new(clock::id(), false),
                             ];
         let continue_instruction = Instruction::new_with_bincode(config.evm_loader, &(0x0a_u8, 400_u64), continue_accounts);
         let signature = send_transaction(config, &[continue_instruction])?;

--- a/evm_loader/performance/sender/Cargo.lock
+++ b/evm_loader/performance/sender/Cargo.lock
@@ -925,8 +925,6 @@ dependencies = [
  "getrandom 0.1.16",
  "hex",
  "impl-serde",
- "libsecp256k1",
- "num-bigint",
  "num-derive",
  "num-traits",
  "num_enum",
@@ -939,7 +937,6 @@ dependencies = [
  "solana-program",
  "spl-associated-token-account",
  "spl-token",
- "tbn",
  "thiserror",
 ]
 
@@ -1624,19 +1621,6 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
-dependencies = [
- "arrayref",
- "crunchy",
- "digest 0.8.1",
- "rand 0.7.3",
- "subtle 2.4.0",
-]
-
-[[package]]
-name = "libsecp256k1"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
@@ -1901,17 +1885,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -2321,15 +2294,6 @@ dependencies = [
  "rand_core 0.3.1",
  "rdrand",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2990,9 +2954,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c520a92d87d9a9ea6240d022d8bbd13aac78ddab0754d037c16d03522e5a26"
+checksum = "4035d75479ba479cc36a15100c9c2786f8c12cb567a81444a3d8b6e4aba75712"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -3013,13 +2977,13 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bce44af56179ac1afea505509820b821663b32113ce806d7b2cbc67d1976fd"
+checksum = "cd114962f06220e800c35e190362f499a5eacbe5f0e0be5da7b84b14aa8b358b"
 dependencies = [
  "bincode",
  "byteorder",
- "libsecp256k1 0.5.0",
+ "libsecp256k1",
  "log",
  "num-derive",
  "num-traits",
@@ -3034,9 +2998,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228ab5c61da8d77979845b093ebdeb80b52e5a8ef2511a4d4b7aee6d4a8e18e4"
+checksum = "511ec69f7913a01987dc3421724c847fa4f7bcbc30c281ea7246f0f0e7495768"
 dependencies = [
  "chrono",
  "clap",
@@ -3051,9 +3015,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2040c3f77570d49b8cf60f6e00eab7be8050edfaf09547f9d205b36fb10bd9"
+checksum = "3f777b09740e16132d27309099a7a9d46ad7be93d78dec7f39711b7e2428787e"
 dependencies = [
  "Inflector",
  "bincode",
@@ -3098,9 +3062,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001baf2fe05f3425e1eb88d2037df3f5cc1d09e2cb15ddf0d06010b195dc8750"
+checksum = "5dd0a63bd98f787d09c54f60d09d5814a821bc566dc7296571c8eb33d1c674aa"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -3112,13 +3076,14 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5fb041ab754367f960167440c0898566fde3839f691969064f0eb8f9584b04"
+checksum = "8500202ab73730c07b6a9e8a47fd823e5e407f6daeced22117382beacf02672d"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
  "chrono",
+ "clap",
  "console 0.14.1",
  "humantime",
  "indicatif",
@@ -3136,9 +3101,9 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af95fabdc6cb99c175c6c8e0a84cd50e683b107dbbbf6f5e6b1b6040700a20"
+checksum = "8ebde9efaa90db1b5653a367d7d2789fcaf88a9299650cd901f9939c510babd3"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -3170,9 +3135,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2245383e19e40a01451563cab7a27215293492371f1730c4a0e83403dac101"
+checksum = "edbfc87161a8231c009bcb15573cba8c1a84ea012caed3b5192989150398e66e"
 dependencies = [
  "bincode",
  "chrono",
@@ -3185,9 +3150,9 @@ dependencies = [
 
 [[package]]
 name = "solana-crate-features"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff6b42fb8897e49b55abaf7d1ce0c3d5f2b5d03aa55c9b22dfb1b586a6813b9"
+checksum = "993fdca281d4ff75c10dab9725a9d9f3e4e5d293cc4a3a89b50a5a1430503d95"
 dependencies = [
  "backtrace",
  "bytes 0.4.12",
@@ -3210,9 +3175,9 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993b4144d72fbc4a08cd5feab0cb5400c04811432ed446bc88db3341f09c5dfb"
+checksum = "2d8cb0f4c332566ee8bcebca00caeb65b70a85f06b2d192f9fa4ba466fa75e3e"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3233,9 +3198,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b98d31e0662fedf3a1ee30919c655713874d578e19e65affe46109b1b927f9"
+checksum = "dbee6969ad41585a93c1669c9b4417cefff4ff52957a45f6c579a1f66f84bb03"
 dependencies = [
  "bs58 0.3.1",
  "bv",
@@ -3253,9 +3218,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceac6e8ad1a784c92ff5f3d6ad68a8d664d389b08055b674c38b2b9abb69e6d4"
+checksum = "24fefced09f5cf4a8bb6b3d475a08992f28215c1bc5c05a2657a85c0e80e8cfd"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
@@ -3265,9 +3230,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7c514fe57f8c5042fa88c19f5711c67f264db723d9d79379fcb78dd1f09bbf"
+checksum = "46823a4af30167a864e38258c2ae803cebac0b19bde9575dc1bdd0e3453c8ccd"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -3276,9 +3241,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e339122713d9bbf6626e6be31d3b8d95b4ae9da717fada96ddd83bf64e6d61"
+checksum = "30d4738c2c946fcfa1563e7dc388c5e70c4d49ae9bded62b586b826ced9f0480"
 dependencies = [
  "log",
  "solana-metrics",
@@ -3287,9 +3252,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31a2edbe81e02bc04ad7476e053be0d6632883ee2ca4178b7b1e27fb5112f535"
+checksum = "41c69913f6b2848ca3383a64f660c66657ff22728969829b35bd0fcb538851a2"
 dependencies = [
  "env_logger",
  "gethostname",
@@ -3301,9 +3266,9 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5198edc8640c5a08d36285de66708f552eb122b43f831809d04b7cf12b63d04e"
+checksum = "017812555b0ff4eba97848e845658317cdc9b70e0ea352f30f1db59d3a923c64"
 dependencies = [
  "bincode",
  "clap",
@@ -3323,9 +3288,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bfe6a5dfc5372c0a946018ecdd8115e38af78cea8275bac48cf3d105c6b1fb3"
+checksum = "ff4d4caae58d145ddf277a5e6b1316d9aa727269e3a5e443f5faa90532e9db22"
 dependencies = [
  "bincode",
  "blake3",
@@ -3337,7 +3302,7 @@ dependencies = [
  "hex",
  "itertools",
  "lazy_static",
- "libsecp256k1 0.5.0",
+ "libsecp256k1",
  "log",
  "num-derive",
  "num-traits",
@@ -3358,9 +3323,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef72f4eaea1cb614c7f87f41468013ec30589161df35ac97e8c7bc04c5bc335"
+checksum = "02da652f0b386a1948b263336b1f5f78d209dc845ad9418a8d21b09c62baf597"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -3368,9 +3333,9 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d306e9aacee606f21ec1a019b75507700da4fa2a21ac7d2fe2933c4c7a33f69f"
+checksum = "91ce4eb2da88c2a830fa09a33392bedcfdc74a1872ec1086bdbb43a52b146de9"
 dependencies = [
  "base32",
  "console 0.14.1",
@@ -3389,9 +3354,9 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4c53d0fee304eca12b988b2ab4869ea150657b88a092288bd73877b0f19c35"
+checksum = "6ec9351f7406a9bfe220d87edd44e37dc8817a29b8d9ff46d4a0533f29550368"
 dependencies = [
  "arrayref",
  "bincode",
@@ -3440,9 +3405,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1337d6ffccb86c325289ce2dc763990423713e004d9829227eeb1bb9d097415"
+checksum = "258e8fa995b28bfe53a90dea7cb3d17c80f022b352349b05b81ef92fa760380c"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -3459,7 +3424,7 @@ dependencies = [
  "hmac 0.10.1",
  "itertools",
  "lazy_static",
- "libsecp256k1 0.5.0",
+ "libsecp256k1",
  "log",
  "memmap2",
  "num-derive",
@@ -3489,9 +3454,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84710ce45a21cccd9f2b09d8e9aad529080bb2540f27b1253874b6e732b465b9"
+checksum = "64e988d7938720ca3090cc02caafa7952a98e28d153c5ecc7661208d5adfd520"
 dependencies = [
  "bs58 0.3.1",
  "proc-macro2 1.0.27",
@@ -3502,18 +3467,18 @@ dependencies = [
 
 [[package]]
 name = "solana-secp256k1-program"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c80a486e9b24009dd69f202b3a9de0a503cc96117de61a6ff3e4a422bc350e"
+checksum = "d4ba307591b7e8e7fada2f4f7f2f7024a9ca3ab2894a09ce05e7ce4fa1387a46"
 dependencies = [
  "solana-sdk",
 ]
 
 [[package]]
 name = "solana-stake-program"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76995cab8160e4dceed310f25ea47e4db6e136604b58aeb0d3dc5c5cf4734700"
+checksum = "4e26bfb4c52fed2c2c2dc3f140a1ac4f871d0c969a2a0526394729c076be1199"
 dependencies = [
  "bincode",
  "log",
@@ -3533,9 +3498,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7876d0bf36d29b998f0ed0846af9c40a137e5aa00f02f37da13c5bff69504a2b"
+checksum = "8d655a6382393c0e80ccd433cf9ddea73f1364a02c5e39db050751dd20a74421"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -3557,9 +3522,9 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cbe19fd461f730821c284797dc40c17863b245f040c06392a25f60ed79c05f0"
+checksum = "852243e0a70048295b838fd36ff9c9123149dc1b8ae1373e24f0e788108c38a1"
 dependencies = [
  "log",
  "rustc_version 0.2.3",
@@ -3573,9 +3538,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.7.6"
+version = "1.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32818e9d7b76500c30a9ac7451052d4e529a8f59f2e4c31b611bc543e7a368b"
+checksum = "80cbea1e2874bc829356d423cd546da1c341b2c1e69b20b6f7096aad0825bcd0"
 dependencies = [
  "bincode",
  "log",
@@ -3619,9 +3584,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spl-associated-token-account"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adc47eebe5d2b662cbaaba1843719c28a67e5ec5d0460bc3ca60900a51f74e2"
+checksum = "393e2240d521c3dd770806bff25c2c00d761ac962be106e14e22dd912007f428"
 dependencies = [
  "solana-program",
  "spl-token",
@@ -3638,9 +3603,9 @@ dependencies = [
 
 [[package]]
 name = "spl-token"
-version = "3.1.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbfa8fd791aeb4d7ad5fedb7872478de9f4e8b4fcb02dfd9e7f2f9ae3f3ddd73"
+checksum = "93bfdd5bd7c869cb565c7d7635c4fafe189b988a0bdef81063cd9585c6b8dc01"
 dependencies = [
  "arrayref",
  "num-derive",
@@ -3729,19 +3694,6 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
-]
-
-[[package]]
-name = "tbn"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5ed04ba9e7938c1af3174aee638301027de8c0617e6b8373b254f308e40d40b"
-dependencies = [
- "byteorder",
- "crunchy",
- "lazy_static",
- "rand 0.5.6",
- "rustc-hex",
 ]
 
 [[package]]

--- a/evm_loader/program/src/account_storage.rs
+++ b/evm_loader/program/src/account_storage.rs
@@ -13,7 +13,7 @@ use solana_program::{
     pubkey::Pubkey,
     instruction::Instruction,
     program_error::ProgramError,
-    sysvar::{clock, clock::Clock, Sysvar},
+    sysvar::{clock::Clock, Sysvar},
     program::invoke_signed,
     entrypoint::ProgramResult,
 };
@@ -40,7 +40,6 @@ struct AccountMeta<'a> {
 pub struct ProgramAccountStorage<'a> {
     accounts: Vec<SolidityAccount<'a>>,
     aliases: RefCell<Vec<(H160, usize)>>,
-    clock_account: &'a AccountInfo<'a>,
     account_metas: Vec<AccountMeta<'a>>,
     contract_id: H160,
     sender: Sender,
@@ -55,7 +54,7 @@ impl<'a> ProgramAccountStorage<'a> {
     /// 0. contract account info
     /// 1. contract code info
     /// 2. caller or caller account info(for ether account)
-    /// 3. ... other accounts (with `clock_account` in any place)
+    /// 3. ... other accounts
     /// 
     /// # Errors
     ///
@@ -72,8 +71,6 @@ impl<'a> ProgramAccountStorage<'a> {
         let mut accounts = Vec::with_capacity(account_infos.len());
         let mut aliases = Vec::with_capacity(account_infos.len());
         let mut account_metas = Vec::with_capacity(account_infos.len());
-
-        let mut clock_account = None;
 
         let mut push_account = |sol_account: SolidityAccount<'a>, account_info: &'a AccountInfo<'a>, token_info: &'a AccountInfo<'a>, code_info: Option<&'a AccountInfo<'a>>| {
             aliases.push((sol_account.get_ether(), accounts.len()));
@@ -168,18 +165,8 @@ impl<'a> ProgramAccountStorage<'a> {
                 };
 
                 push_account(sol_account, account_info, token_info, code_info);
-            } else if clock::check_id(account_info.key) {
-                debug_print!("Clock account {}", account_info.key);
-                clock_account = Some(account_info);
             }
         }
-
-        let clock_account = if let Some(clock_acc) = clock_account {
-            clock_acc
-        } else {
-            return Err!(ProgramError::NotEnoughAccountKeys);
-        };
-
 
         debug_print!("Accounts was read");
         aliases.sort_by_key(|v| v.0);
@@ -187,7 +174,6 @@ impl<'a> ProgramAccountStorage<'a> {
         Ok(Self {
             accounts,
             aliases: RefCell::new(aliases),
-            clock_account,
             account_metas,
             contract_id,
             sender
@@ -365,12 +351,12 @@ impl<'a> AccountStorage for ProgramAccountStorage<'a> {
     }
 
     fn block_number(&self) -> U256 {
-        let clock = &Clock::from_account_info(self.clock_account).unwrap();
+        let clock = Clock::get().unwrap();
         clock.slot.into()
     }
 
     fn block_timestamp(&self) -> U256 {
-        let clock = &Clock::from_account_info(self.clock_account).unwrap();
+        let clock = Clock::get().unwrap();
         clock.unix_timestamp.into()
     }
 

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -478,7 +478,7 @@ fn process_instruction<'a>(
                 return Err!(ProgramError::InvalidAccountData);
             }
 
-            let mut storage = StorageAccount::restore(storage_info, operator_sol_info, trx_accounts).map_err(|err| {
+            let mut storage = StorageAccount::restore(storage_info, operator_sol_info).map_err(|err| {
                 if err == ProgramError::InvalidAccountData {EvmLoaderError::StorageAccountUninitialized.into()}
                 else {err}
             })?;
@@ -552,7 +552,7 @@ fn process_instruction<'a>(
                 return Err!(ProgramError::InvalidAccountData);
             }
 
-            let storage = StorageAccount::restore(storage_info, operator_sol_info, trx_accounts)?;
+            let storage = StorageAccount::restore(storage_info, operator_sol_info)?;
             storage.check_accounts(program_id, trx_accounts)?;
 
             let account_storage = ProgramAccountStorage::new(program_id, trx_accounts)?;

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -33,7 +33,7 @@ use crate::{
     account_storage::{ProgramAccountStorage, Sender},
     solana_backend::{SolanaBackend, AccountStorage},
     solidity_account::SolidityAccount,
-    transaction::{UnsignedTransaction, verify_tx_signature, check_secp256k1_instruction, find_rent_info},
+    transaction::{UnsignedTransaction, verify_tx_signature, check_secp256k1_instruction},
     executor_state::{ ExecutorState, ExecutorSubstate },
     storage_account::{ StorageAccount },
     error::EvmLoaderError,
@@ -124,19 +124,19 @@ fn process_instruction<'a>(
     #[allow(clippy::match_same_arms)]
     let result = match instruction {
         EvmInstruction::CreateAccount {lamports, space: _, ether, nonce} => {
-            let rent_info = find_rent_info(accounts)?;
-            let rent = Rent::from_account_info(rent_info)?;
-
+            let rent = Rent::get()?;
+            
             let funding_info = next_account_info(account_info_iter)?;
             let account_info = next_account_info(account_info_iter)?;
             let token_account_info = next_account_info(account_info_iter)?;
-
+            
             debug_print!("Ether: {} {}", &(hex::encode(ether)), &hex::encode([nonce]));
-
+            
             let expected_address = Pubkey::create_program_address(&[ether.as_bytes(), &[nonce]], program_id)?;
             if expected_address != *account_info.key {
                 return Err!(ProgramError::InvalidArgument; "expected_address<{:?}> != *account_info.key<{:?}>", expected_address, *account_info.key);
             };
+            
 
             let code_account_key = {
                 let program_code = next_account_info(account_info_iter)?;
@@ -183,9 +183,6 @@ fn process_instruction<'a>(
             Ok(())
         },
         EvmInstruction::CreateAccountWithSeed {base, seed, lamports, space, owner, token} => {
-            let rent_info = find_rent_info(accounts)?;
-            let rent = Rent::from_account_info(rent_info)?;
-
             let funding_info = next_account_info(account_info_iter)?;
             let created_info = next_account_info(account_info_iter)?;
             let base_info = next_account_info(account_info_iter)?;
@@ -200,7 +197,7 @@ fn process_instruction<'a>(
             let caller = SolidityAccount::new(base_info.key, base_info.lamports(), base_info_data, None);
 
             let space_as_usize = usize::try_from(space).map_err(|e| E!(ProgramError::InvalidArgument; "e={:?}", e))?;
-            let account_lamports = rent.minimum_balance(space_as_usize) + lamports;
+            let account_lamports = Rent::get()?.minimum_balance(space_as_usize) + lamports;
 
             let (caller_ether, caller_nonce) = caller.get_seeds();
             let program_seeds = [caller_ether.as_bytes(), &[caller_nonce]];

--- a/evm_loader/program/src/storage_account.rs
+++ b/evm_loader/program/src/storage_account.rs
@@ -6,14 +6,13 @@ use solana_program::{
     account_info::AccountInfo,
     pubkey::Pubkey,
     program_error::ProgramError,
-    sysvar,
     sysvar::Sysvar,
     clock::Clock,
 };
 use serde::{ Serialize, de::DeserializeOwned };
 use std::convert::TryInto;
 
-const OPERATOR_PRIORITY_SLOTS: u64 = 3;
+const OPERATOR_PRIORITY_SLOTS: u64 = 16;
 
 pub struct StorageAccount<'a> {
     info: &'a AccountInfo<'a>,
@@ -22,9 +21,6 @@ pub struct StorageAccount<'a> {
 
 impl<'a> StorageAccount<'a> {
     pub fn new(info: &'a AccountInfo<'a>, operator: &AccountInfo, accounts: &[AccountInfo], caller: H160, nonce: u64, gas_limit: u64, gas_price: u64) -> Result<Self, ProgramError> {
-        let clock_info = accounts.iter().find(|a| sysvar::clock::check_id(a.key)).ok_or_else(||E!(ProgramError::InvalidAccountData))?;
-        let clock = Clock::from_account_info(clock_info)?;
-
         let account_data = info.try_borrow_data()?;
 
         if let AccountData::Empty = AccountData::unpack(&account_data)? {
@@ -34,7 +30,7 @@ impl<'a> StorageAccount<'a> {
                     nonce,
                     gas_limit,
                     gas_price,
-                    slot: clock.slot,
+                    slot: Clock::get()?.slot,
                     operator: *operator.key,
                     accounts_len: accounts.len(),
                     executor_data_size: 0,
@@ -47,19 +43,19 @@ impl<'a> StorageAccount<'a> {
         }
     }
 
-    pub fn restore(info: &'a AccountInfo<'a>, operator: &AccountInfo, accounts: &[AccountInfo]) -> Result<Self, ProgramError> {
-        let clock_info = accounts.iter().find(|a| sysvar::clock::check_id(a.key)).ok_or_else(||E!(ProgramError::InvalidAccountData))?;
-        let clock = Clock::from_account_info(clock_info)?;
-
+    pub fn restore(info: &'a AccountInfo<'a>, operator: &AccountInfo) -> Result<Self, ProgramError> {
         let mut account_data = info.try_borrow_mut_data()?;
-
+        
         if let AccountData::Storage(mut data) = AccountData::unpack(&account_data)? {
+            let clock = Clock::get()?;
             if (*operator.key != data.operator) && ((clock.slot - data.slot) <= OPERATOR_PRIORITY_SLOTS) {
                 return Err!(ProgramError::InvalidAccountData);
             }
 
-            data.operator = *operator.key;
-            data.slot = clock.slot;
+            if data.operator != *operator.key {
+                data.operator = *operator.key;
+                data.slot = clock.slot;
+            }
 
             let data = AccountData::Storage(data);
             AccountData::pack(&data, &mut account_data)?;

--- a/evm_loader/program/src/transaction.rs
+++ b/evm_loader/program/src/transaction.rs
@@ -127,22 +127,3 @@ pub fn verify_tx_signature(signature: &[u8], unsigned_trx: &[u8]) -> Result<H160
 
     Ok(address)
 }
-
-// pub fn find_sysvar_info<'a>(accounts: &'a [AccountInfo<'a>]) -> Result<&'a AccountInfo<'a>, ProgramError> {
-//     for account in accounts {
-//         if solana_program::sysvar::instructions::check_id(account.key) {
-//             return Ok(account);
-//         }
-//     }
-// Err!(ProgramError::InvalidInstructionData; "sysvar account not found in {:?}", accounts)
-// }
-
-pub fn find_rent_info<'a>(accounts: &'a [AccountInfo<'a>]) -> Result<&'a AccountInfo<'a>, ProgramError> {
-    for account in accounts {
-        if solana_program::sysvar::rent::check_id(account.key) {
-            return Ok(account);
-        }
-    }
-
-    Err!(ProgramError::InvalidInstructionData; "rent account not found in {:?}",  accounts)
-}

--- a/evm_loader/solana_utils.py
+++ b/evm_loader/solana_utils.py
@@ -338,7 +338,6 @@ class NeonEvmClient:
     def __send_neon_transaction(self, ethereum_transaction, trx) -> types.RPCResponse:
         if ethereum_transaction.trx_account_metas is not None:
             trx.instructions[-1].keys.extend(ethereum_transaction.trx_account_metas)
-        trx.instructions[-1].keys.append(AccountMeta(pubkey=PublicKey(sysvarclock), is_signer=False, is_writable=False))
 
         return send_transaction(client, trx, self.solana_wallet)
 

--- a/evm_loader/test.py
+++ b/evm_loader/test.py
@@ -239,7 +239,6 @@ class EvmLoaderTests(unittest.TestCase):
                 AccountMeta(pubkey=self.contract, is_signer=False, is_writable=True),
                 AccountMeta(pubkey=self.caller, is_signer=False, is_writable=True),
                 AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=False),
-                AccountMeta(pubkey=PublicKey("SysvarC1ock11111111111111111111111111111111"), is_signer=False, is_writable=False),
             ]))
         result = send_transaction(client, trx, self.acc)
 
@@ -263,7 +262,6 @@ class EvmLoaderTests(unittest.TestCase):
                 AccountMeta(pubkey=self.contract, is_signer=False, is_writable=True),
                 AccountMeta(pubkey=self.caller, is_signer=False, is_writable=True),
                 AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=False),
-                AccountMeta(pubkey=PublicKey("SysvarC1ock11111111111111111111111111111111"), is_signer=False, is_writable=False),
             ]))
         result = send_transaction(client, trx, self.acc)
 

--- a/evm_loader/test_delete_account.py
+++ b/evm_loader/test_delete_account.py
@@ -110,7 +110,6 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
             AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
             AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
             AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-            AccountMeta(pubkey=PublicKey("SysvarC1ock11111111111111111111111111111111"), is_signer=False, is_writable=False),
         ])
 
 

--- a/evm_loader/test_deploy.py
+++ b/evm_loader/test_deploy.py
@@ -193,7 +193,6 @@ class DeployTest(unittest.TestCase):
                 AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=PublicKey(sysvarclock), is_signer=False, is_writable=False),
             ])
 
     def sol_instr_10_continue(self, storage_account, step_count, contract_sol, code_sol):
@@ -224,7 +223,6 @@ class DeployTest(unittest.TestCase):
                 AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=PublicKey(sysvarclock), is_signer=False, is_writable=False),
             ])
 
 

--- a/evm_loader/test_eth_token.py
+++ b/evm_loader/test_eth_token.py
@@ -87,7 +87,6 @@ class EthTokenTest(unittest.TestCase):
                 AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=PublicKey(sysvarclock), is_signer=False, is_writable=False),
             ])
 
     def sol_instr_10_continue(self, storage_account, step_count):
@@ -118,7 +117,6 @@ class EthTokenTest(unittest.TestCase):
                 AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=PublicKey(sysvarclock), is_signer=False, is_writable=False),
             ])
 
     def sol_instr_keccak(self, keccak_instruction):

--- a/evm_loader/test_event.py
+++ b/evm_loader/test_event.py
@@ -80,7 +80,6 @@ class EventTest(unittest.TestCase):
                 AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=PublicKey("SysvarC1ock11111111111111111111111111111111"), is_signer=False, is_writable=False),
             ])
 
     def sol_instr_09_partial_call(self, storage_account, step_count, evm_instruction):
@@ -112,7 +111,6 @@ class EventTest(unittest.TestCase):
                 AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=PublicKey(sysvarclock), is_signer=False, is_writable=False),
             ])
 
     def sol_instr_10_continue(self, storage_account, step_count):
@@ -142,7 +140,6 @@ class EventTest(unittest.TestCase):
                 AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=PublicKey(sysvarclock), is_signer=False, is_writable=False),
             ])
 
     def sol_instr_12_cancel(self, storage_account):
@@ -172,7 +169,6 @@ class EventTest(unittest.TestCase):
                 AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=PublicKey(sysvarclock), is_signer=False, is_writable=False),
             ])
 
 

--- a/evm_loader/test_nested_call.py
+++ b/evm_loader/test_nested_call.py
@@ -127,7 +127,6 @@ class EventTest(unittest.TestCase):
                 AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=PublicKey(sysvarclock), is_signer=False, is_writable=False),
             ])
 
     def sol_instr_09_partial_call(self, storage_account, step_count, evm_instruction, contract, code):
@@ -174,7 +173,6 @@ class EventTest(unittest.TestCase):
                 AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=PublicKey(sysvarclock), is_signer=False, is_writable=False),
             ])
 
     def sol_instr_10_continue(self, storage_account, step_count, contract, code):
@@ -219,7 +217,6 @@ class EventTest(unittest.TestCase):
                 AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=PublicKey(sysvarclock), is_signer=False, is_writable=False),
             ])
 
     def create_account_with_seed(self, seed):

--- a/evm_loader/test_remove_caller.py
+++ b/evm_loader/test_remove_caller.py
@@ -68,7 +68,6 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
                 AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=False),
                 AccountMeta(pubkey=get_associated_token_address(self.acc.public_key(), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
                 AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=PublicKey("SysvarC1ock11111111111111111111111111111111"), is_signer=False, is_writable=False),
             ]))
         result = send_transaction(client, trx, self.acc)
         print(result)
@@ -94,7 +93,6 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
                 AccountMeta(pubkey=acc.public_key(), is_signer=True, is_writable=False),
                 AccountMeta(pubkey=get_associated_token_address(acc.public_key(), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
                 AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=PublicKey("SysvarC1ock11111111111111111111111111111111"), is_signer=False, is_writable=False),
             ]))
 
         #err = "invalid program argument"

--- a/evm_loader/test_solidity_precompiles.py
+++ b/evm_loader/test_solidity_precompiles.py
@@ -214,7 +214,6 @@ class PrecompilesTests(unittest.TestCase):
                 AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=PublicKey("SysvarC1ock11111111111111111111111111111111"), is_signer=False, is_writable=False),
             ])
 
     def sol_instr_10_continue(self, storage_account, step_count):
@@ -245,7 +244,6 @@ class PrecompilesTests(unittest.TestCase):
                 AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=PublicKey("SysvarC1ock11111111111111111111111111111111"), is_signer=False, is_writable=False),
             ])
 
     def create_account_with_seed(self, seed):

--- a/evm_loader/test_transaction.py
+++ b/evm_loader/test_transaction.py
@@ -99,7 +99,6 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
                 AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
                 AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=PublicKey("SysvarC1ock11111111111111111111111111111111"), is_signer=False, is_writable=False),
             ]))
         result = send_transaction(client, trx, self.acc)
 
@@ -160,8 +159,7 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
     #         TransactionInstruction(program_id=self.evm_loader, data=bytearray.fromhex("05") + from_addr + sign + msg, keys=[
     #             AccountMeta(pubkey=self.owner_contract, is_signer=False, is_writable=True),
     #             AccountMeta(pubkey=self.acc.get_acc().public_key(), is_signer=True, is_writable=False),
-    #             AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),  
-    #             AccountMeta(pubkey=PublicKey("SysvarC1ock11111111111111111111111111111111"), is_signer=False, is_writable=False),              
+    #             AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
     #         ]))
     #     result = client.send_transaction(trx, self.acc.get_acc())
 
@@ -179,8 +177,7 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
     #         TransactionInstruction(program_id=self.evm_loader, data=bytearray.fromhex("05") + from_addr + sign + msg, keys=[
     #             AccountMeta(pubkey=self.owner_contract, is_signer=False, is_writable=True),
     #             AccountMeta(pubkey=self.acc.get_acc().public_key(), is_signer=True, is_writable=False),
-    #             AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),  
-    #             AccountMeta(pubkey=PublicKey("SysvarC1ock11111111111111111111111111111111"), is_signer=False, is_writable=False),              
+    #             AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
     #         ]))
     #     result = client.send_transaction(trx, self.acc.get_acc())
 


### PR DESCRIPTION
Sysvar data can be received from the syscall.
Clock and Rent accounts no longer needed in the transaction.