### PR TITLE
Introduce test_03_create2_opcode_by_0x0e_without_accounts

### DIFF
--- a/evm_loader/test_nested_call.py
+++ b/evm_loader/test_nested_call.py
@@ -45,10 +45,8 @@ class EventTest(unittest.TestCase):
         cls.loader = EvmLoader(wallet, evm_loader_id)
         cls.acc = wallet.get_acc()
 
-        # Create ethereum account for user account
-        user_wallet = RandomAccount()
-        cls.user_acc = user_wallet.get_acc()
-        cls.caller_ether = eth_keys.PrivateKey(cls.user_acc.secret_key()).public_key.to_canonical_address()
+        # Create ethereum account for operator account
+        cls.caller_ether = eth_keys.PrivateKey(cls.acc.secret_key()).public_key.to_canonical_address()
         (cls.caller, cls.caller_nonce) = cls.loader.ether2program(cls.caller_ether)
 
         if getBalance(cls.caller) < 20:
@@ -57,7 +55,7 @@ class EventTest(unittest.TestCase):
             cls.token.transfer(ETH_TOKEN_MINT_ID, 20, get_associated_token_address(PublicKey(cls.caller), ETH_TOKEN_MINT_ID))
             print("Done\n")
 
-        print('Account:', cls.user_acc.public_key(), bytes(cls.user_acc.public_key()).hex())
+        print('Account:', cls.acc.public_key(), bytes(cls.acc.public_key()).hex())
         print("Caller:", cls.caller_ether.hex(), cls.caller_nonce, "->", cls.caller,
               "({})".format(bytes(PublicKey(cls.caller)).hex()))
 
@@ -97,7 +95,7 @@ class EventTest(unittest.TestCase):
         cls.collateral_pool_index_buf = collateral_pool_index.to_bytes(4, 'little')
 
         cls.holder = create_storage_account(cls.acc, '1236')
