### PR TITLE
197 integration test for erc20 wrapper contract

### DIFF
--- a/evm_loader/cli/src/account_storage.rs
+++ b/evm_loader/cli/src/account_storage.rs
@@ -300,7 +300,9 @@ impl<'a> EmulatorAccountStorage<'a> {
                 }
             );
 
-            let target_token_exists = self.config.rpc_client.get_token_account_with_commitment(&transfer.target_token, CommitmentConfig::processed()).unwrap().value.is_some();
+            let ui_token_account = self.config.rpc_client.get_token_account_with_commitment(&transfer.target_token, CommitmentConfig::processed());
+            let target_token_exists = ui_token_account.map(|r| r.value.is_some()).unwrap_or(false);
+
             let (target_solana_address, _) = make_solana_program_address(&transfer.target, &self.config.evm_loader);
             token_accounts.entry(transfer.target_token).or_insert(
                 TokenAccount {

--- a/evm_loader/cli/src/account_storage.rs
+++ b/evm_loader/cli/src/account_storage.rs
@@ -535,6 +535,10 @@ impl<'a> AccountStorage for EmulatorAccountStorage<'a> {
 
     fn block_timestamp(&self) -> U256 { self.block_timestamp.into() }
 
+    fn get_account_solana_address(&self, address: &H160) -> Pubkey {
+        make_solana_program_address(address, &self.config.evm_loader).0
+    }
+
     fn external_call(
         &self,
         instruction: &Instruction

--- a/evm_loader/program/src/account_data.rs
+++ b/evm_loader/program/src/account_data.rs
@@ -454,3 +454,11 @@ impl ERC20Allowance {
     }
 }
 
+/// Returns PDA (program derived account) address for given Ethereum address.
+#[must_use]
+pub fn make_solana_program_address(
+    ether_address: &H160,
+    program_id: &Pubkey
+) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[&[ACCOUNT_SEED_VERSION], ether_address.as_bytes()], program_id)
+}

--- a/evm_loader/program/src/account_data.rs
+++ b/evm_loader/program/src/account_data.rs
@@ -453,12 +453,3 @@ impl ERC20Allowance {
         Self::SIZE
     }
 }
-
-/// Returns PDA (program derived account) address for given Ethereum address.
-#[must_use]
-pub fn make_solana_program_address(
-    ether_address: &H160,
-    program_id: &Pubkey
-) -> (Pubkey, u8) {
-    Pubkey::find_program_address(&[&[ACCOUNT_SEED_VERSION], ether_address.as_bytes()], program_id)
-}

--- a/evm_loader/program/src/account_storage.rs
+++ b/evm_loader/program/src/account_storage.rs
@@ -519,6 +519,10 @@ impl<'a> AccountStorage for ProgramAccountStorage<'a> {
         self.find_account(address).is_some()
     }
 
