### PR TITLE
neon-cli refunded_gas is included in the estimate_gas

### DIFF
--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -189,18 +189,12 @@ fn command_emulate(config: &Config, contract_id: Option<H160>, caller_id: H160, 
         let used_gas = executor_state.substate().metadata().gasometer().used_gas() + 1; // "+ 1" because of https://github.com/neonlabsorg/neon-evm/issues/144
         let refunded_gas = executor_state.substate().metadata().gasometer().refunded_gas();
         debug!("used_gas={:?} refunded_gas={:?}", used_gas, refunded_gas);
-
-        let mut refunded_gas_abs : u64 = 0;
-        if refunded_gas > 0 {
-            refunded_gas_abs = refunded_gas as u64;
-        }
-
         if exit_reason.is_succeed() {
             debug!("Succeed execution");
             let (_, (applies, logs, _transfer)) = executor_state.deconstruct();
-            (exit_reason, result, Some((applies, logs)), used_gas + refunded_gas_abs)
+            (exit_reason, result, Some((applies, logs)), used_gas + (if refunded_gas > 0 { u64::try_from(refunded_gas)? } else { 0 }))
         } else {
-            (exit_reason, result, None, used_gas + refunded_gas_abs)
+            (exit_reason, result, None, used_gas + (if refunded_gas > 0 { u64::try_from(refunded_gas)? } else { 0 }))
         }
     };
 

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -190,12 +190,17 @@ fn command_emulate(config: &Config, contract_id: Option<H160>, caller_id: H160, 
         let refunded_gas = executor_state.substate().metadata().gasometer().refunded_gas();
         debug!("used_gas={:?} refunded_gas={:?}", used_gas, refunded_gas);
 
+        let mut refunded_gas_abs : u64 = 0;
+        if refunded_gas > 0 {
+            refunded_gas_abs = refunded_gas as u64;
+        }
+
         if exit_reason.is_succeed() {
             debug!("Succeed execution");
             let (_, (applies, logs, _transfer)) = executor_state.deconstruct();
-            (exit_reason, result, Some((applies, logs)), used_gas)
+            (exit_reason, result, Some((applies, logs)), used_gas + refunded_gas_abs)
         } else {
-            (exit_reason, result, None, used_gas)
+            (exit_reason, result, None, used_gas + refunded_gas_abs)
         }
     };
 


### PR DESCRIPTION
gas analize   is performed for each opcode. 
Exceeding the limit is checking inside that function. 
This condition is not take into account the refunded gas.

https://github.com/neonlabsorg/evm/blob/develop/gasometer/src/lib.rs#L160

gas_refund is not substructed from all_gas_cost