-        cls.storage = create_storage_account(cls.acc)
+        cls.storage = create_storage_account(cls.acc, '123435456776')
 
     def sol_instr_keccak(self, keccak_instruction):
         return TransactionInstruction(program_id=keccakprog, data=keccak_instruction, keys=[
@@ -298,7 +296,7 @@ class EventTest(unittest.TestCase):
         tx = {'to': solana2ether(contract), 'value': 0, 'gas': 9_999_999, 'gasPrice': 1_000_000_000,
               'nonce': getTransactionCount(http_client, self.caller), 'data': input, 'chainId': 111}
 
-        (from_addr, sign, msg) = make_instruction_data_from_tx(tx, self.user_acc.secret_key())
+        (from_addr, sign, msg) = make_instruction_data_from_tx(tx, self.acc.secret_key())
         assert (from_addr == self.caller_ether)
         instruction = from_addr + sign + msg
 
@@ -321,7 +319,7 @@ class EventTest(unittest.TestCase):
         tx = {'to': solana2ether(contract), 'value': 0, 'gas': 9999999, 'gasPrice': 1_000_000_000,
             'nonce': getTransactionCount(http_client, self.caller), 'data': input, 'chainId': 111}
 
-        (from_addr, sign, msg) = make_instruction_data_from_tx(tx, self.user_acc.secret_key())
+        (from_addr, sign, msg) = make_instruction_data_from_tx(tx, self.acc.secret_key())
         assert (from_addr == self.caller_ether)
 
         self.write_transaction_to_holder_account(self.holder, sign, msg)
@@ -345,7 +343,7 @@ class EventTest(unittest.TestCase):
         tx = {'to': solana2ether(contract), 'value': 0, 'gas': 9999999, 'gasPrice': 1_000_000_000,
               'nonce': getTransactionCount(http_client, self.caller), 'data': input, 'chainId': 111}
 
-        (from_addr, sign, msg) = make_instruction_data_from_tx(tx, self.user_acc.secret_key())
+        (from_addr, sign, msg) = make_instruction_data_from_tx(tx, self.acc.secret_key())
         assert (from_addr == self.caller_ether)
 
         self.write_transaction_to_holder_account(self.holder, sign, msg)

--- a/evm_loader/test_nested_call.py
+++ b/evm_loader/test_nested_call.py
@@ -1,4 +1,6 @@
 import unittest
+from random import randrange
+
 from base58 import b58decode
 from solana_utils import *
 from eth_tx_utils import make_keccak_instruction_data, make_instruction_data_from_tx, Trx
@@ -18,6 +20,21 @@ evm_loader_id = os.environ.get("EVM_LOADER")
 # evm_loader_id = "7NXfEKTMhPdkviCjWipXxUtkEMDRzPJMQnz39aRMCwb1"
 
 
+def get_recent_account_balance(code_account_address):
+    return http_client.get_balance(code_account_address, commitment='recent')['result']['value']
+
+
+def create_storage_account(operator_acc, seed=str(randrange(1000000000))):
+    storage = PublicKey(sha256(bytes(operator_acc.public_key()) + bytes(seed, 'utf8') + bytes(PublicKey(evm_loader_id))).digest())
+    print("Storage", storage)
+    minimum_balance = client.get_minimum_balance_for_rent_exemption(128*1024, commitment=Confirmed)["result"]
+    if get_recent_account_balance(storage) == 0:
+        trx = Transaction()
+        trx.add(createAccountWithSeed(operator_acc.public_key(), operator_acc.public_key(), seed, minimum_balance, 128*1024, PublicKey(evm_loader_id)))
+        send_transaction(client, trx, operator_acc)
+    return storage
+
+
 class EventTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -29,16 +46,18 @@ class EventTest(unittest.TestCase):
         cls.acc = wallet.get_acc()
 
         # Create ethereum account for user account
-        cls.caller_ether = eth_keys.PrivateKey(cls.acc.secret_key()).public_key.to_canonical_address()
+        user_wallet = RandomAccount()
+        cls.user_acc = user_wallet.get_acc()
+        cls.caller_ether = eth_keys.PrivateKey(cls.user_acc.secret_key()).public_key.to_canonical_address()
         (cls.caller, cls.caller_nonce) = cls.loader.ether2program(cls.caller_ether)
 
-        if getBalance(cls.caller) == 0:
+        if getBalance(cls.caller) < 20:
             print("Create caller account...")
             _ = cls.loader.createEtherAccount(cls.caller_ether)
-            cls.token.transfer(ETH_TOKEN_MINT_ID, 2000, get_associated_token_address(PublicKey(cls.caller), ETH_TOKEN_MINT_ID))
+            cls.token.transfer(ETH_TOKEN_MINT_ID, 20, get_associated_token_address(PublicKey(cls.caller), ETH_TOKEN_MINT_ID))
             print("Done\n")
 
-        print('Account:', cls.acc.public_key(), bytes(cls.acc.public_key()).hex())
+        print('Account:', cls.user_acc.public_key(), bytes(cls.user_acc.public_key()).hex())
         print("Caller:", cls.caller_ether.hex(), cls.caller_nonce, "->", cls.caller,
               "({})".format(bytes(PublicKey(cls.caller)).hex()))
 
@@ -77,6 +96,8 @@ class EventTest(unittest.TestCase):
         cls.collateral_pool_address = create_collateral_pool_address(collateral_pool_index)
         cls.collateral_pool_index_buf = collateral_pool_index.to_bytes(4, 'little')
 
+        cls.holder = create_storage_account(cls.acc, '1236')
+        cls.storage = create_storage_account(cls.acc)
 
     def sol_instr_keccak(self, keccak_instruction):
         return TransactionInstruction(program_id=keccakprog, data=keccak_instruction, keys=[
@@ -174,9 +195,9 @@ class EventTest(unittest.TestCase):
 
                 # Operator address:
                 AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=True),
-                # User ETH address (stub for now):
+                # Operator ETH address:
                 AccountMeta(pubkey=get_associated_token_address(self.acc.public_key(), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
-                # User ETH address (stub for now):
+                # User ETH address:
                 AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
                 # System program account:
                 AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
@@ -207,15 +228,50 @@ class EventTest(unittest.TestCase):
                 AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
             ])
 
-    def create_account_with_seed(self, seed):
-        storage = accountWithSeed(self.acc.public_key(), seed, PublicKey(evm_loader_id))
+    def sol_instr_14_combined_call_continue_from_account(self, holder_account, storage_account, step_count, contract, code):
+        return TransactionInstruction(
+            program_id=self.loader.loader_id,
+            data=bytearray.fromhex("0E") + self.collateral_pool_index_buf + step_count.to_bytes(8, byteorder='little'),
+            keys=[
+                AccountMeta(pubkey=holder_account, is_signer=False, is_writable=False),
+                AccountMeta(pubkey=storage_account, is_signer=False, is_writable=True),
 
-        if getBalance(storage) == 0:
-            trx = Transaction()
-            trx.add(createAccountWithSeed(self.acc.public_key(), self.acc.public_key(), seed, 10**9, 128*1024, PublicKey(evm_loader_id)))
-            http_client.send_transaction(trx, self.acc, opts=TxOpts(skip_confirmation=False))
+                # Operator address:
+                AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=True),
+                # Collateral pool address:
+                AccountMeta(pubkey=self.collateral_pool_address, is_signer=False, is_writable=True),
+                # Operator ETH address:
+                AccountMeta(pubkey=get_associated_token_address(self.acc.public_key(), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+                # User ETH address:
+                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+                # System program account:
+                AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
 
-        return storage
+                AccountMeta(pubkey=contract, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=get_associated_token_address(PublicKey(contract), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+                AccountMeta(pubkey=code, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.caller, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.reId_caller, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.reId_caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.reId_caller_code, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.reId_reciever, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.reId_reciever), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.reId_reciever_code, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.reId_recover, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.reId_recover), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.reId_recover_code, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.reId_create_receiver, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.reId_create_receiver), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.reId_create_receiver_code_account, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.reId_revert, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.reId_revert), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.reId_revert_code, is_signer=False, is_writable=True),
+
+                AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
+                AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
+                AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
+            ])
 
     def write_transaction_to_holder_account(self, holder, signature, message):
         message = signature + len(message).to_bytes(8, byteorder="little") + message
@@ -239,58 +295,97 @@ class EventTest(unittest.TestCase):
             confirm_transaction(http_client, rcpt)
 
     def call_partial_signed(self, input, contract, code):
-        tx = {'to': solana2ether(contract), 'value': 0, 'gas': 9999999, 'gasPrice': 1_000_000_000,
-            'nonce': getTransactionCount(http_client, self.caller), 'data': input, 'chainId': 111}
+        tx = {'to': solana2ether(contract), 'value': 0, 'gas': 9_999_999, 'gasPrice': 1_000_000_000,
+              'nonce': getTransactionCount(http_client, self.caller), 'data': input, 'chainId': 111}
 
-        (from_addr, sign, msg) = make_instruction_data_from_tx(tx, self.acc.secret_key())
+        (from_addr, sign, msg) = make_instruction_data_from_tx(tx, self.user_acc.secret_key())
         assert (from_addr == self.caller_ether)
         instruction = from_addr + sign + msg
 
-        storage = self.create_account_with_seed(sign[:8].hex())
-
         trx = Transaction()
         trx.add(self.sol_instr_keccak(make_keccak_instruction_data(1, len(msg), 13)))
-        trx.add(self.sol_instr_09_partial_call(storage, 0, instruction, contract, code))
+        trx.add(self.sol_instr_09_partial_call(self.storage, 0, instruction, contract, code))
         send_transaction(http_client, trx, self.acc)
 
-        while (True):
+        while True:
             print("Continue")
-            trx = Transaction().add(self.sol_instr_10_continue(storage, 400, contract, code))
+            trx = Transaction().add(self.sol_instr_10_continue(self.storage, 400, contract, code))
             result = send_transaction(http_client, trx, self.acc)["result"]
 
-            if (result['meta']['innerInstructions'] and result['meta']['innerInstructions'][0]['instructions']):
-                data = b58decode(result['meta']['innerInstructions'][0]['instructions'][-1]['data'])
-                if (data[0] == 6):
+            if result['meta']['innerInstructions'] and result['meta']['innerInstructions'][-1]['instructions']:
+                data = b58decode(result['meta']['innerInstructions'][-1]['instructions'][-1]['data'])
+                if data[0] == 6:
                     return result
 
     def call_with_holder_account(self, input, contract, code):
         tx = {'to': solana2ether(contract), 'value': 0, 'gas': 9999999, 'gasPrice': 1_000_000_000,
             'nonce': getTransactionCount(http_client, self.caller), 'data': input, 'chainId': 111}
 
-        (from_addr, sign, msg) = make_instruction_data_from_tx(tx, self.acc.secret_key())
+        (from_addr, sign, msg) = make_instruction_data_from_tx(tx, self.user_acc.secret_key())
         assert (from_addr == self.caller_ether)
 
-        holder = self.create_account_with_seed("1236")
-        storage = self.create_account_with_seed(sign[:8].hex())
-
-        self.write_transaction_to_holder_account(holder, sign, msg)
+        self.write_transaction_to_holder_account(self.holder, sign, msg)
 
         trx = Transaction()
-        trx.add(self.sol_instr_11_partial_call_from_account(holder, storage, 0, contract, code))
+        trx.add(self.sol_instr_11_partial_call_from_account(self.holder, self.storage, 0, contract, code))
         send_transaction(http_client, trx, self.acc)
 
         while (True):
             print("Continue")
             trx = Transaction()
-            trx.add(self.sol_instr_10_continue(storage, 400, contract, code))
+            trx.add(self.sol_instr_10_continue(self.storage, 400, contract, code))
             result = send_transaction(http_client, trx, self.acc)["result"]
-            
-            if (result['meta']['innerInstructions'] and result['meta']['innerInstructions'][0]['instructions']):
-                data = b58decode(result['meta']['innerInstructions'][0]['instructions'][-1]['data'])
+
+            if (result['meta']['innerInstructions'] and result['meta']['innerInstructions'][-1]['instructions']):
+                data = b58decode(result['meta']['innerInstructions'][-1]['instructions'][-1]['data'])
                 if (data[0] == 6):
                     return result
 
-    def test_callFoo(self):
+    def call_with_holder_account_0x0e(self, input, contract, code):
+        tx = {'to': solana2ether(contract), 'value': 0, 'gas': 9999999, 'gasPrice': 1_000_000_000,
+              'nonce': getTransactionCount(http_client, self.caller), 'data': input, 'chainId': 111}
+
+        (from_addr, sign, msg) = make_instruction_data_from_tx(tx, self.user_acc.secret_key())
+        assert (from_addr == self.caller_ether)
+
+        self.write_transaction_to_holder_account(self.holder, sign, msg)
+
+        trx = Transaction()
+        trx.add(self.sol_instr_14_combined_call_continue_from_account(self.holder, self.storage, 200, contract, code))
+        send_transaction(http_client, trx, self.acc)
+
+        while (True):
+            print("Combined Continue")
+            result = send_transaction(http_client, trx, self.acc)["result"]
+
+            if (result['meta']['innerInstructions'] and result['meta']['innerInstructions'][-1]['instructions']):
+                data = b58decode(result['meta']['innerInstructions'][-1]['instructions'][-1]['data'])
+                if (data[0] == 6):
+                    return result
+
+    def create_code_account_if_zero_balance(self, seed, code_account_address):
+        if get_recent_account_balance(code_account_address) == 0:
+            trx = Transaction()
+            trx.add(
+                createAccountWithSeed(self.acc.public_key(),
+                                      self.acc.public_key(),
+                                      seed,
+                                      10 ** 9,
+                                      4096 + 4 * 1024,
+                                      PublicKey(evm_loader_id)))
+            res = http_client.send_transaction(trx, self.acc, opts=TxOpts(skip_confirmation=False, preflight_commitment="root"))["result"]
+
+    def create_code_owner_account_if_zero_balance(self, code_owner_account_address, code_owner_account_eth_address, code_account_address):
+        if get_recent_account_balance(code_owner_account_address) == 0:
+            trx = Transaction()
+            trx.add(
+                self.loader.createEtherAccountTrx(code_owner_account_eth_address, code_account_address)[0]
+            )
+            res = http_client.send_transaction(trx, self.acc, opts=TxOpts(skip_confirmation=False, preflight_commitment="root"))["result"]
+
+    # @unittest.skip("a.i.")
+    def test_01_callFoo(self):
+        print('\ntest_01_callFoo')
         func_name = abi.function_signature_to_4byte_selector('callFoo(address)')
         data = (func_name + bytes.fromhex("%024x" % 0x0 + self.reId_reciever_eth.hex()))
         result = self.call_partial_signed(input=data, contract=self.reId_caller, code=self.reId_caller_code)
@@ -325,7 +420,9 @@ class EventTest(unittest.TestCase):
         self.assertEqual(data[125:157], bytes.fromhex("%062x" %0x0 + "20"))
         self.assertEqual(data[157:189], bytes.fromhex("%062x" %0x0 + hex(124)[2:]))
 
-    def test_ecrecover(self):
+    # @unittest.skip("a.i.")
+    def test_02_ecrecover(self):
+        print('\ntest_02_ecrecover')
         tx = {'to': solana2ether(self.reId_caller), 'value': 0, 'gas': 9999999, 'gasPrice': 1_000_000_000,
               'nonce': getTransactionCount(client, self.caller), 'data': bytes().fromhex("001122"), 'chainId': 111}
 
@@ -382,25 +479,87 @@ class EventTest(unittest.TestCase):
         self.assertEqual(data[125:157], bytes.fromhex("%062x" %0x0 + "20"))
         self.assertEqual(data[157:189], bytes.fromhex("%062x" %0x0 + "01"))
 
-    def test_create2_opcode(self):
-        if http_client.get_balance(self.reId_create_receiver_code_account, commitment='recent')['result']['value'] == 0:
-            trx = Transaction()
-            trx.add(
-                createAccountWithSeed(self.acc.public_key(),
-                                      self.acc.public_key(),
-                                      self.reId_create_receiver_seed,
-                                      10 ** 9,
-                                      4096 + 4 * 1024,
-                                      PublicKey(evm_loader_id)))
-            res = http_client.send_transaction(trx, self.acc, opts=TxOpts(skip_confirmation=False, preflight_commitment="root"))["result"]
+    # @unittest.skip("a.i.")
+    def test_03_create2_opcode_by_0x0e_without_accounts(self):
+        print('\ntest_03_create2_opcode_by_0x0e_without_accounts')
+        print('Check zero balance of code account:', self.reId_create_receiver_code_account)
+        self.assertEqual(get_recent_account_balance(self.reId_create_receiver_code_account), 0)
+        print('Ok: balance of code account is zero')
+        # self.create_code_account_if_zero_balance(self.reId_create_receiver_seed, self.reId_create_receiver_code_account)
 
-        if http_client.get_balance(self.reId_create_receiver, commitment='recent')['result']['value'] == 0:
-            trx = Transaction()
-            trx.add(
-                self.loader.createEtherAccountTrx(self.reId_create_receiver_eth, self.reId_create_receiver_code_account)[0]
-            )
-            res = http_client.send_transaction(trx, self.acc, opts=TxOpts(skip_confirmation=False, preflight_commitment="root"))["result"]
+        print('Check zero balance of code owner account:', self.reId_create_receiver)
+        self.assertEqual(get_recent_account_balance(self.reId_create_receiver), 0)
+        print('Ok: balance of code owner account is zero')
+        # self.create_code_owner_account_if_zero_balance(self.reId_create_receiver, self.reId_create_receiver_eth, self.reId_create_receiver_code_account)
 
+        func_name = abi.function_signature_to_4byte_selector('creator()')
+        print("Expecting Exception: Program failed to complete")
+        with self.assertRaisesRegex(Exception, 'Program failed to complete'):
+            response = self.call_with_holder_account_0x0e(input=func_name, contract=self.reId_create_caller, code=self.reId_create_caller_code)
+            print('response:', response)
+
+        print('Check zero balance of code account:', self.reId_create_receiver_code_account)
+        self.assertEqual(get_recent_account_balance(self.reId_create_receiver_code_account), 0)
+        print('Ok: balance of code account is zero')
+        print('Create code account:', self.reId_create_receiver_code_account)
+        self.create_code_account_if_zero_balance(self.reId_create_receiver_seed, self.reId_create_receiver_code_account)
+        self.assertGreater(get_recent_account_balance(self.reId_create_receiver_code_account), 0)
+        print('Ok: code account has been created')
+
+        print('Check zero balance of code owner account:', self.reId_create_receiver)
+        self.assertEqual(get_recent_account_balance(self.reId_create_receiver), 0)
+        print('Ok: balance of code owner account is zero')
+        print('Create code owner account:', self.reId_create_receiver)
+        self.create_code_owner_account_if_zero_balance(self.reId_create_receiver, self.reId_create_receiver_eth, self.reId_create_receiver_code_account)
+        self.assertGreater(get_recent_account_balance(self.reId_create_receiver), 0)
+        print('Ok: code owner account has been created')
+
+        print('Call creator() with holder account:')
+        result = self.call_with_holder_account_0x0e(input=func_name, contract=self.reId_create_caller, code=self.reId_create_caller_code)
+        print('result:', result)
+
+        self.assertEqual(result['meta']['err'], None)
+        self.assertEqual(len(result['meta']['innerInstructions']), 1)
+        # self.assertEqual(len(result['meta']['innerInstructions'][0]['instructions']), 5) # TODO: why not 2?
+        self.assertEqual(result['meta']['innerInstructions'][0]['index'], 0)
+
+        # emit Foo(caller, amount, message)
+        data = b58decode(result['meta']['innerInstructions'][0]['instructions'][-3]['data'])
+        self.assertEqual(data[:1], b'\x07') # 7 means OnEvent
+        self.assertEqual(data[1:21], self.reId_create_receiver_eth)
+        count_topics = int().from_bytes(data[21:29], 'little')
+        self.assertEqual(count_topics, 1)
+        self.assertEqual(data[29:61], abi.event_signature_to_log_topic('Foo(address,uint256,string)'))
+        self.assertEqual(data[61:93], bytes.fromhex("%024x" %0x0 + self.reId_create_caller_eth.hex()))
+        self.assertEqual(data[93:125], bytes.fromhex("%064x" %0x0))
+        self.assertEqual(data[125:157], bytes.fromhex("%062x" %0x0 + "60"))
+        self.assertEqual(data[157:189], bytes.fromhex("%062x" %0x0 + "08"))
+        s = "call foo".encode("utf-8")
+        self.assertEqual(data[189:221], bytes.fromhex('{:0<64}'.format(s.hex())))
+
+        # emit Result_foo(result)
+        data = b58decode(result['meta']['innerInstructions'][0]['instructions'][-2]['data'])
+        self.assertEqual(data[:1], b'\x07') # 7 means OnEvent
+        self.assertEqual(data[1:21], self.reId_create_caller_eth)
+        count_topics = int().from_bytes(data[21:29], 'little')
+        self.assertEqual(count_topics, 1)
+        self.assertEqual(data[29:61], abi.event_signature_to_log_topic('Result_foo(uint256)'))
+        self.assertEqual(data[61:93], bytes.fromhex("%062x" %0x0 + hex(124)[2:]))
+
+    # @unittest.skip("a.i.")
+    def test_04_create2_opcode(self):
+        print('\ntest_04_create2_opcode')
+        print('Create code account:', self.reId_create_receiver_code_account)
+        self.create_code_account_if_zero_balance(self.reId_create_receiver_seed, self.reId_create_receiver_code_account)
+        self.assertGreater(get_recent_account_balance(self.reId_create_receiver_code_account), 0)
+        print('Ok: code account has been created')
+
+        print('Create code owner account:', self.reId_create_receiver)
+        self.create_code_owner_account_if_zero_balance(self.reId_create_receiver, self.reId_create_receiver_eth, self.reId_create_receiver_code_account)
+        self.assertGreater(get_recent_account_balance(self.reId_create_receiver), 0)
+        print('Ok: code owner account has been created')
+
+        print('Call creator() with holder account:')
         func_name = abi.function_signature_to_4byte_selector('creator()')
         result = self.call_with_holder_account(input=func_name, contract=self.reId_create_caller, code=self.reId_create_caller_code)
 
@@ -432,7 +591,9 @@ class EventTest(unittest.TestCase):
         self.assertEqual(data[29:61], abi.event_signature_to_log_topic('Result_foo(uint256)'))
         self.assertEqual(data[61:93], bytes.fromhex("%062x" %0x0 + hex(124)[2:]))
 
-    def test_nested_revert(self):
+    # @unittest.skip("a.i.")
+    def test_05_nested_revert(self):
+        print('\ntest_05_nested_revert')
         func_name = abi.function_signature_to_4byte_selector('callFoo(address)')
         data = (func_name + bytes.fromhex("%024x" % 0x0 + self.reId_revert_eth.hex()))
         result = self.call_partial_signed(input=data, contract=self.reId_caller, code=self.reId_caller_code)
@@ -452,6 +613,7 @@ class EventTest(unittest.TestCase):
         self.assertEqual(data[61:93], bytes.fromhex("%062x" %0x0 + "00")) # result false
         self.assertEqual(data[93:125], bytes.fromhex("%062x" %0x0 + "40"))
         self.assertEqual(data[125:157], bytes.fromhex("%062x" %0x0 + "00"))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/evm_loader/test_nested_call.py
+++ b/evm_loader/test_nested_call.py
@@ -317,7 +317,7 @@ class EventTest(unittest.TestCase):
 
     def call_with_holder_account(self, input, contract, code):
         tx = {'to': solana2ether(contract), 'value': 0, 'gas': 9999999, 'gasPrice': 1_000_000_000,
-            'nonce': getTransactionCount(http_client, self.caller), 'data': input, 'chainId': 111}
+              'nonce': getTransactionCount(http_client, self.caller), 'data': input, 'chainId': 111}
 
         (from_addr, sign, msg) = make_instruction_data_from_tx(tx, self.acc.secret_key())
         assert (from_addr == self.caller_ether)
@@ -331,7 +331,7 @@ class EventTest(unittest.TestCase):
         while (True):
             print("Continue")
             trx = Transaction()
-            trx.add(self.sol_instr_10_continue(self.storage, 400, contract, code))
+            trx.add(self.sol_instr_10_continue(self.storage, 200, contract, code))
             result = send_transaction(http_client, trx, self.acc)["result"]
 
             if (result['meta']['innerInstructions'] and result['meta']['innerInstructions'][-1]['instructions']):
@@ -339,7 +339,7 @@ class EventTest(unittest.TestCase):
                 if (data[0] == 6):
                     return result
 
-    def call_with_holder_account_0x0e(self, input, contract, code):
+    def call_with_holder_account_by_0x0e(self, input, contract, code):
         tx = {'to': solana2ether(contract), 'value': 0, 'gas': 9999999, 'gasPrice': 1_000_000_000,
               'nonce': getTransactionCount(http_client, self.caller), 'data': input, 'chainId': 111}
 
@@ -350,7 +350,6 @@ class EventTest(unittest.TestCase):
 
         trx = Transaction()
         trx.add(self.sol_instr_14_combined_call_continue_from_account(self.holder, self.storage, 200, contract, code))
-        send_transaction(http_client, trx, self.acc)
 
         while (True):
             print("Combined Continue")
@@ -493,7 +492,7 @@ class EventTest(unittest.TestCase):
         func_name = abi.function_signature_to_4byte_selector('creator()')
         print("Expecting Exception: Program failed to complete")
         with self.assertRaisesRegex(Exception, 'Program failed to complete'):
-            response = self.call_with_holder_account_0x0e(input=func_name, contract=self.reId_create_caller, code=self.reId_create_caller_code)
+            response = self.call_with_holder_account_by_0x0e(input=func_name, contract=self.reId_create_caller, code=self.reId_create_caller_code)
             print('response:', response)
 
         print('Check zero balance of code account:', self.reId_create_receiver_code_account)
@@ -513,7 +512,7 @@ class EventTest(unittest.TestCase):
         print('Ok: code owner account has been created')
 
         print('Call creator() with holder account:')
-        result = self.call_with_holder_account_0x0e(input=func_name, contract=self.reId_create_caller, code=self.reId_create_caller_code)
+        result = self.call_with_holder_account_by_0x0e(input=func_name, contract=self.reId_create_caller, code=self.reId_create_caller_code)
         print('result:', result)
 
         self.assertEqual(result['meta']['err'], None)
@@ -544,7 +543,7 @@ class EventTest(unittest.TestCase):
         self.assertEqual(data[29:61], abi.event_signature_to_log_topic('Result_foo(uint256)'))
         self.assertEqual(data[61:93], bytes.fromhex("%062x" %0x0 + hex(124)[2:]))
 
-    # @unittest.skip("a.i.")
+    @unittest.skip("a.i.")
     def test_04_create2_opcode(self):
         print('\ntest_04_create2_opcode')
         print('Create code account:', self.reId_create_receiver_code_account)

--- a/evm_loader/test_nested_call.py
+++ b/evm_loader/test_nested_call.py
@@ -292,7 +292,7 @@ class EventTest(unittest.TestCase):
         for rcpt in receipts:
             confirm_transaction(http_client, rcpt)
 
-    def call_partial_signed(self, input, contract, code):
+    def call_partial_signed(self, input, contract_eth, contract, code):
         tx = {'to': contract_eth, 'value': 0, 'gas': 9_999_999, 'gasPrice': 1_000_000_000,
               'nonce': getTransactionCount(http_client, self.caller), 'data': input, 'chainId': 111}
 
@@ -315,7 +315,7 @@ class EventTest(unittest.TestCase):
                 if data[0] == 6:
                     return result
 
-    def call_with_holder_account(self, input, contract, code):
+    def call_with_holder_account(self, input, contract_eth, contract, code):
         tx = {'to': contract_eth, 'value': 0, 'gas': 9999999, 'gasPrice': 1_000_000_000,
               'nonce': getTransactionCount(http_client, self.caller), 'data': input, 'chainId': 111}
 
@@ -339,8 +339,8 @@ class EventTest(unittest.TestCase):
                 if (data[0] == 6):
                     return result
 
-    def call_with_holder_account_by_0x0e(self, input, contract, code):
-        tx = {'to': solana2ether(contract), 'value': 0, 'gas': 9999999, 'gasPrice': 1_000_000_000,
+    def call_with_holder_account_by_0x0e(self, input, contract_eth, contract, code):
+        tx = {'to': contract_eth, 'value': 0, 'gas': 9999999, 'gasPrice': 1_000_000_000,
               'nonce': getTransactionCount(http_client, self.caller), 'data': input, 'chainId': 111}
 
         (from_addr, sign, msg) = make_instruction_data_from_tx(tx, self.acc.secret_key())
@@ -492,7 +492,7 @@ class EventTest(unittest.TestCase):
         func_name = abi.function_signature_to_4byte_selector('creator()')
         print("Expecting Exception: Program failed to complete")
         with self.assertRaisesRegex(Exception, 'Program failed to complete'):
-            response = self.call_with_holder_account_by_0x0e(input=func_name, contract=self.reId_create_caller, code=self.reId_create_caller_code)
+            response = self.call_with_holder_account_by_0x0e(input=func_name, contract_eth=self.reId_create_caller_eth, contract=self.reId_create_caller, code=self.reId_create_caller_code)
             print('response:', response)
 
         print('Check zero balance of code account:', self.reId_create_receiver_code_account)
@@ -512,7 +512,7 @@ class EventTest(unittest.TestCase):
         print('Ok: code owner account has been created')
 
         print('Call creator() with holder account:')
-        result = self.call_with_holder_account_by_0x0e(input=func_name, contract=self.reId_create_caller, code=self.reId_create_caller_code)
+        result = self.call_with_holder_account_by_0x0e(input=func_name, contract_eth=self.reId_create_caller_eth, contract=self.reId_create_caller, code=self.reId_create_caller_code)
         print('result:', result)
 
         self.assertEqual(result['meta']['err'], None)


### PR DESCRIPTION
Deploying a contract from another contract without contract accounts gives the following [response](https://buildkite.com/cyberway/evm-loader/builds/1494#3faa427a-9004-4cbd-9daa-81ae7c830a13/37-2286):
```javascript
{
  'code': -32002,
  'message': 'Transaction simulation failed: Error processing Instruction 0: Program failed to complete',
  'data': {
    'accounts': None,
    'err': {
      'InstructionError': [
        0,
        'ProgramFailedToComplete'
      ]
    },
    'logs': [
      'Program 53DfF883gyixYNXnM7s5xhdeyV8mVk9T4i2hGV9vG9io invoke [1]',
      'Program log: src/storage_account.rs:65',
      'Program 11111111111111111111111111111111 invoke [2]',
      'Program 11111111111111111111111111111111 success',
      'Program 11111111111111111111111111111111 invoke [2]',
      'Program 11111111111111111111111111111111 success',
      'Program log: libstd rust_begin_panic',
      "Program log: panicked at 'called `Option::unwrap()` on a `None` value', src/account_storage.rs:489:37",
      'Program 53DfF883gyixYNXnM7s5xhdeyV8mVk9T4i2hGV9vG9io consumed 200000000 of 200000000 compute units',
      'Program failed to complete: BPF program panicked',
      'Program 53DfF883gyixYNXnM7s5xhdeyV8mVk9T4i2hGV9vG9io failed: Program failed to complete'
    ]
  }
}
```