### PR TITLE
#340 Return execution steps in emulation

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,8 @@ steps:
   - label: ":docker: build proxy docker image"
     trigger: "neon-proxy"
     build:
-       branch: "${PROXY_BRANCH:-develop}"
+       branch: "241_iterations_from_emulator"
+      #  branch: "${PROXY_BRANCH:-develop}"
        env:
           EVM_LOADER_REVISION: "${BUILDKITE_COMMIT}"
           EVM_LOADER_BRANCH: "${EVM_LOADER_BRANCH}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,8 +15,7 @@ steps:
   - label: ":docker: build proxy docker image"
     trigger: "neon-proxy"
     build:
-       branch: "241_iterations_from_emulator"
-      #  branch: "${PROXY_BRANCH:-develop}"
+       branch: "${PROXY_BRANCH:-develop}"
        env:
           EVM_LOADER_REVISION: "${BUILDKITE_COMMIT}"
           EVM_LOADER_BRANCH: "${EVM_LOADER_BRANCH}"

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -1115,7 +1115,7 @@ fn command_cancel_trx(
                     } else {
                         false
                     }
-                } else {return Err(format!("Missed account {}", key).into());}
+                } else {false}
             };
 
             if writable {

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -346,7 +346,7 @@ fn process_instruction<'a>(
             let trx: UnsignedTransaction = rlp::decode(unsigned_msg).map_err(|e| E!(ProgramError::InvalidInstructionData; "DecoderError={:?}", e))?;
 
             do_begin(
-                collateral_pool_index, step_count, caller, trx,
+                collateral_pool_index, caller, trx,
                 program_id, trx_accounts, accounts, storage_info,
                 operator_sol_info, collateral_pool_sol_info,
                 operator_eth_info, user_eth_info,
@@ -442,7 +442,7 @@ fn process_instruction<'a>(
                 .map_err(|e| E!(ProgramError::InvalidInstructionData; "DecoderError={:?}", e))?;
 
             do_begin(
-                collateral_pool_index, step_count, caller, trx,
+                collateral_pool_index, caller, trx,
                 program_id, trx_accounts, accounts, storage_info,
                 operator_sol_info, collateral_pool_sol_info,
                 operator_eth_info, user_eth_info,
@@ -555,7 +555,7 @@ fn process_instruction<'a>(
                         .map_err(|e| E!(ProgramError::InvalidInstructionData; "DecoderError={:?}", e))?;
 
                     do_begin(
-                        collateral_pool_index, step_count, caller, trx,
+                        collateral_pool_index, caller, trx,
                         program_id, trx_accounts, accounts, storage_info,
                         operator_sol_info, collateral_pool_sol_info,
                         operator_eth_info, user_eth_info,
@@ -596,7 +596,7 @@ fn process_instruction<'a>(
                     let trx: UnsignedTransaction = rlp::decode(unsigned_msg).map_err(|e| E!(ProgramError::InvalidInstructionData; "DecoderError={:?}", e))?;
 
                     do_begin(
-                        collateral_pool_index, step_count, caller, trx,
+                        collateral_pool_index, caller, trx,
                         program_id, trx_accounts, accounts, storage_info,
                         operator_sol_info, collateral_pool_sol_info,
                         operator_eth_info, user_eth_info,
@@ -861,7 +861,6 @@ fn do_call(
 #[allow(clippy::too_many_arguments)]
 fn do_begin<'a>(
     collateral_pool_index: u32,
-    step_count: u64,
     caller: H160,
     trx: UnsignedTransaction,
     program_id: &Pubkey,

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -346,7 +346,7 @@ fn process_instruction<'a>(
             let trx: UnsignedTransaction = rlp::decode(unsigned_msg).map_err(|e| E!(ProgramError::InvalidInstructionData; "DecoderError={:?}", e))?;
 
             do_begin(
-                collateral_pool_index, caller, trx,
+                collateral_pool_index, step_count, caller, trx,
                 program_id, trx_accounts, accounts, storage_info,
                 operator_sol_info, collateral_pool_sol_info,
                 operator_eth_info, user_eth_info,
@@ -442,7 +442,7 @@ fn process_instruction<'a>(
                 .map_err(|e| E!(ProgramError::InvalidInstructionData; "DecoderError={:?}", e))?;
 
             do_begin(
-                collateral_pool_index, caller, trx,
+                collateral_pool_index, step_count, caller, trx,
                 program_id, trx_accounts, accounts, storage_info,
                 operator_sol_info, collateral_pool_sol_info,
                 operator_eth_info, user_eth_info,
@@ -555,7 +555,7 @@ fn process_instruction<'a>(
                         .map_err(|e| E!(ProgramError::InvalidInstructionData; "DecoderError={:?}", e))?;
 
                     do_begin(
-                        collateral_pool_index, caller, trx,
+                        collateral_pool_index, 0, caller, trx,
                         program_id, trx_accounts, accounts, storage_info,
                         operator_sol_info, collateral_pool_sol_info,
                         operator_eth_info, user_eth_info,
@@ -596,7 +596,7 @@ fn process_instruction<'a>(
                     let trx: UnsignedTransaction = rlp::decode(unsigned_msg).map_err(|e| E!(ProgramError::InvalidInstructionData; "DecoderError={:?}", e))?;
 
                     do_begin(
-                        collateral_pool_index, caller, trx,
+                        collateral_pool_index, 0, caller, trx,
                         program_id, trx_accounts, accounts, storage_info,
                         operator_sol_info, collateral_pool_sol_info,
                         operator_eth_info, user_eth_info,
@@ -861,6 +861,7 @@ fn do_call(
 #[allow(clippy::too_many_arguments)]
 fn do_begin<'a>(
     collateral_pool_index: u32,
+    step_count: u64,
     caller: H160,
     trx: UnsignedTransaction,
     program_id: &Pubkey,
@@ -904,10 +905,10 @@ fn do_begin<'a>(
         system_info)?;
 
     let (_,used_gas) = if trx.to.is_some() {
-        do_partial_call(&mut storage, 0, &account_storage, trx.call_data, trx.value, trx_gas_limit)?
+        do_partial_call(&mut storage, step_count, &account_storage, trx.call_data, trx.value, trx_gas_limit)?
     }
     else {
-        do_partial_create(&mut storage, 0, &account_storage, trx.call_data, trx.value, trx_gas_limit)?
+        do_partial_create(&mut storage, step_count, &account_storage, trx.call_data, trx.value, trx_gas_limit)?
     };
 
     token::user_pays_operator_for_iteration(

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -905,7 +905,7 @@ fn do_begin<'a>(
         system_info)?;
 
     let (_,used_gas) = if trx.to.is_some() {
-        do_partial_call(&mut storage, step_count, &account_storage, trx.call_data, trx.value, trx_gas_limit)?
+        do_partial_call(&mut storage, 0, &account_storage, trx.call_data, trx.value, trx_gas_limit)?
     }
     else {
         do_partial_create(&mut storage, 0, &account_storage, trx.call_data, trx.value, trx_gas_limit)?

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -908,7 +908,7 @@ fn do_begin<'a>(
         do_partial_call(&mut storage, step_count, &account_storage, trx.call_data, trx.value, trx_gas_limit)?
     }
     else {
-        do_partial_create(&mut storage, step_count, &account_storage, trx.call_data, trx.value, trx_gas_limit)?
+        do_partial_create(&mut storage, 0, &account_storage, trx.call_data, trx.value, trx_gas_limit)?
     };
 
     token::user_pays_operator_for_iteration(

--- a/evm_loader/test_nested_call.py
+++ b/evm_loader/test_nested_call.py
@@ -549,10 +549,12 @@ class EventTest(unittest.TestCase):
         # self.create_code_owner_account_if_zero_balance(self.reId_create_receiver, self.reId_create_receiver_eth, self.reId_create_receiver_code_account)
 
         func_name = abi.function_signature_to_4byte_selector('creator()')
-        print("Expecting Exception: Program failed to complete")
-        with self.assertRaisesRegex(Exception, 'Program failed to complete'):
-            response = self.call_with_holder_account_by_0x0e(input=func_name, contract_eth=self.reId_create_caller_eth, contract=self.reId_create_caller, code=self.reId_create_caller_code)
-            print('response:', response)
+        # TODO Fix this part of test
+        # Fails and locks storage and accounts 
+        # print("Expecting Exception: Program failed to complete")
+        # with self.assertRaisesRegex(Exception, 'Program failed to complete'):
+        #     response = self.call_with_holder_account_by_0x0e(input=func_name, contract_eth=self.reId_create_caller_eth, contract=self.reId_create_caller, code=self.reId_create_caller_code)
+        #     print('response:', response)
 
         print('Check zero balance of code account:', self.reId_create_receiver_code_account)
         self.assertEqual(get_recent_account_balance(self.reId_create_receiver_code_account), 0)

--- a/evm_loader/test_nested_call.py
+++ b/evm_loader/test_nested_call.py
@@ -556,6 +556,8 @@ class EventTest(unittest.TestCase):
         # with self.assertRaisesRegex(Exception, 'Program failed to complete'):
         #     response = self.call_with_holder_account_by_0x0e(input=func_name, contract_eth=self.reId_create_caller_eth, contract=self.reId_create_caller, code=self.reId_create_caller_code)
         #     print('response:', response)
+        # enable when https://github.com/neonlabsorg/neon-evm/pull/359 merged
+        # neon_cli().call("cancel-trx --evm_loader {} {}".format(evm_loader_id, storage))
 
         print('Check zero balance of code account:', self.reId_create_receiver_code_account)
         self.assertEqual(get_recent_account_balance(self.reId_create_receiver_code_account), 0)

--- a/evm_loader/test_nested_call.py
+++ b/evm_loader/test_nested_call.py
@@ -553,7 +553,7 @@ class EventTest(unittest.TestCase):
         with self.assertRaisesRegex(Exception, 'Program failed to complete'):
             response = self.call_with_holder_account_by_0x0e(input=func_name, contract_eth=self.reId_create_caller_eth, contract=self.reId_create_caller, code=self.reId_create_caller_code)
             print('response:', response)
-        neon_cli().call("cancel-trx --evm_loader {} {}".format(evm_loader_id, storage))
+        neon_cli().call("cancel-trx --evm_loader {} {}".format(evm_loader_id, self.storage))
 
         print('Check zero balance of code account:', self.reId_create_receiver_code_account)
         self.assertEqual(get_recent_account_balance(self.reId_create_receiver_code_account), 0)

--- a/evm_loader/test_nested_call.py
+++ b/evm_loader/test_nested_call.py
@@ -549,15 +549,11 @@ class EventTest(unittest.TestCase):
         # self.create_code_owner_account_if_zero_balance(self.reId_create_receiver, self.reId_create_receiver_eth, self.reId_create_receiver_code_account)
 
         func_name = abi.function_signature_to_4byte_selector('creator()')
-        # TODO Fix this part of test
-        # Fails and locks storage and accounts 
-        # Need to be canceled explicitly
-        # print("Expecting Exception: Program failed to complete")
-        # with self.assertRaisesRegex(Exception, 'Program failed to complete'):
-        #     response = self.call_with_holder_account_by_0x0e(input=func_name, contract_eth=self.reId_create_caller_eth, contract=self.reId_create_caller, code=self.reId_create_caller_code)
-        #     print('response:', response)
-        # enable when https://github.com/neonlabsorg/neon-evm/pull/359 merged
-        # neon_cli().call("cancel-trx --evm_loader {} {}".format(evm_loader_id, storage))
+        print("Expecting Exception: Program failed to complete")
+        with self.assertRaisesRegex(Exception, 'Program failed to complete'):
+            response = self.call_with_holder_account_by_0x0e(input=func_name, contract_eth=self.reId_create_caller_eth, contract=self.reId_create_caller, code=self.reId_create_caller_code)
+            print('response:', response)
+        neon_cli().call("cancel-trx --evm_loader {} {}".format(evm_loader_id, storage))
 
         print('Check zero balance of code account:', self.reId_create_receiver_code_account)
         self.assertEqual(get_recent_account_balance(self.reId_create_receiver_code_account), 0)

--- a/evm_loader/test_nested_call.py
+++ b/evm_loader/test_nested_call.py
@@ -551,6 +551,7 @@ class EventTest(unittest.TestCase):
         func_name = abi.function_signature_to_4byte_selector('creator()')
         # TODO Fix this part of test
         # Fails and locks storage and accounts 
+        # Need to be canceled explicitly
         # print("Expecting Exception: Program failed to complete")
         # with self.assertRaisesRegex(Exception, 'Program failed to complete'):
         #     response = self.call_with_holder_account_by_0x0e(input=func_name, contract_eth=self.reId_create_caller_eth, contract=self.reId_create_caller, code=self.reId_create_caller_code)

--- a/evm_loader/test_transaction.py
+++ b/evm_loader/test_transaction.py
@@ -388,6 +388,7 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
 
         # TODO Fix this part of test
         # Fails and locks storage and accounts 
+        # Need to be canceled explicitly
         # print('Send a transaction "combined continue(0x0d)" before creating an account - wait for the confirmation '
         #       'and make sure of the error. See https://github.com/neonlabsorg/neon-evm/pull/320')
         # with self.assertRaisesRegex(Exception, "Error processing Instruction 1: insufficient funds for instruction"):

--- a/evm_loader/test_transaction.py
+++ b/evm_loader/test_transaction.py
@@ -215,8 +215,8 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
         collateral_pool_balance_change = int(collateral_pool_post_balance) - int(collateral_pool_pre_balance)
         print('     collateral_pool_balance_change:', collateral_pool_balance_change)
         if step is Step.Begin:
-            self.assertEqual(operator_balance_change, 0 - fee - NEON_PAYMENT_TO_TREASURE)
-            # self.assertEqual(deposit_balance_change, NEON_PAYMENT_TO_DEPOSIT)
+            self.assertEqual(operator_balance_change, 0 - fee - NEON_PAYMENT_TO_DEPOSIT - NEON_PAYMENT_TO_TREASURE)
+            self.assertEqual(deposit_balance_change, NEON_PAYMENT_TO_DEPOSIT)
             self.assertEqual(collateral_pool_balance_change, NEON_PAYMENT_TO_TREASURE)
         if step is Step.Iteration:
             self.assertEqual(operator_balance_change, 0 - fee - NEON_PAYMENT_TO_TREASURE)
@@ -315,9 +315,9 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
         self.assertLess(data[1], 0xd0)  # less 0xd0 - success
         self.assertEqual(int().from_bytes(data[2:10], 'little'), 24301)  # used_gas
 
-    @unittest.skip("works only in 5 instructions but cant be serialized")
+    # @unittest.skip("a.i.")
     def test_05_failure_tx_send_iteratively_by_4_instructions_in_one_transaction(self):
-        step_count = 100
+        step_count = 150
         (keccak_instruction, trx_data, sign) = self.get_keccak_instruction_and_trx_data(13, self.acc.secret_key(), self.caller, self.caller_ether)
         storage = self.create_storage_account(sign[:8].hex())
         neon_emv_instr_0d = self.neon_emv_instr_0D(step_count, trx_data, storage, self.caller)
@@ -386,13 +386,10 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
             .add(keccak_instruction) \
             .add(neon_emv_instr_0d_2)
 
-        # TODO Fix this part of test
-        # Fails and locks storage and accounts 
-        # Need to be canceled explicitly
-        # print('Send a transaction "combined continue(0x0d)" before creating an account - wait for the confirmation '
-        #       'and make sure of the error. See https://github.com/neonlabsorg/neon-evm/pull/320')
-        # with self.assertRaisesRegex(Exception, "Error processing Instruction 1: insufficient funds for instruction"):
-        #     send_transaction(client, trx, self.acc)
+        print('Send a transaction "combined continue(0x0d)" before creating an account - wait for the confirmation '
+              'and make sure of the error. See https://github.com/neonlabsorg/neon-evm/pull/320')
+        with self.assertRaisesRegex(Exception, "Error processing Instruction 1: insufficient funds for instruction"):
+            send_transaction(client, trx, self.acc)
 
         if getBalance(self.caller_2) == 0:
             print("Send a transaction to create an account - wait for the confirmation and make sure of successful "
@@ -458,9 +455,12 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
         collateral_pool_sol_acc = self.collateral_pool_address
         deposit_sol_acc = storage
 
-        self.check_transfers_between_operator_deposit_and_collateral_pool(response_1, operator_sol_acc,
+        self.check_transfers_between_operator_deposit_and_collateral_pool(response_0, operator_sol_acc,
                                                                           deposit_sol_acc, collateral_pool_sol_acc,
                                                                           step=Step.Begin)
+        self.check_transfers_between_operator_deposit_and_collateral_pool(response_1, operator_sol_acc,
+                                                                          deposit_sol_acc, collateral_pool_sol_acc,
+                                                                          step=Step.Iteration)
         self.check_transfers_between_operator_deposit_and_collateral_pool(response_2, operator_sol_acc,
                                                                           deposit_sol_acc, collateral_pool_sol_acc,
                                                                           step=Step.Iteration)


### PR DESCRIPTION
PR:
 - adds an option in executor to store executed steps count and function to return them.
 - adds a field with executed steps in return of the `neon-cli` emulation command.
 - fixes #351 by ignoring steps in initial combined transactions.

