### PR TITLE
Refund accounts #311

### DIFF
--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -600,26 +600,29 @@ fn process_instruction<'a>(
             let creator_acc_info = next_account_info(account_info_iter)?;
             let evm_loader = next_account_info(account_info_iter)?;
 
+            if !creator_acc_info.is_signer {
+                return Err!(ProgramError::InvalidAccountData; "Creator acc must be signer. Acc {:?}", *creator_acc_info.key);
+            }
+
             let address = Pubkey::create_with_seed(
                 creator_acc_info.key, 
                 std::str::from_utf8(seed).map_err(|e| E!(ProgramError::InvalidInstructionData; "Seed decode error={:?}", e))?, 
                 evm_loader.key)?;
 
             if *deleted_acc_info.key != address {
-                return Err!(ProgramError::InvalidAccountData; "*deleted_acc_info.key<{:?}> != address<{:?}>", *deleted_acc_info.key, address);
+                return Err!(ProgramError::InvalidAccountData; "Deleted account info doesn't equal to generated. *deleted_acc_info.key<{:?}> != address<{:?}>", *deleted_acc_info.key, address);
             }
 
-            let mut data = deleted_acc_info.data.borrow_mut();
+            let data = deleted_acc_info.data.borrow_mut();
             let account_data = AccountData::unpack(&data)?;
             match account_data {
-                AccountData::Account(_) | AccountData::Storage(_) | AccountData::ERC20Allowance(_) => {
-                    return Err!(ProgramError::InvalidAccountData);
-                },
-                AccountData::Contract(acc) if acc.code_size != 0 => {
-                    return Err!(ProgramError::InvalidAccountData);
-                },
-                AccountData::Contract(_) | AccountData::Empty => { },
+                AccountData::Empty => { },
+                _ => { return Err!(ProgramError::InvalidAccountData; "Can only delete empty accounts.") },
             };
+
+            **creator_acc_info.lamports.borrow_mut() = creator_acc_info.lamports().checked_add(deleted_acc_info.lamports()).unwrap();
+            **deleted_acc_info.lamports.borrow_mut() = 0;
+
             Ok(())
         },
 

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -598,7 +598,6 @@ fn process_instruction<'a>(
         EvmInstruction::DeleteAccount { seed } => {
             let deleted_acc_info = next_account_info(account_info_iter)?;
             let creator_acc_info = next_account_info(account_info_iter)?;
-            let evm_loader = next_account_info(account_info_iter)?;
 
             if !creator_acc_info.is_signer {
                 return Err!(ProgramError::InvalidAccountData; "Creator acc must be signer. Acc {:?}", *creator_acc_info.key);
@@ -607,7 +606,7 @@ fn process_instruction<'a>(
             let address = Pubkey::create_with_seed(
                 creator_acc_info.key, 
                 std::str::from_utf8(seed).map_err(|e| E!(ProgramError::InvalidInstructionData; "Seed decode error={:?}", e))?, 
-                evm_loader.key)?;
+                program_id)?;
 
             if *deleted_acc_info.key != address {
                 return Err!(ProgramError::InvalidAccountData; "Deleted account info doesn't equal to generated. *deleted_acc_info.key<{:?}> != address<{:?}>", *deleted_acc_info.key, address);

--- a/evm_loader/program/src/instruction.rs
+++ b/evm_loader/program/src/instruction.rs
@@ -186,7 +186,6 @@ pub enum EvmInstruction<'a> {
     /// # Account references
     ///   0. [WRITE] Deleted account
     ///   1. [WRITE] Deleted account creator
-    ///   2. [] evm_loader account
     DeleteAccount {
         /// seed used to create account
         seed:  &'a [u8],

--- a/evm_loader/program/src/instruction.rs
+++ b/evm_loader/program/src/instruction.rs
@@ -180,7 +180,17 @@ pub enum EvmInstruction<'a> {
     ///   5. `[]` System program
     ///   6. `[]` SPL Token program
     ///   7. '[]' Rent sysvar
-    ERC20CreateTokenAccount
+    ERC20CreateTokenAccount,
+
+    /// Create Ethereum account (create program_address account and write data)
+    /// # Account references
+    ///   0. [WRITE] Deleted account
+    ///   1. [WRITE] Deleted account creator
+    ///   2. [] evm_loader account
+    DeleteAccount {
+        /// seed used to create account
+        seed:  &'a [u8],
+    },
 }
 
 
@@ -297,6 +307,9 @@ impl<'a> EvmInstruction<'a> {
                 EvmInstruction::ExecuteTrxFromAccountDataIterativeOrContinue {collateral_pool_index, step_count}
             },
             15 => EvmInstruction::ERC20CreateTokenAccount,
+            16 => {
+                EvmInstruction::DeleteAccount { seed: rest }
+            },
             _ => return Err(InvalidInstructionData),
         })
     }

