### PR TITLE
Introduce test_07_combined_continue_gets_before_the_creation_of_accounts

### DIFF
--- a/evm_loader/test_transaction.py
+++ b/evm_loader/test_transaction.py
@@ -79,19 +79,6 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
 
         return storage
 
-    def create_storage_account_2(self, seed):
-        storage = PublicKey(
-            sha256(bytes(self.acc_2.public_key()) + bytes(seed, 'utf8') + bytes(PublicKey(evm_loader_id))).digest())
-        print("Storage", storage)
-
-        if getBalance(storage) == 0:
-            trx = Transaction()
-            trx.add(createAccountWithSeed(self.acc_2.public_key(), self.acc_2.public_key(), seed, 10 ** 9, 128 * 1024,
-                                          PublicKey(evm_loader_id)))
-            send_transaction(client, trx, self.acc_2)
-
-        return storage
-
     def get_tx(self):
         return {
             'to': solana2ether(self.owner_contract),
@@ -196,8 +183,6 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
             AccountMeta(pubkey=self.loader_2.loader_id, is_signer=False, is_writable=False),
             AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
             AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
-            # User address:
-            # AccountMeta(pubkey=self.acc_2.public_key(), is_signer=False, is_writable=True),
         ]
 
     def get_account_metas_for_instr_0D(self, storage):
@@ -241,7 +226,7 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
         file_name = 'src/entrypoint.rs'
         self.assertTrue(file_name in log)
 
-    @unittest.skip("a.i.")
+    # @unittest.skip("a.i.")
     def test_01_success_tx_send(self):
         (keccak_instruction, trx_data, sign) = self.get_keccak_instruction_and_trx_data(5)
         trx = Transaction() \
@@ -251,7 +236,7 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
         response = send_transaction(client, trx, self.acc)
         print('response:', response)
 
-    @unittest.skip("a.i.")
+    # @unittest.skip("a.i.")
     def test_02_success_tx_send_iteratively_in_3_solana_transactions_sequentially(self):
         step_count = 100
         (keccak_instruction, trx_data, sign) = self.get_keccak_instruction_and_trx_data(13)
@@ -274,7 +259,7 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
         self.assertLess(data[1], 0xd0)  # less 0xd0 - success
         self.assertEqual(int().from_bytes(data[2:10], 'little'), 24301)  # used_gas
 
-    @unittest.skip("a.i.")
+    # @unittest.skip("a.i.")
     def test_03_failure_tx_send_iteratively_in_4_solana_transactions_sequentially(self):
         step_count = 100
         (keccak_instruction, trx_data, sign) = self.get_keccak_instruction_and_trx_data(13)
@@ -303,7 +288,7 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
             print('err:', str(err))
             self.assertTrue(False)
 
-    @unittest.skip("a.i.")
+    # @unittest.skip("a.i.")
     def test_04_success_tx_send_iteratively_by_3_instructions_in_one_transaction(self):
         step_count = 100
         (keccak_instruction, trx_data, sign) = self.get_keccak_instruction_and_trx_data(13)
@@ -324,7 +309,7 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
         self.assertLess(data[1], 0xd0)  # less 0xd0 - success
         self.assertEqual(int().from_bytes(data[2:10], 'little'), 24301)  # used_gas
 
-    @unittest.skip("a.i.")
+    # @unittest.skip("a.i.")
     def test_05_failure_tx_send_iteratively_by_4_instructions_in_one_transaction(self):
         step_count = 100
         (keccak_instruction, trx_data, sign) = self.get_keccak_instruction_and_trx_data(13)
@@ -362,7 +347,7 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
             print('err:', str(err))
             self.assertTrue(False)
 
-    @unittest.skip("a.i.")
+    # @unittest.skip("a.i.")
     def test_06_failure_tx_send_iteratively_transaction_too_large(self):
         step_count = 100
         (keccak_instruction, trx_data, sign) = self.get_keccak_instruction_and_trx_data(13)

