### PR TITLE
216 add a new instruction type to combine partial call and continue

### DIFF
--- a/evm_loader/ci_checks.sh
+++ b/evm_loader/ci_checks.sh
@@ -5,7 +5,7 @@ SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 print_non_err_info()
 {
-  egrep -vn "(use|enum|Err\!|E\!|\/\/\/|==|\_\ =>)" $SCRIPTPATH/program/src/*.rs | grep "ProgramError::"
+  egrep -vn "(use|enum|Err\!|E\!|\/\/\/|==|\_\ =>|EXCLUDE\ Err\!)" $SCRIPTPATH/program/src/*.rs | grep "ProgramError::"
 }
 export NON_ERR_INFO=$(print_non_err_info | wc -l)
 if (("NON_ERR_INFO" > 0)); then

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -566,51 +566,106 @@ fn process_instruction<'a>(
             Ok(())
         },
         EvmInstruction::PartialCallOrContinueFromRawEthereumTX {collateral_pool_index, step_count, from_addr, sign: _, unsigned_msg} => {
-            debug_print!("Execute from raw ethereum transaction iterative");
+            debug_print!("Execute from raw ethereum transaction iterative or continue");
             let storage_info = next_account_info(account_info_iter)?;
-
             let sysvar_info = next_account_info(account_info_iter)?;
             let operator_sol_info = next_account_info(account_info_iter)?;
             let collateral_pool_sol_info = next_account_info(account_info_iter)?;
+            let operator_eth_info = next_account_info(account_info_iter)?;
+            let user_eth_info = next_account_info(account_info_iter)?;
             let system_info = next_account_info(account_info_iter)?;
 
-            let trx_accounts = &accounts[5..];
-
-            let caller = H160::from_slice(from_addr);
-            let trx: UnsignedTransaction = rlp::decode(unsigned_msg).map_err(|e| E!(ProgramError::InvalidInstructionData; "DecoderError={:?}", e))?;
-            let trx_gas_limit = u64::try_from(trx.gas_limit).map_err(|e| E!(ProgramError::InvalidInstructionData; "e={:?}", e))?;
-            let trx_gas_price = u64::try_from(trx.gas_price).map_err(|e| E!(ProgramError::InvalidInstructionData; "e={:?}", e))?;
-            // if trx_gas_price < 1_000_000_000_u64 {
-            //     return Err!(ProgramError::InvalidArgument; "trx_gas_price < 1_000_000_000_u64: {} ", trx_gas_price);
-            // }
+            let trx_accounts = &accounts[7..];
 
             if !operator_sol_info.is_signer {
                 return Err!(ProgramError::InvalidAccountData);
             }
 
-            let mut storage = StorageAccount::new(storage_info, operator_sol_info, trx_accounts, caller, trx.nonce, trx_gas_limit, trx_gas_price)?;
-            StorageAccount::check_for_blocked_accounts(program_id, trx_accounts)?;
-            let account_storage = ProgramAccountStorage::new(program_id, trx_accounts)?;
+            let caller = H160::from_slice(from_addr);
+            let trx: UnsignedTransaction = rlp::decode(unsigned_msg).map_err(|e| E!(ProgramError::InvalidInstructionData; "DecoderError={:?}", e))?;
+            let trx_gas_limit = u64::try_from(trx.gas_limit).map_err(|e| E!(ProgramError::InvalidInstructionData; "e={:?}", e))?;
+            let trx_gas_price = u64::try_from(trx.gas_price).map_err(|e| E!(ProgramError::InvalidInstructionData; "e={:?}", e))?;
+            // if trx_gas_price < 1_u64 {
+            //     Err!(ProgramError::InvalidArgument; "trx_gas_price < 1_u64: {} ", trx_gas_price)
+            // }
 
-            check_secp256k1_instruction(sysvar_info, unsigned_msg.len(), 13_u16)?;
-            check_ethereum_authority(
-                account_storage.get_caller_account().ok_or_else(||E!(ProgramError::InvalidArgument))?,
-                &caller, trx.nonce, &trx.chain_id)?;
+            let mut begin: bool = false;
+            let mut storage = match StorageAccount::restore(storage_info, operator_sol_info) {
+                Ok(restored_storage) => Ok(restored_storage),
+                Err(ProgramError::InvalidAccountData) => {
+                    begin = true;
+                    StorageAccount::new(storage_info, operator_sol_info, trx_accounts, caller, trx.nonce, trx_gas_limit, trx_gas_price)
+                },
+                Err(err) => return Err(err),
+            }?;
 
-            payment::transfer_from_operator_to_collateral_pool(
-                program_id,
-                collateral_pool_index,
-                operator_sol_info,
-                collateral_pool_sol_info,
-                system_info)?;
-            payment::transfer_from_operator_to_deposit(
-                operator_sol_info,
-                storage_info,
-                system_info)?;
+            if begin {
+                StorageAccount::check_for_blocked_accounts(program_id, trx_accounts)?;
+                let account_storage = ProgramAccountStorage::new(program_id, trx_accounts)?;
+                check_secp256k1_instruction(sysvar_info, unsigned_msg.len(), 13_u16)?;
+                check_ethereum_authority(
+                    account_storage.get_caller_account().ok_or_else(|| E!(ProgramError::InvalidArgument))?,
+                    &caller, trx.nonce, &trx.chain_id)?;
 
-            do_partial_call(&mut storage, step_count, &account_storage, trx_accounts, trx.call_data, trx.value, trx_gas_limit)?;
+                payment::transfer_from_operator_to_collateral_pool(
+                    program_id,
+                    collateral_pool_index,
+                    operator_sol_info,
+                    collateral_pool_sol_info,
+                    system_info)?;
+                payment::transfer_from_operator_to_deposit(
+                    operator_sol_info,
+                    storage_info,
+                    system_info)?;
 
-            storage.block_accounts(program_id, trx_accounts)
+                do_partial_call(&mut storage, step_count, &account_storage, trx_accounts, trx.call_data, trx.value, trx_gas_limit)?;
+
+                storage.block_accounts(program_id, trx_accounts)
+            }
+            else {
+                storage.check_accounts(program_id, trx_accounts)?;
+                let mut account_storage = ProgramAccountStorage::new(program_id, trx_accounts)?;
+                let call_return = do_continue(&mut storage, step_count, &mut account_storage, trx_accounts)?;
+
+                if let Some(call_results) = call_return {
+                    payment::transfer_from_deposit_to_operator(
+                        storage_info,
+                        operator_sol_info,
+                        system_info)?;
+                    if get_token_account_owner(operator_eth_info)? != *operator_sol_info.key {
+                        debug_print!("operator token ownership");
+                        debug_print!("operator token owner {}", operator_eth_info.owner);
+                        debug_print!("operator key {}", operator_sol_info.key);
+                        return Err!(ProgramError::InvalidInstructionData; "Wrong operator token ownership")
+                    }
+                    let (gas_limit, gas_price) = storage.get_gas_params()?;
+                    let used_gas = call_results.1;
+                    if used_gas > gas_limit {
+                        return Err!(ProgramError::InvalidArgument);
+                    }
+                    let gas_price_wei = U256::from(gas_price);
+                    let fee = U256::from(used_gas)
+                        .checked_mul(gas_price_wei).ok_or_else(||E!(ProgramError::InvalidArgument))?;
+                    token::transfer_token(
+                        accounts,
+                        user_eth_info,
+                        operator_eth_info,
+                        account_storage.get_caller_account_info().ok_or_else(||E!(ProgramError::InvalidArgument))?,
+                        account_storage.get_caller_account().ok_or_else(||E!(ProgramError::InvalidArgument))?,
+                        &fee)?;
+
+                    applies_and_invokes(
+                        program_id,
+                        &mut account_storage,
+                        accounts,
+                        Some(operator_sol_info),
+                        call_results)?;
+
+                    storage.unblock_accounts_and_destroy(program_id, trx_accounts)?;
+                }
+
+                Ok(())
+            }
         },
     };
 

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -592,7 +592,7 @@ fn process_instruction<'a>(
             let mut begin: bool = false;
             let mut storage = match StorageAccount::restore(storage_info, operator_sol_info) {
                 Ok(restored_storage) => Ok(restored_storage),
-                Err(ProgramError::InvalidAccountData) => {
+                Err(ProgramError::InvalidAccountData) => { // EXCLUDE Err!
                     begin = true;
                     StorageAccount::new(storage_info, operator_sol_info, trx_accounts, caller, trx.nonce, trx_gas_limit, trx_gas_price)
                 },

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -298,10 +298,6 @@ fn process_instruction<'a>(
 
             let trx_accounts = &accounts[5..];
 
-            if !operator_sol_info.is_signer {
-                return Err!(ProgramError::InvalidAccountData);
-            }
-
             let from_addr = verify_tx_signature(signature, unsigned_msg).map_err(|e| E!(ProgramError::MissingRequiredSignature; "Error={:?}", e))?;
             let trx: UnsignedTransaction = rlp::decode(unsigned_msg).map_err(|e| E!(ProgramError::InvalidInstructionData; "DecoderError={:?}", e))?;
 
@@ -395,10 +391,6 @@ fn process_instruction<'a>(
 
             let trx_accounts = &accounts[5..];
 
-            if !operator_sol_info.is_signer {
-                return Err!(ProgramError::InvalidAccountData);
-            }
-
             check_secp256k1_instruction(sysvar_info, unsigned_msg.len(), 13_u16)?;
 
             let caller = H160::from_slice(from_addr);
@@ -422,10 +414,6 @@ fn process_instruction<'a>(
             let system_info = next_account_info(account_info_iter)?;
 
             let trx_accounts = &accounts[5..];
-
-            if !operator_sol_info.is_signer {
-                return Err!(ProgramError::InvalidAccountData);
-            }
 
             let storage = StorageAccount::restore(storage_info, operator_sol_info).map_err(|err| {
                 if err == ProgramError::InvalidAccountData {EvmLoaderError::StorageAccountUninitialized.into()}
@@ -493,10 +481,6 @@ fn process_instruction<'a>(
             let system_info = next_account_info(account_info_iter)?;
 
             let trx_accounts = &accounts[7..];
-
-            if !operator_sol_info.is_signer {
-                return Err!(ProgramError::InvalidAccountData);
-            }
 
             match StorageAccount::restore(storage_info, operator_sol_info) {
                 Err(ProgramError::InvalidAccountData) => { // EXCLUDE Err!
@@ -689,6 +673,10 @@ fn do_begin<'a>(
     system_info: &'a AccountInfo<'a>
 ) -> ProgramResult
 {
+    if !operator_sol_info.is_signer {
+        return Err!(ProgramError::InvalidAccountData);
+    }
+
     let trx_gas_limit = u64::try_from(trx.gas_limit).map_err(|e| E!(ProgramError::InvalidInstructionData; "e={:?}", e))?;
     let trx_gas_price = u64::try_from(trx.gas_price).map_err(|e| E!(ProgramError::InvalidInstructionData; "e={:?}", e))?;
 
@@ -736,6 +724,10 @@ fn do_continue_top_level<'a>(
     system_info: &'a AccountInfo<'a>
 ) -> ProgramResult
 {
+    if !operator_sol_info.is_signer {
+        return Err!(ProgramError::InvalidAccountData);
+    }
+
     storage.check_accounts(program_id, trx_accounts)?;
     let mut account_storage = ProgramAccountStorage::new(program_id, trx_accounts)?;
     let call_return = do_continue(&mut storage, step_count, &mut account_storage, trx_accounts)?;

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -633,10 +633,10 @@ fn process_instruction<'a>(
                         operator_sol_info,
                         system_info)?;
                     if get_token_account_owner(operator_eth_info)? != *operator_sol_info.key {
-                        debug_print!("operator token ownership");
-                        debug_print!("operator token owner {}", operator_eth_info.owner);
-                        debug_print!("operator key {}", operator_sol_info.key);
-                        return Err!(ProgramError::InvalidInstructionData; "Wrong operator token ownership")
+                        return Err!(ProgramError::InvalidInstructionData;
+                            "Wrong operator token ownership: operator token owner = {:?}, operator key = {:?}",
+                            operator_eth_info.owner,
+                            operator_sol_info.key)
                     }
                     let (gas_limit, gas_price) = storage.get_gas_params()?;
                     let used_gas = call_results.1;

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -581,91 +581,58 @@ fn process_instruction<'a>(
                 return Err!(ProgramError::InvalidAccountData);
             }
 
-            let caller = H160::from_slice(from_addr);
-            let trx: UnsignedTransaction = rlp::decode(unsigned_msg).map_err(|e| E!(ProgramError::InvalidInstructionData; "DecoderError={:?}", e))?;
-            let trx_gas_limit = u64::try_from(trx.gas_limit).map_err(|e| E!(ProgramError::InvalidInstructionData; "e={:?}", e))?;
-            let trx_gas_price = u64::try_from(trx.gas_price).map_err(|e| E!(ProgramError::InvalidInstructionData; "e={:?}", e))?;
-            // if trx_gas_price < 1_u64 {
-            //     Err!(ProgramError::InvalidArgument; "trx_gas_price < 1_u64: {} ", trx_gas_price)
-            // }
-
-            let mut begin: bool = false;
-            let mut storage = match StorageAccount::restore(storage_info, operator_sol_info) {
-                Ok(restored_storage) => Ok(restored_storage),
+            match StorageAccount::restore(storage_info, operator_sol_info) {
                 Err(ProgramError::InvalidAccountData) => { // EXCLUDE Err!
-                    begin = true;
-                    StorageAccount::new(storage_info, operator_sol_info, trx_accounts, caller, trx.nonce, trx_gas_limit, trx_gas_price)
+                    do_begin(collateral_pool_index, step_count, from_addr, unsigned_msg,
+                             program_id, trx_accounts,
+                             operator_sol_info, collateral_pool_sol_info,
+                             storage_info, system_info, sysvar_info)?
                 },
-                Err(err) => return Err(err),
-            }?;
+                Ok(mut storage) => {
+                    storage.check_accounts(program_id, trx_accounts)?;
+                    let mut account_storage = ProgramAccountStorage::new(program_id, trx_accounts)?;
+                    let call_return = do_continue(&mut storage, step_count, &mut account_storage, trx_accounts)?;
 
-            if begin {
-                StorageAccount::check_for_blocked_accounts(program_id, trx_accounts)?;
-                let account_storage = ProgramAccountStorage::new(program_id, trx_accounts)?;
-                check_secp256k1_instruction(sysvar_info, unsigned_msg.len(), 13_u16)?;
-                check_ethereum_authority(
-                    account_storage.get_caller_account().ok_or_else(|| E!(ProgramError::InvalidArgument))?,
-                    &caller, trx.nonce, &trx.chain_id)?;
+                    if let Some(call_results) = call_return {
+                        payment::transfer_from_deposit_to_operator(
+                            storage_info,
+                            operator_sol_info,
+                            system_info)?;
+                        if get_token_account_owner(operator_eth_info)? != *operator_sol_info.key {
+                            return Err!(ProgramError::InvalidInstructionData;
+                                "Wrong operator token ownership: operator token owner = {:?}, operator key = {:?}",
+                                operator_eth_info.owner,
+                                operator_sol_info.key)
+                        }
+                        let (gas_limit, gas_price) = storage.get_gas_params()?;
+                        let used_gas = call_results.1;
+                        if used_gas > gas_limit {
+                            return Err!(ProgramError::InvalidArgument);
+                        }
+                        let gas_price_wei = U256::from(gas_price);
+                        let fee = U256::from(used_gas)
+                            .checked_mul(gas_price_wei).ok_or_else(||E!(ProgramError::InvalidArgument))?;
+                        token::transfer_token(
+                            accounts,
+                            user_eth_info,
+                            operator_eth_info,
+                            account_storage.get_caller_account_info().ok_or_else(||E!(ProgramError::InvalidArgument))?,
+                            account_storage.get_caller_account().ok_or_else(||E!(ProgramError::InvalidArgument))?,
+                            &fee)?;
 
-                payment::transfer_from_operator_to_collateral_pool(
-                    program_id,
-                    collateral_pool_index,
-                    operator_sol_info,
-                    collateral_pool_sol_info,
-                    system_info)?;
-                payment::transfer_from_operator_to_deposit(
-                    operator_sol_info,
-                    storage_info,
-                    system_info)?;
+                        applies_and_invokes(
+                            program_id,
+                            &mut account_storage,
+                            accounts,
+                            Some(operator_sol_info),
+                            call_results)?;
 
-                do_partial_call(&mut storage, step_count, &account_storage, trx_accounts, trx.call_data, trx.value, trx_gas_limit)?;
-
-                storage.block_accounts(program_id, trx_accounts)
-            }
-            else {
-                storage.check_accounts(program_id, trx_accounts)?;
-                let mut account_storage = ProgramAccountStorage::new(program_id, trx_accounts)?;
-                let call_return = do_continue(&mut storage, step_count, &mut account_storage, trx_accounts)?;
-
-                if let Some(call_results) = call_return {
-                    payment::transfer_from_deposit_to_operator(
-                        storage_info,
-                        operator_sol_info,
-                        system_info)?;
-                    if get_token_account_owner(operator_eth_info)? != *operator_sol_info.key {
-                        return Err!(ProgramError::InvalidInstructionData;
-                            "Wrong operator token ownership: operator token owner = {:?}, operator key = {:?}",
-                            operator_eth_info.owner,
-                            operator_sol_info.key)
+                        storage.unblock_accounts_and_destroy(program_id, trx_accounts)?
                     }
-                    let (gas_limit, gas_price) = storage.get_gas_params()?;
-                    let used_gas = call_results.1;
-                    if used_gas > gas_limit {
-                        return Err!(ProgramError::InvalidArgument);
-                    }
-                    let gas_price_wei = U256::from(gas_price);
-                    let fee = U256::from(used_gas)
-                        .checked_mul(gas_price_wei).ok_or_else(||E!(ProgramError::InvalidArgument))?;
-                    token::transfer_token(
-                        accounts,
-                        user_eth_info,
-                        operator_eth_info,
-                        account_storage.get_caller_account_info().ok_or_else(||E!(ProgramError::InvalidArgument))?,
-                        account_storage.get_caller_account().ok_or_else(||E!(ProgramError::InvalidArgument))?,
-                        &fee)?;
-
-                    applies_and_invokes(
-                        program_id,
-                        &mut account_storage,
-                        accounts,
-                        Some(operator_sol_info),
-                        call_results)?;
-
-                    storage.unblock_accounts_and_destroy(program_id, trx_accounts)?;
-                }
-
-                Ok(())
+                },
+                Err(err) => return Err(err)?,
             }
+            Ok(())
         },
     };
 
@@ -819,6 +786,52 @@ fn do_call<'a>(
     };
 
     Ok(Some(call_results))
+}
+
+fn do_begin<'a,'b>(
+    collateral_pool_index: u32,
+    step_count: u64,
+    from_addr: &'a [u8],
+    unsigned_msg: &'a [u8],
+    program_id: &Pubkey,
+    trx_accounts: &'b [AccountInfo<'b>],
+    operator_sol_info: &'b AccountInfo<'b>,
+    collateral_pool_sol_info: &'b AccountInfo<'b>,
+    storage_info: &'b AccountInfo<'b>,
+    system_info: &'b AccountInfo<'b>,
+    sysvar_info: &'b AccountInfo<'b>
+) -> ProgramResult
+{
+    let caller = H160::from_slice(from_addr);
+    let trx: UnsignedTransaction = rlp::decode(unsigned_msg).map_err(|e| E!(ProgramError::InvalidInstructionData; "DecoderError={:?}", e))?;
+    let trx_gas_limit = u64::try_from(trx.gas_limit).map_err(|e| E!(ProgramError::InvalidInstructionData; "e={:?}", e))?;
+    let trx_gas_price = u64::try_from(trx.gas_price).map_err(|e| E!(ProgramError::InvalidInstructionData; "e={:?}", e))?;
+    // if trx_gas_price < 1_u64 {
+    //     Err!(ProgramError::InvalidArgument; "trx_gas_price < 1_u64: {} ", trx_gas_price)
+    // }
+
+    let mut storage = StorageAccount::new(storage_info, operator_sol_info, trx_accounts, caller, trx.nonce, trx_gas_limit, trx_gas_price)?;
+    StorageAccount::check_for_blocked_accounts(program_id, trx_accounts)?;
+    let account_storage = ProgramAccountStorage::new(program_id, trx_accounts)?;
+    check_secp256k1_instruction(sysvar_info, unsigned_msg.len(), 13_u16)?;
+    check_ethereum_authority(
+        account_storage.get_caller_account().ok_or_else(|| E!(ProgramError::InvalidArgument))?,
+        &storage.caller_and_nonce()?.0, trx.nonce, &trx.chain_id)?;
+
+    payment::transfer_from_operator_to_collateral_pool(
+        program_id,
+        collateral_pool_index,
+        operator_sol_info,
+        collateral_pool_sol_info,
+        system_info)?;
+    payment::transfer_from_operator_to_deposit(
+        operator_sol_info,
+        storage_info,
+        system_info)?;
+
+    do_partial_call(&mut storage, step_count, &account_storage, trx_accounts, trx.call_data, trx.value, trx_gas_limit)?;
+
+    storage.block_accounts(program_id, trx_accounts)
 }
 
 fn do_partial_call<'a>(

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -584,9 +584,9 @@ fn process_instruction<'a>(
             match StorageAccount::restore(storage_info, operator_sol_info) {
                 Err(ProgramError::InvalidAccountData) => { // EXCLUDE Err!
                     do_begin(collateral_pool_index, step_count, from_addr, unsigned_msg,
-                             program_id, trx_accounts,
+                             program_id, trx_accounts, storage_info,
                              operator_sol_info, collateral_pool_sol_info,
-                             storage_info, system_info, sysvar_info)?
+                             system_info, sysvar_info)?;
                 },
                 Ok(mut storage) => {
                     storage.check_accounts(program_id, trx_accounts)?;
@@ -627,10 +627,10 @@ fn process_instruction<'a>(
                             Some(operator_sol_info),
                             call_results)?;
 
-                        storage.unblock_accounts_and_destroy(program_id, trx_accounts)?
+                        storage.unblock_accounts_and_destroy(program_id, trx_accounts)?;
                     }
                 },
-                Err(err) => return Err(err)?,
+                Err(err) => return Err(err),
             }
             Ok(())
         },
@@ -788,18 +788,19 @@ fn do_call<'a>(
     Ok(Some(call_results))
 }
 
-fn do_begin<'a,'b>(
+#[allow(clippy::too_many_arguments)]
+fn do_begin<'a>(
     collateral_pool_index: u32,
     step_count: u64,
-    from_addr: &'a [u8],
-    unsigned_msg: &'a [u8],
+    from_addr: &[u8],
+    unsigned_msg: &[u8],
     program_id: &Pubkey,
-    trx_accounts: &'b [AccountInfo<'b>],
-    operator_sol_info: &'b AccountInfo<'b>,
-    collateral_pool_sol_info: &'b AccountInfo<'b>,
-    storage_info: &'b AccountInfo<'b>,
-    system_info: &'b AccountInfo<'b>,
-    sysvar_info: &'b AccountInfo<'b>
+    trx_accounts: &'a [AccountInfo<'a>],
+    storage_info: &'a AccountInfo<'a>,
+    operator_sol_info: &'a AccountInfo<'a>,
+    collateral_pool_sol_info: &'a AccountInfo<'a>,
+    system_info: &'a AccountInfo<'a>,
+    sysvar_info: &'a AccountInfo<'a>
 ) -> ProgramResult
 {
     let caller = H160::from_slice(from_addr);

--- a/evm_loader/program/src/instruction.rs
+++ b/evm_loader/program/src/instruction.rs
@@ -173,6 +173,24 @@ pub enum EvmInstruction<'a> {
     /// Partial call Ethereum-contract action from raw transaction data
     /// ### Account references same as in PartialCallFromRawEthereumTX
     Cancel,
+
+    /// Partial call Ethereum-contract action from raw transaction data
+    /// or Continue
+    /// ### Account references
+    ///   0. \[WRITE\] storage account
+    ///   1. ... Account references same as in Call
+    PartialCallOrContinueFromRawEthereumTX {
+        /// Seed index for a collateral pool account
+        collateral_pool_index: u32,
+        /// Steps of ethereum contract to execute
+        step_count: u64,
+        /// Ethereum transaction sender address
+        from_addr: &'a [u8],
+        /// Ethereum transaction sign
+        sign: &'a [u8],
+        /// Unsigned ethereum transaction
+        unsigned_msg: &'a [u8],
+    },
 }
 
 
@@ -303,6 +321,15 @@ impl<'a> EvmInstruction<'a> {
             },
             12 => {
                 EvmInstruction::Cancel
+            },
+            13 => {
+                let (collateral_pool_index, rest) = rest.split_at(4);
+                let collateral_pool_index = collateral_pool_index.try_into().ok().map(u32::from_le_bytes).ok_or(InvalidInstructionData)?;
+                let (step_count, rest) = rest.split_at(8);
+                let step_count = step_count.try_into().ok().map(u64::from_le_bytes).ok_or(InvalidInstructionData)?;
+                let (from_addr, rest) = rest.split_at(20);
+                let (sign, unsigned_msg) = rest.split_at(65);
+                EvmInstruction::PartialCallOrContinueFromRawEthereumTX {collateral_pool_index, step_count, from_addr, sign, unsigned_msg}
             },
             _ => return Err(InvalidInstructionData),
         })

--- a/evm_loader/program/src/transaction.rs
+++ b/evm_loader/program/src/transaction.rs
@@ -64,7 +64,7 @@ pub fn check_secp256k1_instruction(sysvar_info: &AccountInfo, message_len: usize
                 return Err!(ProgramError::InvalidInstructionData; "wrong keccak instruction data, instruction={}, reference={}", &hex::encode(&instr.data), &hex::encode(&reference_instruction));
             }
         } else {
-            return Err!(ProgramError::IncorrectProgramId; "index={:?}, sysvar_info={:?}, instr.program_id={:?}", index, sysvar_info, instr.program_id);
+            return Err!(ProgramError::IncorrectProgramId; "Incorrect Program Id: index={:?}, sysvar_info={:?}, instr.program_id={:?}", index, sysvar_info, instr.program_id);
         }
     }
     else {

--- a/evm_loader/test_transaction.py
+++ b/evm_loader/test_transaction.py
@@ -1,17 +1,18 @@
-from solana.publickey import PublicKey
-from solana.transaction import AccountMeta, TransactionInstruction, Transaction
-from solana.rpc.types import TxOpts
 import unittest
-import base58
-from eth_account import Account as EthAccount
-from spl.token.instructions import get_associated_token_address
 
-from eth_tx_utils import make_keccak_instruction_data, make_instruction_data_from_tx
+import solana
+from base58 import b58decode
+
 from solana_utils import *
 
 CONTRACTS_DIR = os.environ.get("CONTRACTS_DIR", "evm_loader/")
 ETH_TOKEN_MINT_ID: PublicKey = PublicKey(os.environ.get("ETH_TOKEN_MINT"))
 evm_loader_id = os.environ.get("EVM_LOADER")
+INVALID_NONCE = 'Invalid Ethereum transaction nonce'
+INCORRECT_PROGRAM_ID = 'Incorrect Program Id'
+
+
+
 
 class EvmLoaderTestsNewAccount(unittest.TestCase):
     @classmethod
@@ -53,8 +54,19 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
         cls.collateral_pool_address = create_collateral_pool_address(collateral_pool_index)
         cls.collateral_pool_index_buf = collateral_pool_index.to_bytes(4, 'little')
 
+    def create_storage_account(self, seed):
+        storage = PublicKey(sha256(bytes(self.acc.public_key()) + bytes(seed, 'utf8') + bytes(PublicKey(evm_loader_id))).digest())
+        print("Storage", storage)
 
-    def test_success_tx_send(self):  
+        if getBalance(storage) == 0:
+            trx = Transaction()
+            trx.add(createAccountWithSeed(self.acc.public_key(), self.acc.public_key(), seed, 10**9, 128*1024, PublicKey(evm_loader_id)))
+            send_transaction(client, trx, self.acc)
+
+        return storage
+
+    # @unittest.skip("a.i.")
+    def test_01_success_tx_send(self):
         tx_1 = {
             'to': solana2ether(self.owner_contract),
             'value': 0,
@@ -100,7 +112,350 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
             ]))
         result = send_transaction(client, trx, self.acc)
 
-    # def test_fail_on_no_signature(self):  
+    # @unittest.skip("a.i.")
+    def test_02_success_tx_send_iteratively_in_3_solana_transactions_sequentially(self):
+        step_count = 100
+        tx_1 = {
+            'to': solana2ether(self.owner_contract),
+            'value': 0,
+            'gas': 9999999,
+            'gasPrice': 1_000_000_000,
+            'nonce': getTransactionCount(client, self.caller),
+            'data': '3917b3df',
+            'chainId': 111
+        }
+
+        (from_addr, sign, msg) = make_instruction_data_from_tx(tx_1, self.acc.secret_key())
+        keccak_instruction = make_keccak_instruction_data(1, len(msg), 13)
+        trx_data = self.caller_ether + sign + msg
+
+        storage = self.create_storage_account(sign[:8].hex())
+
+        trx = Transaction().add(
+            TransactionInstruction(program_id="KeccakSecp256k11111111111111111111111111111", data=keccak_instruction, keys=[
+                AccountMeta(pubkey=self.caller, is_signer=False, is_writable=False),
+            ])).add(
+            TransactionInstruction(program_id=self.loader.loader_id, data=bytearray.fromhex("0D") + self.collateral_pool_index_buf + step_count.to_bytes(8, byteorder='little') + trx_data, keys=[
+                # Storage account:
+                AccountMeta(pubkey=storage, is_signer=False, is_writable=True),
+                # System instructions account:
+                AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
+                # Operator address:
+                AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=True),
+                # Collateral pool address:
+                AccountMeta(pubkey=self.collateral_pool_address, is_signer=False, is_writable=True),
+                # Operator ETH address (stub for now):
+                AccountMeta(pubkey=get_associated_token_address(self.acc.public_key(), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+                # User ETH address (stub for now):
+                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+                # System program account:
+                AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
+
+                AccountMeta(pubkey=self.owner_contract, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.owner_contract), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.contract_code, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.caller, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+
+                AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
+                AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
+                AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
+            ]))
+        response = send_transaction(client, trx, self.acc)
+        print('response_1:', response)
+        response = send_transaction(client, trx, self.acc)
+        print('response_2:', response)
+        response = send_transaction(client, trx, self.acc)
+        print('response_3:', response)
+        self.assertEqual(response['result']['meta']['err'], None)
+        data = b58decode(response['result']['meta']['innerInstructions'][-1]['instructions'][-1]['data'])
+        self.assertEqual(data[0], 6)  # 6 means OnReturn,
+        self.assertLess(data[1], 0xd0)  # less 0xd0 - success
+        self.assertEqual(int().from_bytes(data[2:10], 'little'), 24301)  # used_gas
+
+    # @unittest.skip("a.i.")
+    def test_03_failure_tx_send_iteratively_in_4_solana_transactions_sequentially(self):
+        step_count = 100
+        tx_1 = {
+            'to': solana2ether(self.owner_contract),
+            'value': 0,
+            'gas': 9999999,
+            'gasPrice': 1_000_000_000,
+            'nonce': getTransactionCount(client, self.caller),
+            'data': '3917b3df',
+            'chainId': 111
+        }
+
+        (from_addr, sign, msg) = make_instruction_data_from_tx(tx_1, self.acc.secret_key())
+        keccak_instruction = make_keccak_instruction_data(1, len(msg), 13)
+        trx_data = self.caller_ether + sign + msg
+
+        storage = self.create_storage_account(sign[:8].hex())
+
+        trx = Transaction().add(
+            TransactionInstruction(program_id="KeccakSecp256k11111111111111111111111111111", data=keccak_instruction, keys=[
+                AccountMeta(pubkey=self.caller, is_signer=False, is_writable=False),
+            ])).add(
+            TransactionInstruction(program_id=self.loader.loader_id, data=bytearray.fromhex("0D") + self.collateral_pool_index_buf + step_count.to_bytes(8, byteorder='little') + trx_data, keys=[
+                # Storage account:
+                AccountMeta(pubkey=storage, is_signer=False, is_writable=True),
+                # System instructions account:
+                AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
+                # Operator address:
+                AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=True),
+                # Collateral pool address:
+                AccountMeta(pubkey=self.collateral_pool_address, is_signer=False, is_writable=True),
+                # Operator ETH address (stub for now):
+                AccountMeta(pubkey=get_associated_token_address(self.acc.public_key(), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+                # User ETH address (stub for now):
+                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+                # System program account:
+                AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
+
+                AccountMeta(pubkey=self.owner_contract, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.owner_contract), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.contract_code, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.caller, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+
+                AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
+                AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
+                AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
+            ]))
+        response = send_transaction(client, trx, self.acc)
+        print('response_1:', response)
+        response = send_transaction(client, trx, self.acc)
+        print('response_2:', response)
+        response = send_transaction(client, trx, self.acc)
+        print('response_3:', response)
+        try:
+            send_transaction(client, trx, self.acc)
+        except solana.rpc.api.SendTransactionError as err:
+            print('SendTransactionError:', str(err))
+            print('SendTransactionError result:', str(err.result))
+            response = json.loads(str(err.result).replace('\'', '\"').replace('None', 'null'))
+            print('response:', response)
+            print('code:', response['code'])
+            self.assertEqual(response['code'], -32002)
+            print('INVALID_NONCE:', INVALID_NONCE)
+            logs = response['data']['logs']
+            print('logs:', logs)
+            log = [s for s in logs if INVALID_NONCE in s][0]
+            print(log)
+            self.assertGreater(len(log), len(INVALID_NONCE))
+            file_name = 'src/entrypoint.rs'
+            self.assertTrue(file_name in log)
+            print('the ether transaction was completed by the previous three solana transactions')
+        except Exception as err:
+            print('type(err):', type(err))
+            print('err:', str(err))
+            self.assertTrue(False)
+
+    # @unittest.skip("a.i.")
+    def test_04_success_tx_send_iteratively_by_3_instructions_in_one_transaction(self):
+        step_count = 100
+        tx_1 = {
+            'to': solana2ether(self.owner_contract),
+            'value': 0,
+            'gas': 9999999,
+            'gasPrice': 1_000_000_000,
+            'nonce': getTransactionCount(client, self.caller),
+            'data': '3917b3df',
+            'chainId': 111
+        }
+
+        (from_addr, sign, msg) = make_instruction_data_from_tx(tx_1, self.acc.secret_key())
+        keccak_instruction = make_keccak_instruction_data(1, len(msg), 13)
+        trx_data = self.caller_ether + sign + msg
+
+        storage = self.create_storage_account(sign[:8].hex())
+
+        instruction = TransactionInstruction(program_id=self.loader.loader_id, data=bytearray.fromhex("0D") + self.collateral_pool_index_buf + step_count.to_bytes(8, byteorder='little') + trx_data, keys=[
+            # Storage account:
+            AccountMeta(pubkey=storage, is_signer=False, is_writable=True),
+            # System instructions account:
+            AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
+            # Operator address:
+            AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=True),
+            # Collateral pool address:
+            AccountMeta(pubkey=self.collateral_pool_address, is_signer=False, is_writable=True),
+            # Operator ETH address (stub for now):
+            AccountMeta(pubkey=get_associated_token_address(self.acc.public_key(), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+            # User ETH address (stub for now):
+            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+            # System program account:
+            AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
+
+            AccountMeta(pubkey=self.owner_contract, is_signer=False, is_writable=True),
+            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.owner_contract), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+            AccountMeta(pubkey=self.contract_code, is_signer=False, is_writable=True),
+            AccountMeta(pubkey=self.caller, is_signer=False, is_writable=True),
+            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+
+            AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
+            AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
+            AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
+        ])
+
+        trx = Transaction().add(
+            TransactionInstruction(program_id="KeccakSecp256k11111111111111111111111111111", data=keccak_instruction, keys=[
+                AccountMeta(pubkey=self.caller, is_signer=False, is_writable=False),
+            ]))\
+            .add(instruction)\
+            .add(instruction)\
+            .add(instruction)
+
+        response = send_transaction(client, trx, self.acc)
+        print('response:', response)
+        self.assertEqual(response['result']['meta']['err'], None)
+        data = b58decode(response['result']['meta']['innerInstructions'][-1]['instructions'][-1]['data'])
+        self.assertEqual(data[0], 6)  # 6 means OnReturn,
+        self.assertLess(data[1], 0xd0)  # less 0xd0 - success
+        self.assertEqual(int().from_bytes(data[2:10], 'little'), 24301)  # used_gas
+
+    # @unittest.skip("a.i.")
+    def test_05_failure_tx_send_iteratively_by_4_instructions_in_one_transaction(self):
+        step_count = 100
+        tx_1 = {
+            'to': solana2ether(self.owner_contract),
+            'value': 0,
+            'gas': 9999999,
+            'gasPrice': 1_000_000_000,
+            'nonce': getTransactionCount(client, self.caller),
+            'data': '3917b3df',
+            'chainId': 111
+        }
+
+        (from_addr, sign, msg) = make_instruction_data_from_tx(tx_1, self.acc.secret_key())
+        keccak_instruction = make_keccak_instruction_data(1, len(msg), 13)
+        trx_data = self.caller_ether + sign + msg
+
+        storage = self.create_storage_account(sign[:8].hex())
+
+        keccak_instruction = TransactionInstruction(program_id="KeccakSecp256k11111111111111111111111111111", data=keccak_instruction, keys=[
+            AccountMeta(pubkey=self.caller, is_signer=False, is_writable=False),
+        ])
+        instruction = TransactionInstruction(program_id=self.loader.loader_id, data=bytearray.fromhex("0D") + self.collateral_pool_index_buf + step_count.to_bytes(8, byteorder='little') + trx_data, keys=[
+            # Storage account:
+            AccountMeta(pubkey=storage, is_signer=False, is_writable=True),
+            # System instructions account:
+            AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
+            # Operator address:
+            AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=True),
+            # Collateral pool address:
+            AccountMeta(pubkey=self.collateral_pool_address, is_signer=False, is_writable=True),
+            # Operator ETH address (stub for now):
+            AccountMeta(pubkey=get_associated_token_address(self.acc.public_key(), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+            # User ETH address (stub for now):
+            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+            # System program account:
+            AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
+
+            AccountMeta(pubkey=self.owner_contract, is_signer=False, is_writable=True),
+            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.owner_contract), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+            AccountMeta(pubkey=self.contract_code, is_signer=False, is_writable=True),
+            AccountMeta(pubkey=self.caller, is_signer=False, is_writable=True),
+            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+
+            AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
+            AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
+            AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
+        ])
+
+        trx = Transaction()\
+            .add(keccak_instruction) \
+            .add(instruction) \
+            .add(instruction) \
+            .add(instruction) \
+            .add(instruction)
+
+        try:
+            send_transaction(client, trx, self.acc)
+        except solana.rpc.api.SendTransactionError as err:
+            print('SendTransactionError:', str(err))
+            print('SendTransactionError result:', str(err.result))
+            response = json.loads(str(err.result).replace('\"', '').replace('\'', '\"').replace('None', 'null'))
+            print('response:', response)
+            print('code:', response['code'])
+            self.assertEqual(response['code'], -32002)
+            print('INCORRECT_PROGRAM_ID:', INCORRECT_PROGRAM_ID)
+            logs = response['data']['logs']
+            print('logs:', logs)
+            log = [s for s in logs if INCORRECT_PROGRAM_ID in s][0]
+            print(log)
+            self.assertGreater(len(log), len(INCORRECT_PROGRAM_ID))
+            file_name = 'src/transaction.rs'
+            self.assertTrue(file_name in log)
+            print('the ether transaction was completed by the previous three instructions in the same solana transaction')
+        except Exception as err:
+            print('type(err):', type(err))
+            print('err:', str(err))
+            self.assertTrue(False)
+
+    # @unittest.skip("a.i.")
+    def test_06_failure_tx_send_iteratively_by_6_instructions_in_one_transaction(self):
+        step_count = 50
+        tx_1 = {
+            'to': solana2ether(self.owner_contract),
+            'value': 0,
+            'gas': 9999999,
+            'gasPrice': 1_000_000_000,
+            'nonce': getTransactionCount(client, self.caller),
+            'data': '3917b3df',
+            'chainId': 111
+        }
+
+        (from_addr, sign, msg) = make_instruction_data_from_tx(tx_1, self.acc.secret_key())
+        keccak_instruction = make_keccak_instruction_data(1, len(msg), 13)
+        trx_data = self.caller_ether + sign + msg
+
+        storage = self.create_storage_account(sign[:8].hex())
+
+        keccak_instruction = TransactionInstruction(program_id="KeccakSecp256k11111111111111111111111111111", data=keccak_instruction, keys=[
+            AccountMeta(pubkey=self.caller, is_signer=False, is_writable=False),
+        ])
+        instruction = TransactionInstruction(program_id=self.loader.loader_id, data=bytearray.fromhex("0D") + self.collateral_pool_index_buf + step_count.to_bytes(8, byteorder='little') + trx_data, keys=[
+            # Storage account:
+            AccountMeta(pubkey=storage, is_signer=False, is_writable=True),
+            # System instructions account:
+            AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
+            # Operator address:
+            AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=True),
+            # Collateral pool address:
+            AccountMeta(pubkey=self.collateral_pool_address, is_signer=False, is_writable=True),
+            # Operator ETH address (stub for now):
+            AccountMeta(pubkey=get_associated_token_address(self.acc.public_key(), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+            # User ETH address (stub for now):
+            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+            # System program account:
+            AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
+
+            AccountMeta(pubkey=self.owner_contract, is_signer=False, is_writable=True),
+            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.owner_contract), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+            AccountMeta(pubkey=self.contract_code, is_signer=False, is_writable=True),
+            AccountMeta(pubkey=self.caller, is_signer=False, is_writable=True),
+            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+
+            AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
+            AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
+            AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
+        ])
+
+        trx = Transaction() \
+            .add(keccak_instruction) \
+            .add(instruction) \
+            .add(instruction) \
+            .add(instruction) \
+            .add(instruction) \
+            .add(instruction) \
+            .add(instruction)
+
+        with self.assertRaisesRegex(RuntimeError, 'transaction too large'):
+            response = send_transaction(client, trx, self.acc)
+            print(response)
+
+
+    # def test_fail_on_no_signature(self):
     #     tx_1 = {
     #         'to': solana2ether(self.owner_contract),
     #         'value': 0,

--- a/evm_loader/test_transaction.py
+++ b/evm_loader/test_transaction.py
@@ -280,12 +280,13 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
             .add(neon_emv_instr_0d) \
             .add(neon_emv_instr_0d) \
             .add(neon_emv_instr_0d) \
-            .add(neon_emv_instr_0d) \
             .add(neon_emv_instr_0d)
 
         with self.assertRaisesRegex(RuntimeError, 'transaction too large'):
             response = send_transaction(client, trx, self.acc)
             print(response)
+
+        print('the solana transaction is too large')
 
     # def test_fail_on_no_signature(self):
     #     tx_1 = {

--- a/evm_loader/test_transaction.py
+++ b/evm_loader/test_transaction.py
@@ -12,8 +12,6 @@ INVALID_NONCE = 'Invalid Ethereum transaction nonce'
 INCORRECT_PROGRAM_ID = 'Incorrect Program Id'
 
 
-
-
 class EvmLoaderTestsNewAccount(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -40,10 +38,10 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
               "({})".format(bytes(PublicKey(cls.caller)).hex()))
 
         program_and_code = cls.loader.deployChecked(
-                CONTRACTS_DIR+'helloWorld.binary',
-                cls.caller,
-                cls.caller_ether
-            )
+            CONTRACTS_DIR + 'helloWorld.binary',
+            cls.caller,
+            cls.caller_ether
+        )
         cls.owner_contract = program_and_code[0]
         cls.contract_code = program_and_code[2]
 
@@ -55,19 +53,20 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
         cls.collateral_pool_index_buf = collateral_pool_index.to_bytes(4, 'little')
 
     def create_storage_account(self, seed):
-        storage = PublicKey(sha256(bytes(self.acc.public_key()) + bytes(seed, 'utf8') + bytes(PublicKey(evm_loader_id))).digest())
+        storage = PublicKey(
+            sha256(bytes(self.acc.public_key()) + bytes(seed, 'utf8') + bytes(PublicKey(evm_loader_id))).digest())
         print("Storage", storage)
 
         if getBalance(storage) == 0:
             trx = Transaction()
-            trx.add(createAccountWithSeed(self.acc.public_key(), self.acc.public_key(), seed, 10**9, 128*1024, PublicKey(evm_loader_id)))
+            trx.add(createAccountWithSeed(self.acc.public_key(), self.acc.public_key(), seed, 10 ** 9, 128 * 1024,
+                                          PublicKey(evm_loader_id)))
             send_transaction(client, trx, self.acc)
 
         return storage
 
-    # @unittest.skip("a.i.")
-    def test_01_success_tx_send(self):
-        tx_1 = {
+    def get_tx(self):
+        return {
             'to': solana2ether(self.owner_contract),
             'value': 0,
             'gas': 9999999,
@@ -77,90 +76,86 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
             'chainId': 111
         }
 
-        (from_addr, sign, msg) = make_instruction_data_from_tx(tx_1, self.acc.secret_key())
-        keccak_instruction = make_keccak_instruction_data(1, len(msg), 5)
+    def get_keccak_instruction_and_trx_data(self, data_start):
+        tx = self.get_tx()
+        (from_addr, sign, msg) = make_instruction_data_from_tx(tx, self.acc.secret_key())
+        keccak_instruction_data = make_keccak_instruction_data(1, len(msg), data_start)
         trx_data = self.caller_ether + sign + msg
 
-        trx = Transaction().add(
-            TransactionInstruction(program_id="KeccakSecp256k11111111111111111111111111111", data=keccak_instruction, keys=[
-                AccountMeta(pubkey=self.caller, is_signer=False, is_writable=False),
-            ])).add(
-            TransactionInstruction(program_id=self.loader.loader_id, data=bytearray.fromhex("05") + self.collateral_pool_index_buf + trx_data, keys=[
-                # Additional accounts for EvmInstruction::CallFromRawEthereumTX:
-                # System instructions account:
-                AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
-                # Operator address:
-                AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=True),
-                # Collateral pool address:
-                AccountMeta(pubkey=self.collateral_pool_address, is_signer=False, is_writable=True),
-                # Operator ETH address (stub for now):
-                AccountMeta(pubkey=get_associated_token_address(self.acc.public_key(), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-                # User ETH address (stub for now):
-                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-                # System program account:
-                AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
+        keccak_instruction = TransactionInstruction(program_id="KeccakSecp256k11111111111111111111111111111",
+                                                    data=keccak_instruction_data,
+                                                    keys=[AccountMeta(pubkey=self.caller, is_signer=False, is_writable=False)]
+                                                    )
+        return keccak_instruction, trx_data, sign
 
-                AccountMeta(pubkey=self.owner_contract, is_signer=False, is_writable=True),
-                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.owner_contract), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-                AccountMeta(pubkey=self.contract_code, is_signer=False, is_writable=True),
-                AccountMeta(pubkey=self.caller, is_signer=False, is_writable=True),
-                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+    def get_account_metas_for_instr_05(self):
+        return [
+            # System instructions account:
+            AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
+            # Operator address:
+            AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=True),
+            # Collateral pool address:
+            AccountMeta(pubkey=self.collateral_pool_address, is_signer=False, is_writable=True),
+            # Operator ETH address (stub for now):
+            AccountMeta(pubkey=get_associated_token_address(self.acc.public_key(), ETH_TOKEN_MINT_ID),
+                        is_signer=False, is_writable=True),
+            # User ETH address (stub for now):
+            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID),
+                        is_signer=False, is_writable=True),
+            # System program account:
+            AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
 
-                AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-            ]))
-        result = send_transaction(client, trx, self.acc)
+            AccountMeta(pubkey=self.owner_contract, is_signer=False, is_writable=True),
+            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.owner_contract), ETH_TOKEN_MINT_ID),
+                        is_signer=False, is_writable=True),
+            AccountMeta(pubkey=self.contract_code, is_signer=False, is_writable=True),
+            AccountMeta(pubkey=self.caller, is_signer=False, is_writable=True),
+            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID),
+                        is_signer=False, is_writable=True),
+
+            AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
+            AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
+            AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
+        ]
+
+    def get_account_metas_for_instr_0D(self, storage):
+        return [AccountMeta(pubkey=storage, is_signer=False, is_writable=True)] + self.get_account_metas_for_instr_05()
+
+    def neon_emv_instr_05(self, trx_data):
+        return TransactionInstruction(
+            program_id=self.loader.loader_id,
+            data=bytearray.fromhex("05") + self.collateral_pool_index_buf + trx_data,
+            keys=self.get_account_metas_for_instr_05()
+        )
+
+    def neon_emv_instr_0D(self, step_count, trx_data, storage):
+        return TransactionInstruction(
+            program_id=self.loader.loader_id,
+            data=bytearray.fromhex("0D") + self.collateral_pool_index_buf + step_count.to_bytes(8, byteorder='little') + trx_data,
+            keys=self.get_account_metas_for_instr_0D(storage)
+        )
+
+    # @unittest.skip("a.i.")
+    def test_01_success_tx_send(self):
+        (keccak_instruction, trx_data, sign) = self.get_keccak_instruction_and_trx_data(5)
+        trx = Transaction() \
+            .add(keccak_instruction) \
+            .add(self.neon_emv_instr_05(trx_data))
+
+        response = send_transaction(client, trx, self.acc)
+        print('response:', response)
 
     # @unittest.skip("a.i.")
     def test_02_success_tx_send_iteratively_in_3_solana_transactions_sequentially(self):
         step_count = 100
-        tx_1 = {
-            'to': solana2ether(self.owner_contract),
-            'value': 0,
-            'gas': 9999999,
-            'gasPrice': 1_000_000_000,
-            'nonce': getTransactionCount(client, self.caller),
-            'data': '3917b3df',
-            'chainId': 111
-        }
-
-        (from_addr, sign, msg) = make_instruction_data_from_tx(tx_1, self.acc.secret_key())
-        keccak_instruction = make_keccak_instruction_data(1, len(msg), 13)
-        trx_data = self.caller_ether + sign + msg
-
+        (keccak_instruction, trx_data, sign) = self.get_keccak_instruction_and_trx_data(13)
         storage = self.create_storage_account(sign[:8].hex())
+        neon_emv_instr_0d = self.neon_emv_instr_0D(step_count, trx_data, storage)
 
-        trx = Transaction().add(
-            TransactionInstruction(program_id="KeccakSecp256k11111111111111111111111111111", data=keccak_instruction, keys=[
-                AccountMeta(pubkey=self.caller, is_signer=False, is_writable=False),
-            ])).add(
-            TransactionInstruction(program_id=self.loader.loader_id, data=bytearray.fromhex("0D") + self.collateral_pool_index_buf + step_count.to_bytes(8, byteorder='little') + trx_data, keys=[
-                # Storage account:
-                AccountMeta(pubkey=storage, is_signer=False, is_writable=True),
-                # System instructions account:
-                AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
-                # Operator address:
-                AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=True),
-                # Collateral pool address:
-                AccountMeta(pubkey=self.collateral_pool_address, is_signer=False, is_writable=True),
-                # Operator ETH address (stub for now):
-                AccountMeta(pubkey=get_associated_token_address(self.acc.public_key(), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-                # User ETH address (stub for now):
-                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-                # System program account:
-                AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
+        trx = Transaction() \
+            .add(keccak_instruction) \
+            .add(neon_emv_instr_0d)
 
-                AccountMeta(pubkey=self.owner_contract, is_signer=False, is_writable=True),
-                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.owner_contract), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-                AccountMeta(pubkey=self.contract_code, is_signer=False, is_writable=True),
-                AccountMeta(pubkey=self.caller, is_signer=False, is_writable=True),
-                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-
-                AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-            ]))
         response = send_transaction(client, trx, self.acc)
         print('response_1:', response)
         response = send_transaction(client, trx, self.acc)
@@ -176,52 +171,14 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
     # @unittest.skip("a.i.")
     def test_03_failure_tx_send_iteratively_in_4_solana_transactions_sequentially(self):
         step_count = 100
-        tx_1 = {
-            'to': solana2ether(self.owner_contract),
-            'value': 0,
-            'gas': 9999999,
-            'gasPrice': 1_000_000_000,
-            'nonce': getTransactionCount(client, self.caller),
-            'data': '3917b3df',
-            'chainId': 111
-        }
-
-        (from_addr, sign, msg) = make_instruction_data_from_tx(tx_1, self.acc.secret_key())
-        keccak_instruction = make_keccak_instruction_data(1, len(msg), 13)
-        trx_data = self.caller_ether + sign + msg
-
+        (keccak_instruction, trx_data, sign) = self.get_keccak_instruction_and_trx_data(13)
         storage = self.create_storage_account(sign[:8].hex())
+        neon_emv_instr_0d = self.neon_emv_instr_0D(step_count, trx_data, storage)
 
-        trx = Transaction().add(
-            TransactionInstruction(program_id="KeccakSecp256k11111111111111111111111111111", data=keccak_instruction, keys=[
-                AccountMeta(pubkey=self.caller, is_signer=False, is_writable=False),
-            ])).add(
-            TransactionInstruction(program_id=self.loader.loader_id, data=bytearray.fromhex("0D") + self.collateral_pool_index_buf + step_count.to_bytes(8, byteorder='little') + trx_data, keys=[
-                # Storage account:
-                AccountMeta(pubkey=storage, is_signer=False, is_writable=True),
-                # System instructions account:
-                AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
-                # Operator address:
-                AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=True),
-                # Collateral pool address:
-                AccountMeta(pubkey=self.collateral_pool_address, is_signer=False, is_writable=True),
-                # Operator ETH address (stub for now):
-                AccountMeta(pubkey=get_associated_token_address(self.acc.public_key(), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-                # User ETH address (stub for now):
-                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-                # System program account:
-                AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
+        trx = Transaction() \
+            .add(keccak_instruction) \
+            .add(neon_emv_instr_0d)
 
-                AccountMeta(pubkey=self.owner_contract, is_signer=False, is_writable=True),
-                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.owner_contract), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-                AccountMeta(pubkey=self.contract_code, is_signer=False, is_writable=True),
-                AccountMeta(pubkey=self.caller, is_signer=False, is_writable=True),
-                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-
-                AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
-                AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-            ]))
         response = send_transaction(client, trx, self.acc)
         print('response_1:', response)
         response = send_transaction(client, trx, self.acc)
@@ -254,56 +211,15 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
     # @unittest.skip("a.i.")
     def test_04_success_tx_send_iteratively_by_3_instructions_in_one_transaction(self):
         step_count = 100
-        tx_1 = {
-            'to': solana2ether(self.owner_contract),
-            'value': 0,
-            'gas': 9999999,
-            'gasPrice': 1_000_000_000,
-            'nonce': getTransactionCount(client, self.caller),
-            'data': '3917b3df',
-            'chainId': 111
-        }
-
-        (from_addr, sign, msg) = make_instruction_data_from_tx(tx_1, self.acc.secret_key())
-        keccak_instruction = make_keccak_instruction_data(1, len(msg), 13)
-        trx_data = self.caller_ether + sign + msg
-
+        (keccak_instruction, trx_data, sign) = self.get_keccak_instruction_and_trx_data(13)
         storage = self.create_storage_account(sign[:8].hex())
+        neon_emv_instr_0d = self.neon_emv_instr_0D(step_count, trx_data, storage)
 
-        instruction = TransactionInstruction(program_id=self.loader.loader_id, data=bytearray.fromhex("0D") + self.collateral_pool_index_buf + step_count.to_bytes(8, byteorder='little') + trx_data, keys=[
-            # Storage account:
-            AccountMeta(pubkey=storage, is_signer=False, is_writable=True),
-            # System instructions account:
-            AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
-            # Operator address:
-            AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=True),
-            # Collateral pool address:
-            AccountMeta(pubkey=self.collateral_pool_address, is_signer=False, is_writable=True),
-            # Operator ETH address (stub for now):
-            AccountMeta(pubkey=get_associated_token_address(self.acc.public_key(), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-            # User ETH address (stub for now):
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-            # System program account:
-            AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
-
-            AccountMeta(pubkey=self.owner_contract, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.owner_contract), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-            AccountMeta(pubkey=self.contract_code, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=self.caller, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-
-            AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
-            AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
-            AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-        ])
-
-        trx = Transaction().add(
-            TransactionInstruction(program_id="KeccakSecp256k11111111111111111111111111111", data=keccak_instruction, keys=[
-                AccountMeta(pubkey=self.caller, is_signer=False, is_writable=False),
-            ]))\
-            .add(instruction)\
-            .add(instruction)\
-            .add(instruction)
+        trx = Transaction() \
+            .add(keccak_instruction) \
+            .add(neon_emv_instr_0d) \
+            .add(neon_emv_instr_0d) \
+            .add(neon_emv_instr_0d)
 
         response = send_transaction(client, trx, self.acc)
         print('response:', response)
@@ -316,58 +232,16 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
     # @unittest.skip("a.i.")
     def test_05_failure_tx_send_iteratively_by_4_instructions_in_one_transaction(self):
         step_count = 100
-        tx_1 = {
-            'to': solana2ether(self.owner_contract),
-            'value': 0,
-            'gas': 9999999,
-            'gasPrice': 1_000_000_000,
-            'nonce': getTransactionCount(client, self.caller),
-            'data': '3917b3df',
-            'chainId': 111
-        }
-
-        (from_addr, sign, msg) = make_instruction_data_from_tx(tx_1, self.acc.secret_key())
-        keccak_instruction = make_keccak_instruction_data(1, len(msg), 13)
-        trx_data = self.caller_ether + sign + msg
-
+        (keccak_instruction, trx_data, sign) = self.get_keccak_instruction_and_trx_data(13)
         storage = self.create_storage_account(sign[:8].hex())
+        neon_emv_instr_0d = self.neon_emv_instr_0D(step_count, trx_data, storage)
 
-        keccak_instruction = TransactionInstruction(program_id="KeccakSecp256k11111111111111111111111111111", data=keccak_instruction, keys=[
-            AccountMeta(pubkey=self.caller, is_signer=False, is_writable=False),
-        ])
-        instruction = TransactionInstruction(program_id=self.loader.loader_id, data=bytearray.fromhex("0D") + self.collateral_pool_index_buf + step_count.to_bytes(8, byteorder='little') + trx_data, keys=[
-            # Storage account:
-            AccountMeta(pubkey=storage, is_signer=False, is_writable=True),
-            # System instructions account:
-            AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
-            # Operator address:
-            AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=True),
-            # Collateral pool address:
-            AccountMeta(pubkey=self.collateral_pool_address, is_signer=False, is_writable=True),
-            # Operator ETH address (stub for now):
-            AccountMeta(pubkey=get_associated_token_address(self.acc.public_key(), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-            # User ETH address (stub for now):
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-            # System program account:
-            AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
-
-            AccountMeta(pubkey=self.owner_contract, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.owner_contract), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-            AccountMeta(pubkey=self.contract_code, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=self.caller, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-
-            AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
-            AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
-            AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-        ])
-
-        trx = Transaction()\
+        trx = Transaction() \
             .add(keccak_instruction) \
-            .add(instruction) \
-            .add(instruction) \
-            .add(instruction) \
-            .add(instruction)
+            .add(neon_emv_instr_0d) \
+            .add(neon_emv_instr_0d) \
+            .add(neon_emv_instr_0d) \
+            .add(neon_emv_instr_0d)
 
         try:
             send_transaction(client, trx, self.acc)
@@ -386,74 +260,32 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
             self.assertGreater(len(log), len(INCORRECT_PROGRAM_ID))
             file_name = 'src/transaction.rs'
             self.assertTrue(file_name in log)
-            print('the ether transaction was completed by the previous three instructions in the same solana transaction')
+            print(
+                'the ether transaction was completed by the previous three instructions in the same solana transaction')
         except Exception as err:
             print('type(err):', type(err))
             print('err:', str(err))
             self.assertTrue(False)
 
     # @unittest.skip("a.i.")
-    def test_06_failure_tx_send_iteratively_by_6_instructions_in_one_transaction(self):
-        step_count = 50
-        tx_1 = {
-            'to': solana2ether(self.owner_contract),
-            'value': 0,
-            'gas': 9999999,
-            'gasPrice': 1_000_000_000,
-            'nonce': getTransactionCount(client, self.caller),
-            'data': '3917b3df',
-            'chainId': 111
-        }
-
-        (from_addr, sign, msg) = make_instruction_data_from_tx(tx_1, self.acc.secret_key())
-        keccak_instruction = make_keccak_instruction_data(1, len(msg), 13)
-        trx_data = self.caller_ether + sign + msg
-
+    def test_06_failure_tx_send_iteratively_transaction_too_large(self):
+        step_count = 100
+        (keccak_instruction, trx_data, sign) = self.get_keccak_instruction_and_trx_data(13)
         storage = self.create_storage_account(sign[:8].hex())
-
-        keccak_instruction = TransactionInstruction(program_id="KeccakSecp256k11111111111111111111111111111", data=keccak_instruction, keys=[
-            AccountMeta(pubkey=self.caller, is_signer=False, is_writable=False),
-        ])
-        instruction = TransactionInstruction(program_id=self.loader.loader_id, data=bytearray.fromhex("0D") + self.collateral_pool_index_buf + step_count.to_bytes(8, byteorder='little') + trx_data, keys=[
-            # Storage account:
-            AccountMeta(pubkey=storage, is_signer=False, is_writable=True),
-            # System instructions account:
-            AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
-            # Operator address:
-            AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=True),
-            # Collateral pool address:
-            AccountMeta(pubkey=self.collateral_pool_address, is_signer=False, is_writable=True),
-            # Operator ETH address (stub for now):
-            AccountMeta(pubkey=get_associated_token_address(self.acc.public_key(), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-            # User ETH address (stub for now):
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-            # System program account:
-            AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
-
-            AccountMeta(pubkey=self.owner_contract, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.owner_contract), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-            AccountMeta(pubkey=self.contract_code, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=self.caller, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-
-            AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
-            AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
-            AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-        ])
+        neon_emv_instr_0d = self.neon_emv_instr_0D(step_count, trx_data, storage)
 
         trx = Transaction() \
             .add(keccak_instruction) \
-            .add(instruction) \
-            .add(instruction) \
-            .add(instruction) \
-            .add(instruction) \
-            .add(instruction) \
-            .add(instruction)
+            .add(neon_emv_instr_0d) \
+            .add(neon_emv_instr_0d) \
+            .add(neon_emv_instr_0d) \
+            .add(neon_emv_instr_0d) \
+            .add(neon_emv_instr_0d) \
+            .add(neon_emv_instr_0d)
 
         with self.assertRaisesRegex(RuntimeError, 'transaction too large'):
             response = send_transaction(client, trx, self.acc)
             print(response)
-
 
     # def test_fail_on_no_signature(self):
     #     tx_1 = {
@@ -465,10 +297,10 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
     #         'data': '3917b3df',
     #         'chainId': 1
     #     }
-        
+
     #     (from_addr, sign, msg) =  make_instruction_data_from_tx(tx_1, self.acc.get_acc().secret_key())
     #     keccak_instruction = make_keccak_instruction_data(1, len(msg), 1)
-        
+
     #     (caller, caller_nonce) = self.loader.ether2programAddress(from_addr)
     #     print(" ether: " + from_addr.hex())
     #     print("solana: " + caller)
@@ -489,8 +321,7 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
     #         ]))
     #     result = client.send_transaction(trx, self.acc.get_acc())
 
-
-    # def test_check_wo_checks(self):  
+    # def test_check_wo_checks(self):
     #     tx_1 = {
     #         'to': solana2ether(self.owner_contract),
     #         'value': 0,
@@ -500,7 +331,7 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
     #         'data': '3917b3df',
     #         'chainId': 1
     #     }
-        
+
     #     (from_addr, sign, msg) =  make_instruction_data_from_tx(tx_1, self.acc.get_acc().secret_key())
 
     #     keccak_instruction = make_keccak_instruction_data(1, len(msg), 1)
@@ -518,7 +349,7 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
 
     # def test_raw_tx_wo_checks(self):  
     #     tx_2 = "0xf86180808094535d33341d2ddcc6411701b1cf7634535f1e8d1680843917b3df26a013a4d8875dfc46a489c2641af798ec566d57852b94743b234517b73e239a5a22a07586d01a8a1125be7108ee6580c225a622c9baa0938f4d08abe78556c8674d58"
-        
+
     #     (from_addr, sign, msg) =  make_instruction_data_from_tx(tx_2)
 
     #     keccak_instruction = make_keccak_instruction_data(1, len(msg), 1)


### PR DESCRIPTION
Added a new instruction 0x0D and tests for it:

Test 1:
        trx = Transaction() \
            .add(keccak_instruction) \
            .add(neon_emv_instr_0d)
        response = send_transaction(client, trx, self.acc)
        response = send_transaction(client, trx, self.acc)
        response = send_transaction(client, trx, self.acc)
        **ethereum transaction successful executed**

Test 2:
        trx = Transaction() \
            .add(keccak_instruction) \
            .add(neon_emv_instr_0d)
        response = send_transaction(client, trx, self.acc)
        response = send_transaction(client, trx, self.acc)
        response = send_transaction(client, trx, self.acc)
        _ethereum transaction successful executed_
        response = send_transaction(client, trx, self.acc)
        **fail because of invalid nonce**

Test 3:
        trx = Transaction() \
            .add(keccak_instruction) \
            .add(neon_emv_instr_0d) \
            .add(neon_emv_instr_0d) \
            .add(neon_emv_instr_0d)
        response = send_transaction(client, trx, self.acc)
        **ethereum transaction successful executed**

Test 4:
        trx = Transaction() \
            .add(keccak_instruction) \
            .add(neon_emv_instr_0d) \
            .add(neon_emv_instr_0d) \
            .add(neon_emv_instr_0d) \ - ethereum transaction needs only 3 instructions
            .add(neon_emv_instr_0d) - the fourth is completely superfluous
        response = send_transaction(client, trx, self.acc)
        **fail because of incorrect program id**

Test 5:
        trx = Transaction() \
            .add(keccak_instruction) \
            .add(neon_emv_instr_0d) \
            .add(neon_emv_instr_0d) \
            .add(neon_emv_instr_0d) \ 
            .add(neon_emv_instr_0d) \ 
            .add(neon_emv_instr_0d) - a lot of instructions
        response = send_transaction(client, trx, self.acc)
        **sending fail because of transaction too large**