### PR TITLE
#296 Cache values from Solana

### DIFF
--- a/evm_loader/cli/src/account_storage.rs
+++ b/evm_loader/cli/src/account_storage.rs
@@ -268,7 +268,7 @@ impl<'a> EmulatorAccountStorage<'a> {
 
         for apply in values {
             match apply {
-                Apply::Modify {address, basic, code_and_valids, storage, reset_storage} => {
+                Apply::Modify {address, nonce, code_and_valids, storage, reset_storage} => {
 
                     if let Some(acc) = accounts.get_mut(&address) {
 
@@ -300,7 +300,7 @@ impl<'a> EmulatorAccountStorage<'a> {
                     else {
                         eprintln!("Account not found {}", &address.to_string());
                     }
-                    eprintln!("Modify: {} {} {} {}", &address.to_string(), &basic.nonce.as_u64(), &basic.balance, &reset_storage.to_string());
+                    eprintln!("Modify: {} {} {}", &address.to_string(), &nonce.as_u64(), &reset_storage.to_string());
                 },
                 Apply::Delete {address: addr} => {
                     eprintln!("Delete: {}", addr.to_string());

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -153,7 +153,8 @@ fn command_emulate(config: &Config, contract_id: Option<H160>, caller_id: H160, 
         // Gas estimation errored with the following message (see below).
         // Number can only safely store up to 53 bits
         let gas_limit = 50_000_000;
-        let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit), &storage);
+        let executor_substate = Box::new(ExecutorSubstate::new(gas_limit, &storage));
+        let executor_state = ExecutorState::new(executor_substate, &storage);
         let mut executor = Machine::new(executor_state);
         debug!("Executor initialized");
 

--- a/evm_loader/program/src/account_storage.rs
+++ b/evm_loader/program/src/account_storage.rs
@@ -261,14 +261,14 @@ impl<'a> ProgramAccountStorage<'a> {
     {
         for apply in values {
             match apply {
-                Apply::Modify {address, basic, code_and_valids, storage, reset_storage} => {
+                Apply::Modify {address, nonce, code_and_valids, storage, reset_storage} => {
                     if is_precompile_address(&address) {
                         continue;
                     }
                     if let Some(pos) = self.find_account(&address) {
                         let account = &mut self.accounts[pos];
                         let AccountMeta{ account: account_info, token: _, code: _ } = &self.account_metas[pos];
-                        account.update(account_info, address, basic.nonce, basic.balance, &code_and_valids, storage, reset_storage)?;
+                        account.update(account_info, address, nonce, &code_and_valids, storage, reset_storage)?;
                     } else {
                         if let Sender::Solana(addr) = self.sender {
                             if addr == address {

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -115,11 +115,10 @@ fn process_instruction<'a>(
     accounts: &'a [AccountInfo<'a>],
     instruction_data: &[u8],
 ) -> ProgramResult {
-
     let account_info_iter = &mut accounts.iter();
 
     let instruction = EvmInstruction::unpack(instruction_data)?;
-    debug_print!("Instruction parsed");
+    debug_print!("Instruction parsed {:?}", instruction);
 
     #[allow(clippy::match_same_arms)]
     let result = match instruction {
@@ -675,7 +674,8 @@ fn do_call(
     debug_print!(" contract: {}", account_storage.contract());
 
     let call_results = {
-        let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit), account_storage);
+        let executor_substate = Box::new(ExecutorSubstate::new(gas_limit, account_storage));
+        let executor_state = ExecutorState::new(executor_substate, account_storage);
         let mut executor = Machine::new(executor_state);
 
         debug_print!("Executor initialized");
@@ -834,7 +834,8 @@ fn do_partial_call<'a>(
 {
     debug_print!("do_partial_call");
 
-    let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit), account_storage);
+    let executor_substate = Box::new(ExecutorSubstate::new(gas_limit, account_storage));
+    let executor_state = ExecutorState::new(executor_substate, account_storage);
     let mut executor = Machine::new(executor_state);
 
     debug_print!("Executor initialized");
@@ -870,7 +871,8 @@ fn do_partial_create<'a>(
 {
     debug_print!("do_partial_create gas_limit={}", gas_limit);
 
-    let executor_state = ExecutorState::new(ExecutorSubstate::new(gas_limit), account_storage);
+    let executor_substate = Box::new(ExecutorSubstate::new(gas_limit, account_storage));
+    let executor_state = ExecutorState::new(executor_substate, account_storage);
     let mut executor = Machine::new(executor_state);
 
     debug_print!("Executor initialized");

--- a/evm_loader/program/src/executor.rs
+++ b/evm_loader/program/src/executor.rs
@@ -64,7 +64,7 @@ impl<'a, B: AccountStorage> Handler for Executor<'a, B> {
     }
 
     fn balance(&self, address: H160) -> U256 {
-        self.state.basic(address).balance
+        self.state.balance(address)
     }
 
     fn code_size(&self, address: H160) -> U256 {
@@ -220,7 +220,7 @@ impl<'a, B: AccountStorage> Handler for Executor<'a, B> {
                     keccak256_h256_v(&[&[0xff], &caller[..], &salt[..], &code_hash[..]]).into()
                 },
                 evm::CreateScheme::Legacy { caller } => {
-                    let nonce = self.state.basic(caller).nonce;
+                    let nonce = self.state.nonce(caller);
                     let mut stream = rlp::RlpStream::new_list(2);
                     stream.append(&caller);
                     stream.append(&nonce);
@@ -240,7 +240,7 @@ impl<'a, B: AccountStorage> Handler for Executor<'a, B> {
             return Capture::Exit((ExitError::CreateCollision.into(), None, Vec::new()))
         }
 
-        if self.state.basic(address).nonce  > U256::zero() {
+        if self.state.nonce(address)  > U256::zero() {
             return Capture::Exit((ExitError::CreateCollision.into(), None, Vec::new()))
         }
 

--- a/evm_loader/program/src/solidity_account.rs
+++ b/evm_loader/program/src/solidity_account.rs
@@ -210,15 +210,13 @@ impl<'a> SolidityAccount<'a> {
         #[allow(unused_variables)]
         solidity_address: H160,
         nonce: U256,
-        #[allow(unused_variables)]
-        balance: U256,
         code_and_valids: &Option<(Vec<u8>, Vec<u8>)>,
         storage_items: I,
         reset_storage: bool,
     ) -> Result<(), ProgramError>
     where I: IntoIterator<Item = (U256, U256)> 
     {
-        debug_print!("Update: {}, {}, {}, {:?}, {}", solidity_address, nonce, balance, if code_and_valids.is_some() {"Exist"} else {"Empty"}, reset_storage);
+        debug_print!("Update: {}", solidity_address);
         let mut data = (*account_info.data).borrow_mut();
         // **account_info.lamports.borrow_mut() = lamports;
 


### PR DESCRIPTION
- Move executor state from stack to heap
- Fix incorrect Neon balance after transfer
- Cache:
  - Neon balance
  - SPL Token balance
  - SPL Token decimals
  - SPL Token supply
  - Block number
  - Block timestamp