+    fn get_account_solana_address(&self, address: &H160) -> Pubkey {
+        self.get_account(address).unwrap().get_solana_address()
+    }
+
     fn external_call(
         &self,
         instruction: &Instruction

--- a/evm_loader/program/src/account_storage.rs
+++ b/evm_loader/program/src/account_storage.rs
@@ -486,15 +486,24 @@ impl<'a> AccountStorage for ProgramAccountStorage<'a> {
         where F: FnOnce(&SolidityAccount) -> U,
               D: FnOnce() -> U
     {
-        f(self.get_account(address).unwrap())
+        let account = self.get_account(address);
+        if let Some(account) = account {
+            f(account)
+        } else {
+            panic!("Solidity account {} must be present in the transaction", address)
+        }
     }
 
     fn apply_to_solana_account<U, D, F>(&self, address: &Pubkey, _d: D, f: F) -> U
         where F: FnOnce(/*data: */ &[u8], /*owner: */ &Pubkey) -> U,
               D: FnOnce() -> U
     {
-        let account_info = self.solana_accounts[address];
-        f(&account_info.data.borrow(), account_info.owner)
+        let account_info = self.solana_accounts.get(address);
+        if let Some(account_info) = account_info {
+            f(&account_info.data.borrow(), account_info.owner)
+        } else {
+            panic!("Solana account {} must be present in the transaction", address)
+        }
     }
 
     fn program_id(&self) -> &Pubkey { &self.program_id }
@@ -520,7 +529,12 @@ impl<'a> AccountStorage for ProgramAccountStorage<'a> {
     }
 
     fn get_account_solana_address(&self, address: &H160) -> Pubkey {
-        self.get_account(address).unwrap().get_solana_address()
+        let account = self.get_account(address);
+        if let Some(account) = account {
+            account.get_solana_address()
+        } else {
+            panic!("Solidity account {} must be present in the transaction", address)
+        }
     }
 
     fn external_call(

--- a/evm_loader/program/src/executor_state.rs
+++ b/evm_loader/program/src/executor_state.rs
@@ -818,14 +818,15 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
     #[must_use]
     pub fn erc20_balance_of(&self, mint: Pubkey, address: H160) -> U256
     {
-        match self.backend.get_account_solana_address(&address) {
-            None => U256::zero(),
-            Some(solana_address) => {
-                let token_account = get_associated_token_address(&solana_address, &mint);
-                let balance = self.substate.spl_balance(&token_account, self.backend);
-                U256::from(balance)
-            }
+        if !self.backend.exists(&address) {
+            return U256::zero();
         }
+
+        let solana_address = self.backend.get_account_solana_address(&address).unwrap();
+        let token_account = get_associated_token_address(&solana_address, &mint);
+
+        let balance = self.substate.spl_balance(&token_account, self.backend);
+        U256::from(balance)
     }
 
     fn erc20_emit_transfer_event(&mut self, contract: H160, source: H160, target: H160, value: u64) {

--- a/evm_loader/program/src/executor_state.rs
+++ b/evm_loader/program/src/executor_state.rs
@@ -822,7 +822,7 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
             return U256::zero();
         }
 
-        let solana_address = self.backend.get_account_solana_address(&address).unwrap();
+        let solana_address = self.backend.get_account_solana_address(&address);
         let token_account = get_associated_token_address(&solana_address, &mint);
 
         let balance = self.substate.spl_balance(&token_account, self.backend);
@@ -852,10 +852,10 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
         }
         let value = value.as_u64();
 
-        let source_solana = self.backend.get_account_solana_address(&source).unwrap();
+        let source_solana = self.backend.get_account_solana_address(&source);
         let source_token = get_associated_token_address(&source_solana, &mint);
 
-        let target_solana = self.backend.get_account_solana_address(&target).unwrap();
+        let target_solana = self.backend.get_account_solana_address(&target);
         let target_token = get_associated_token_address(&target_solana, &mint);
 
         let transfer = SplTransfer { source, target, mint, source_token, target_token, value };

--- a/evm_loader/program/src/executor_state.rs
+++ b/evm_loader/program/src/executor_state.rs
@@ -813,14 +813,19 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
         U256::from(supply)
     }
 
+    /// Returns the account balance of another account with `address`.
+    /// Returns zero if the account is not yet known.
     #[must_use]
     pub fn erc20_balance_of(&self, mint: Pubkey, address: H160) -> U256
     {
-        let solana_address = self.backend.get_account_solana_address(&address).unwrap();
-        let token_account = get_associated_token_address(&solana_address, &mint);
-
-        let balance = self.substate.spl_balance(&token_account, self.backend);
-        U256::from(balance)
+        match self.backend.get_account_solana_address(&address) {
+            None => U256::zero(),
+            Some(solana_address) => {
+                let token_account = get_associated_token_address(&solana_address, &mint);
+                let balance = self.substate.spl_balance(&token_account, self.backend);
+                U256::from(balance)
+            }
+        }
     }
 
     fn erc20_emit_transfer_event(&mut self, contract: H160, source: H160, target: H160, value: u64) {

--- a/evm_loader/program/src/executor_state.rs
+++ b/evm_loader/program/src/executor_state.rs
@@ -818,10 +818,6 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
     #[must_use]
     pub fn erc20_balance_of(&self, mint: Pubkey, address: H160) -> U256
     {
-        if !self.backend.exists(&address) {
-            return U256::zero();
-        }
-
         let solana_address = self.backend.get_account_solana_address(&address);
         let token_account = get_associated_token_address(&solana_address, &mint);
 

--- a/evm_loader/program/src/precompile_contracts.rs
+++ b/evm_loader/program/src/precompile_contracts.rs
@@ -109,10 +109,7 @@ fn solana_call<'a, B: AccountStorage>(input: &[u8], state: &mut ExecutorState<'a
                 let pubkey = if translate[0] == 0 {
                     Pubkey::new(pubkey)
                 } else {
-                    match backend.get_account_solana_address(&H160::from_slice(&pubkey[12..])) {
-                        Some(key) => key,
-                        None => { return Capture::Exit((ExitReason::Error(evm::ExitError::InvalidRange), Vec::new())); },
-                    }
+                    backend.get_account_solana_address(&H160::from_slice(&pubkey[12..]))
                 };
                 accounts.push(AccountMeta {
                     is_signer: signer[0] != 0,
@@ -145,19 +142,13 @@ fn solana_call<'a, B: AccountStorage>(input: &[u8], state: &mut ExecutorState<'a
             let base = if tr_base[0] == 0 {
                 Pubkey::new(base)
             } else {
-                match backend.get_account_solana_address(&H160::from_slice(&base[12..])) {
-                    Some(key) => key,
-                    None => { return Capture::Exit((ExitReason::Error(evm::ExitError::InvalidRange), Vec::new())); },
-                }
+                backend.get_account_solana_address(&H160::from_slice(&base[12..]))
             };
 
             let owner = if tr_owner[0] == 0 {
                 Pubkey::new(owner)
             } else {
-                match backend.get_account_solana_address(&H160::from_slice(&owner[12..])) {
-                    Some(key) => key,
-                    None => { return Capture::Exit((ExitReason::Error(evm::ExitError::InvalidRange), Vec::new())); },
-                }
+                backend.get_account_solana_address(&H160::from_slice(&owner[12..]))
             };
 
             let (_, seed) = input.split_at(66);

--- a/evm_loader/program/src/solana_backend.rs
+++ b/evm_loader/program/src/solana_backend.rs
@@ -43,6 +43,9 @@ pub trait AccountStorage {
     /// Get block timestamp
     fn block_timestamp(&self) -> U256;
 
+    /// Get solana address for given ethereum account
+    fn get_account_solana_address(&self, address: &H160) -> Pubkey;
+
     /// Get SPL token balance
     fn get_spl_token_balance(&self, token_account: &Pubkey) -> u64 {
         self.apply_to_solana_account(
@@ -84,19 +87,6 @@ pub trait AccountStorage {
         account_data
             .and_then(|d| d.get_erc20_allowance().ok().map(|a| a.value))
             .unwrap_or_else(U256::zero)
-    }
-
-    /// Get solana address for given ethereum account
-    fn get_account_solana_address(&self, address: &H160) -> Option<Pubkey> {
-        let make_solana_address = || {
-            let (sa, _) = crate::account_data::make_solana_program_address(address, self.program_id());
-            Some(sa)
-        };
-        self.apply_to_account(
-            address,
-            make_solana_address,
-            |account| Some(account.get_solana_address()),
-        )
     }
 
     /// Check if ethereum account exists

--- a/evm_loader/program/src/solana_backend.rs
+++ b/evm_loader/program/src/solana_backend.rs
@@ -70,7 +70,6 @@ pub trait AccountStorage {
         )
     }
 
-
     /// Get ERC20 allowance
     fn get_erc20_allowance(&self, owner: &H160, spender: &H160, mint: &Pubkey) -> U256 {
         let seeds: &[&[u8]] = &[&[ACCOUNT_SEED_VERSION], b"ERC20Allowance", &mint.to_bytes(), owner.as_bytes(), spender.as_bytes()];
@@ -89,16 +88,22 @@ pub trait AccountStorage {
 
     /// Get solana address for given ethereum account
     fn get_account_solana_address(&self, address: &H160) -> Option<Pubkey> {
+        let find_solana_address = || {
+            let (sa, _) = crate::account_data::make_solana_program_address(address, self.program_id());
+            Some(sa)
+        };
         self.apply_to_account(
             address,
-            || None,
+            find_solana_address,
             |account| Some(account.get_solana_address()),
         )
     }
+
     /// Check if ethereum account exists
     fn exists(&self, address: &H160) -> bool {
         self.apply_to_account(address, || false, |_| true)
     }
+
     /// Get account basic info (balance and nonce)
     fn basic(&self, address: &H160) -> Basic {
         self.apply_to_account(
@@ -110,6 +115,7 @@ pub trait AccountStorage {
             |account| account.basic(),
         )
     }
+
     /// Get code hash
     fn code_hash(&self, address: &H160) -> H256 {
         self.apply_to_account(
@@ -118,26 +124,32 @@ pub trait AccountStorage {
             |account| account.code_hash(),
         )
     }
+
     /// Get code size
     fn code_size(&self, address: &H160) -> usize {
         self.apply_to_account(address, || 0, |account| account.code_size())
     }
+
     /// Get code data
     fn code(&self, address: &H160) -> Vec<u8> {
         self.apply_to_account(address, Vec::new, |account| account.get_code())
     }
+
     /// Get valids data
     fn valids(&self, address: &H160) -> Vec<u8> {
         self.apply_to_account(address, Vec::new, |account| account.get_valids())
     }
+
     /// Get data from storage
     fn storage(&self, address: &H160, index: &U256) -> U256 {
         self.apply_to_account(address, U256::zero, |account| account.get_storage(index))
     }
+
     /// Get account seeds
     fn seeds(&self, address: &H160) -> Option<(H160, u8)> {
         self.apply_to_account(address, || None, |account| Some(account.get_seeds()))
     }
+
     /// External call
     /// # Errors
     /// Will return `Err` if the external call returns err

--- a/evm_loader/program/src/solana_backend.rs
+++ b/evm_loader/program/src/solana_backend.rs
@@ -88,13 +88,13 @@ pub trait AccountStorage {
 
     /// Get solana address for given ethereum account
     fn get_account_solana_address(&self, address: &H160) -> Option<Pubkey> {
-        let find_solana_address = || {
+        let make_solana_address = || {
             let (sa, _) = crate::account_data::make_solana_program_address(address, self.program_id());
             Some(sa)
         };
         self.apply_to_account(
             address,
-            find_solana_address,
+            make_solana_address,
             |account| Some(account.get_solana_address()),
         )
     }

--- a/evm_loader/program/src/solidity_account.rs
+++ b/evm_loader/program/src/solidity_account.rs
@@ -41,7 +41,7 @@ impl<'a> SolidityAccount<'a> {
         let balance = U256::from(balance);
         let balance = balance * min_value;
 
-        debug_print!("  SolidityAccount::new solana_adress={} balance={}", solana_address, balance);
+        debug_print!("  SolidityAccount::new solana_address={} balance={}", solana_address, balance);
         Self{account_data, solana_address, code_data, balance}
     }
 


### PR DESCRIPTION
Implementation of the ERC20 Wrapper has to support balanceOf and transfer for arbitrary Ethereum addresses.

The emulator should initiate creation of corresponding Solana accounts.