--- a/evm_loader/test_fund_return.py
+++ b/evm_loader/test_fund_return.py
@@ -1,0 +1,110 @@
+import unittest
+import solana
+from solana.transaction import AccountMeta, TransactionInstruction, Transaction
+from solana_utils import *
+
+
+class FundReturnTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        print("\ntest_fund_return.py setUpClass")
+
+        wallet = WalletAccount(wallet_path())
+        cls.loader = EvmLoader(wallet, EVM_LOADER)
+        cls.acc = wallet.get_acc()
+
+        cls.alice_acc = cls.create_account(cls, "alice")
+        cls.bob_acc = cls.create_account(cls, "bob")
+
+        cls.refundable_seed = "refund"
+        cls.refundable_acc = cls.create_account_with_seed_from_acc(cls, cls.alice_acc, cls.refundable_seed)
+
+        cls.fail_seed = "fail"
+        cls.fail_acc = cls.create_account_with_seed_from_acc(cls, cls.alice_acc, cls.fail_seed)
+
+
+    def create_account(self, seed):
+        bytes_seed = sha256(bytes(seed, 'utf8'))
+        new_acc = Account(bytes_seed)
+        trx = client.request_airdrop(new_acc.public_key(), 10 * 10 ** 9)
+        confirm_transaction(client, trx['result'])
+        return new_acc
+
+
+    def create_account_with_seed_from_acc(self, acc, seed):
+        storage = PublicKey(sha256(bytes(acc.public_key()) + bytes(seed, 'utf8') + bytes(PublicKey(EVM_LOADER))).digest())
+        print("Storage", storage)
+
+        if getBalance(storage) == 0:
+            trx = Transaction()
+            trx.add(createAccountWithSeed(acc.public_key(), acc.public_key(), seed, 10**9, 128*1024, PublicKey(EVM_LOADER)))
+            send_transaction(client, trx, acc)
+
+        return storage
+
+
+    def call_refund_tx(self, del_key, acc, seed, signer):
+        trx = Transaction()
+        trx.add(TransactionInstruction(
+            program_id=self.loader.loader_id,
+            data=bytearray.fromhex("10") + bytes(seed, 'utf8'),
+            keys=[
+                AccountMeta(pubkey=del_key, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=acc.public_key(), is_signer=(signer==acc), is_writable=True),
+                AccountMeta(pubkey=self.loader.loader_id, is_signer=False, is_writable=False),
+            ]))
+        return send_transaction(client, trx, signer)
+
+
+    def test_creator_not_signer(self):
+        err_msg = "Creator acc must be signer."
+
+        try:
+            self.call_refund_tx(self.fail_acc, self.alice_acc, self.fail_seed, self.bob_acc)
+        except solana.rpc.api.SendTransactionError as err:
+            self.assertTrue(err_msg in str(err.result))
+        except Exception as err:
+            print('type(err):', type(err))
+            print('err:', str(err))
+            self.assertTrue(False)
+        else:
+            self.assertTrue(False)
+
+
+    def test_error_on_wrong_creator(self):
+        err_msg = "Deleted account info doesn't equal to generated."
+
+        try:
+            self.call_refund_tx(self.fail_acc, self.bob_acc, self.fail_seed, self.bob_acc)
+        except solana.rpc.api.SendTransactionError as err:
+            self.assertTrue(err_msg in str(err.result))
+        except Exception as err:
+            print('type(err):', type(err))
+            print('err:', str(err))
+            self.assertTrue(False)
+        else:
+            self.assertTrue(False)
+
+
+    def test_error_on_wrong_seed(self):
+        err_msg = "Deleted account info doesn't equal to generated."
+
+        try:
+            self.call_refund_tx(self.fail_acc, self.alice_acc, self.refundable_seed, self.alice_acc)
+        except solana.rpc.api.SendTransactionError as err:
+            self.assertTrue(err_msg in str(err.result))
+        except Exception as err:
+            print('type(err):', type(err))
+            print('err:', str(err))
+            self.assertTrue(False)
+        else:
+            self.assertTrue(False)
+
+
+    def test_success_refund(self):
+        result = self.call_refund_tx(self.refundable_acc, self.alice_acc, self.refundable_seed, self.alice_acc)
+        print(result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/evm_loader/test_fund_return.py
+++ b/evm_loader/test_fund_return.py
@@ -107,7 +107,7 @@ class FundReturnTest(unittest.TestCase):
         print(pre_storage + pre_acc)
         print(post_acc)
 
-        self.assertAlmostEqual(pre_storage + pre_acc, post_acc)
+        self.assertAlmostEqual(pre_storage + pre_acc, post_acc + 5000)
 
 
 if __name__ == '__main__':

--- a/evm_loader/test_fund_return.py
+++ b/evm_loader/test_fund_return.py
@@ -46,7 +46,6 @@ class FundReturnTest(unittest.TestCase):
             keys=[
                 AccountMeta(pubkey=del_key, is_signer=False, is_writable=True),
                 AccountMeta(pubkey=acc.public_key(), is_signer=(signer==acc), is_writable=True),
-                AccountMeta(pubkey=EVM_LOADER, is_signer=False, is_writable=False),
             ]))
         return send_transaction(client, trx, signer)
 
@@ -107,7 +106,7 @@ class FundReturnTest(unittest.TestCase):
         print(pre_storage + pre_acc)
         print(post_acc)
 
-        self.assertAlmostEqual(pre_storage + pre_acc, post_acc + 5000)
+        self.assertEqual(pre_storage + pre_acc, post_acc + 5000)
 
 
 if __name__ == '__main__':

--- a/evm_loader/test_fund_return.py
+++ b/evm_loader/test_fund_return.py
@@ -98,11 +98,11 @@ class FundReturnTest(unittest.TestCase):
 
     def test_success_refund(self):
         pre_storage = getBalance(self.refundable_acc)
-        pre_acc = getBalance(self.alice_acc)
+        pre_acc = getBalance(self.alice_acc.public_key())
 
         self.call_refund_tx(self.refundable_acc, self.alice_acc, self.refundable_seed, self.alice_acc)
 
-        post_acc = getBalance(self.alice_acc)
+        post_acc = getBalance(self.alice_acc.public_key())
 
         print(pre_storage + pre_acc)
         print(post_acc)


### PR DESCRIPTION
Added new instruction `DeleteAccount`.
Refund funds spent on account creation by moving them to the creator's account by moving from the created account and deleting it.
Check if a deleted account is created by provided account with a given seed.
Check if a deleted account is empty.
Check if creator is signer.