### PR TITLE
Fix QueryAccount.sol

### DIFF
--- a/evm_loader/QueryAccount.sol
+++ b/evm_loader/QueryAccount.sol
@@ -6,40 +6,40 @@ contract QueryAccount {
 
     // Takes a Solana address, treats it as an address of an account.
     // Returns the account's owner Solana address (32 bytes).
-    function owner(uint256 solana_address) public returns (uint256) {
-        (bool success, bytes memory result) = precompiled.delegatecall(abi.encodeWithSignature("owner(uint256)", solana_address));
+    function owner(uint256 solana_address) public view returns (uint256) {
+        (bool success, bytes memory result) = precompiled.staticcall(abi.encodeWithSignature("owner(uint256)", solana_address));
         require(success, "QueryAccount.owner failed");
         return to_uint256(result);
     }
 
     // Takes a Solana address, treats it as an address of an account.
     // Returns the length of the account's data (8 bytes).
-    function length(uint256 solana_address) public returns (uint256) {
-        (bool success, bytes memory result) = precompiled.delegatecall(abi.encodeWithSignature("length(uint256)", solana_address));
+    function length(uint256 solana_address) public view returns (uint256) {
+        (bool success, bytes memory result) = precompiled.staticcall(abi.encodeWithSignature("length(uint256)", solana_address));
         require(success, "QueryAccount.length failed");
         return to_uint256(result);
     }
 
     // Takes a Solana address, treats it as an address of an account.
     // Returns the funds in lamports of the account.
-    function lamports(uint256 solana_address) public returns (uint256) {
-        (bool success, bytes memory result) = precompiled.delegatecall(abi.encodeWithSignature("lamports(uint256)", solana_address));
+    function lamports(uint256 solana_address) public view returns (uint256) {
+        (bool success, bytes memory result) = precompiled.staticcall(abi.encodeWithSignature("lamports(uint256)", solana_address));
         require(success, "QueryAccount.lamports failed");
         return to_uint256(result);
     }
 
     // Takes a Solana address, treats it as an address of an account.
     // Returns the executable flag of the account.
-    function executable(uint256 solana_address) public returns (bool) {
-        (bool success, bytes memory result) = precompiled.delegatecall(abi.encodeWithSignature("executable(uint256)", solana_address));
+    function executable(uint256 solana_address) public view returns (bool) {
+        (bool success, bytes memory result) = precompiled.staticcall(abi.encodeWithSignature("executable(uint256)", solana_address));
         require(success, "QueryAccount.executable failed");
         return to_bool(result);
     }
 
     // Takes a Solana address, treats it as an address of an account.
     // Returns the rent epoch of the account.
-    function rent_epoch(uint256 solana_address) public returns (uint256) {
-        (bool success, bytes memory result) = precompiled.delegatecall(abi.encodeWithSignature("rent_epoch(uint256)", solana_address));
+    function rent_epoch(uint256 solana_address) public view returns (uint256) {
+        (bool success, bytes memory result) = precompiled.staticcall(abi.encodeWithSignature("rent_epoch(uint256)", solana_address));
         require(success, "QueryAccount.rent_epoch failed");
         return to_uint256(result);
     }
@@ -47,8 +47,8 @@ contract QueryAccount {
     // Takes a Solana address, treats it as an address of an account,
     // also takes an offset and length of the account's data.
     // Returns a chunk of the data (length bytes).
-    function data(uint256 solana_address, uint64 offset, uint64 len) public returns (bytes memory) {
-        (bool success, bytes memory result) = precompiled.delegatecall(abi.encodeWithSignature("data(uint256,uint64,uint64)", solana_address, offset, len));
+    function data(uint256 solana_address, uint64 offset, uint64 len) public view returns (bytes memory) {
+        (bool success, bytes memory result) = precompiled.staticcall(abi.encodeWithSignature("data(uint256,uint64,uint64)", solana_address, offset, len));
         require(success, "QueryAccount.data failed");
         return result;
     }


### PR DESCRIPTION
Use staticcall instead of delegatecall.

For example:
```
     // Takes a Solana address, treats it as an address of an account.
     // Returns the account's owner Solana address (32 bytes).
-    function owner(uint256 solana_address) public returns (uint256) {
-        (bool success, bytes memory result) = precompiled.delegatecall(abi.encodeWithSignature("owner(uint256)", solana_address));
+    function owner(uint256 solana_address) public view returns (uint256) {
+        (bool success, bytes memory result) = precompiled.staticcall(abi.encodeWithSignature("owner(uint256)", solana_address));
         require(success, "QueryAccount.owner failed");
         return to_uint256(result);
     }
```