--- a/evm_loader/test_transaction.py
+++ b/evm_loader/test_transaction.py
@@ -89,8 +89,10 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
             'chainId': 111
         }
 
-    def get_keccak_instruction_and_trx_data(self, data_start, secret_key, caller, caller_ether):
-        tx = self.get_tx(0)
+    def get_keccak_instruction_and_trx_data(self, data_start, secret_key, caller, caller_ether, trx_cnt=None):
+        if trx_cnt is None:
+            trx_cnt = getTransactionCount(client, self.caller)
+        tx = self.get_tx(trx_cnt)
         (from_addr, sign, msg) = make_instruction_data_from_tx(tx, secret_key)
         keccak_instruction_data = make_keccak_instruction_data(1, len(msg), data_start)
         trx_data = caller_ether + sign + msg
@@ -307,7 +309,7 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
     # @unittest.skip("a.i.")
     def test_07_combined_continue_gets_before_the_creation_of_accounts(self):
         step_count = 100
-        (keccak_instruction, trx_data, sign) = self.get_keccak_instruction_and_trx_data(13, self.acc_2.secret_key(), self.caller_2, self.caller_ether_2)
+        (keccak_instruction, trx_data, sign) = self.get_keccak_instruction_and_trx_data(13, self.acc_2.secret_key(), self.caller_2, self.caller_ether_2, 0)
         storage = self.create_storage_account(sign[:8].hex())
         neon_emv_instr_0d_2 = self.neon_emv_instr_0D(step_count, trx_data, storage, self.caller_2)
 

--- a/evm_loader/test_transaction.py
+++ b/evm_loader/test_transaction.py
@@ -62,7 +62,7 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
 
         # Create ethereum account for user 2 account
         cls.caller_ether_2 = eth_keys.PrivateKey(cls.acc_2.secret_key()).public_key.to_canonical_address()
-        (cls.caller_2, cls.caller_nonce_2) = cls.loader_2.ether2program(cls.caller_ether_2)
+        (cls.caller_2, cls.caller_nonce_2) = cls.loader.ether2program(cls.caller_ether_2)
         cls.caller_token_2 = get_associated_token_address(PublicKey(cls.caller_2), ETH_TOKEN_MINT_ID)
 
     def create_storage_account(self, seed):
@@ -323,7 +323,7 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
         if getBalance(self.caller_2) == 0:
             print("Send a transaction to create an account - wait for the confirmation and make sure of successful "
                   "completion")
-            _ = self.loader_2.createEtherAccount(self.caller_ether_2)
+            _ = self.loader.createEtherAccount(self.caller_ether_2)
             self.token.transfer(ETH_TOKEN_MINT_ID, 10, self.caller_token_2)
             print("Done\n")
 


### PR DESCRIPTION
Execution a contract by eth key pair at the first time give the following [response](https://buildkite.com/cyberway/evm-loader/builds/1466#090cc57c-6fa9-4176-a22e-a0fa2dac5543/35-2628)
```javascript
{
  'code': -32002,
  'message': 'Transaction simulation failed: Error processing Instruction 1: invalid program argument',
  'data': {
    'accounts': None,
    'err': {
      'InstructionError': [
        1,
        'InvalidArgument'
      ]
    },
    'logs': [
      'Program 53DfF883gyixYNXnM7s5xhdeyV8mVk9T4i2hGV9vG9io invoke [1]',
      'Program log: src/storage_account.rs:65',
      'Program log: src/account_storage.rs:156 : Caller could not be Solana user. It must be neon-evm owned account',
      'Program 53DfF883gyixYNXnM7s5xhdeyV8mVk9T4i2hGV9vG9io consumed 26875 of 200000000 compute units',
      'Program 53DfF883gyixYNXnM7s5xhdeyV8mVk9T4i2hGV9vG9io failed: invalid program argument'
    ]
  }
}
```