### PR TITLE
#278 Replace `create_account` by `transfer`, `allocate` and `assign`

### DIFF
--- a/evm_loader/program/src/account_data.rs
+++ b/evm_loader/program/src/account_data.rs
@@ -9,7 +9,7 @@ use solana_program::{
 /// Ethereum account version
 pub const ACCOUNT_SEED_VERSION: u8 = 1_u8;
 /// Ethereum account allocated data size
-pub const ACCOUNT_MAX_SIZE: u64 = 256;
+pub const ACCOUNT_MAX_SIZE: usize = 256;
 
 /// Ethereum account data
 #[derive(Debug,Clone)]

--- a/evm_loader/program/src/lib.rs
+++ b/evm_loader/program/src/lib.rs
@@ -27,6 +27,7 @@ pub mod utils;
 pub mod neon;
 pub mod payment;
 pub mod token;
+pub mod system;
 pub mod precompile_contracts;
 
 // Export current solana-sdk types for downstream users who may also be building with a different

--- a/evm_loader/program/src/system.rs
+++ b/evm_loader/program/src/system.rs
@@ -1,0 +1,64 @@
+//! `EVMLoader` system functions
+use solana_program::{
+    account_info::AccountInfo,
+    program::{invoke, invoke_signed},
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    rent::Rent,
+    system_instruction,
+    sysvar::Sysvar
+};
+
+/// Create program derived account
+///
+/// # Errors
+///
+/// Will return:
+/// `ProgramError::AccountBorrowFailed` is `new_account` data already borrowed
+/// `ProgramError::Custom` from `invoke_signed`
+pub fn create_pda_account(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    new_account: &AccountInfo,
+    new_account_seeds: &[&[u8]],
+    payer: &Pubkey,
+    space: usize
+) -> Result<(), ProgramError> {
+    let rent = Rent::get()?;
+    let minimum_balance = rent.minimum_balance(space).max(1);
+
+    if new_account.lamports() > 0 {
+        let required_lamports = minimum_balance.saturating_sub(new_account.lamports());
+
+        if required_lamports > 0 {
+            invoke(
+                &system_instruction::transfer(payer, new_account.key, required_lamports),
+                accounts
+            )?;
+        }
+
+        invoke_signed(
+            &system_instruction::allocate(new_account.key, space as u64),
+            accounts,
+            &[new_account_seeds],
+        )?;
+
+        invoke_signed(
+            &system_instruction::assign(new_account.key, program_id),
+            accounts,
+            &[new_account_seeds]
+        )
+    } else {
+        invoke_signed(
+            &system_instruction::create_account(
+                payer,
+                new_account.key,
+                minimum_balance,
+                space as u64,
+                program_id,
+            ),
+            accounts,
+            &[new_account_seeds],
+        )
+    }
+}


### PR DESCRIPTION
Function `create_account` fails if the target account already exists.
Existing can already mean "has at least 1 lamport balance".