### PR TITLE
Fix instruction serialization #281

### DIFF
--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -517,6 +517,8 @@ fn process_instruction<'a>(
             }
             Ok(())
         },
+
+        EvmInstruction::Finalise | EvmInstruction::CreateAccountWithSeed => Err!(ProgramError::InvalidInstructionData; "Deprecated instruction"),
     };
 
     solana_program::msg!("Total memory occupied: {}", &BumpAllocator::occupied());

--- a/evm_loader/program/src/instruction.rs
+++ b/evm_loader/program/src/instruction.rs
@@ -25,6 +25,10 @@ pub enum EvmInstruction<'a> {
         bytes: &'a [u8],
     },
 
+    /// Deprecated: Finalize an account loaded with program data for execution
+    #[deprecated(note = "Instruction not supported")]
+    Finalise,
+
     ///
     /// Create Ethereum account (create program_address account and write data)
     /// # Account references
@@ -64,6 +68,10 @@ pub enum EvmInstruction<'a> {
     //     /// Call data
     //     bytes: &'a [u8],
     // },
+
+    /// Deprecated: Create ethereum account with seed
+    #[deprecated(note = "Instruction not supported")]
+    CreateAccountWithSeed,
 
     /// Call Ethereum-contract action from raw transaction data
     /// #### Account references same as in Call

--- a/evm_loader/program/src/lib.rs
+++ b/evm_loader/program/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(missing_docs)]
 //#![forbid(unsafe_code)]
 #![deny(warnings)]
+#![allow(deprecated)]
 #![deny(clippy::all, clippy::pedantic, clippy::nursery)]
 #![allow(clippy::module_name_repetitions)]
 


### PR DESCRIPTION
Changes to fix:
- restore `Finalise` & `CreateAccountWithSeed` enum values with deprecated mark
- enable `#![allow(deprecated)]` in `evm_loader/program/src/lib.rs`. This need to mark enum values as deprecated.