### PR TITLE
382 query account caching

### DIFF
--- a/evm_loader/program/src/account_storage.rs
+++ b/evm_loader/program/src/account_storage.rs
@@ -1,11 +1,10 @@
 //! `AccountStorage` for solana program realisation
+
 use std::{
     cell::RefCell,
     collections::BTreeMap
 };
 
-use evm::{H160, U256};
-use evm::backend::Apply;
 use solana_program::{
     account_info::{AccountInfo, next_account_info},
     entrypoint::ProgramResult,
@@ -15,17 +14,17 @@ use solana_program::{
     sysvar::{clock::Clock, Sysvar},
 };
 
+use evm::{backend::Apply, H160, U256};
+
 use crate::{
-    account_data::{ACCOUNT_SEED_VERSION, AccountData},
+    account_data::{ACCOUNT_SEED_VERSION, AccountData, ERC20Allowance},
+    executor_state::{ERC20Approve, SplApprove, SplTransfer},
     precompile_contracts::is_precompile_address,
     solana_backend::{AccountStorage, AccountStorageInfo},
-    // utils::keccak256_h256,
     solidity_account::SolidityAccount,
     system::create_pda_account,
-    token::{check_token_account, get_token_account_balance, transfer_token}
+    token::{check_token_account, get_token_account_balance, transfer_token},
 };
-use crate::account_data::ERC20Allowance;
-use crate::executor_state::{ERC20Approve, SplApprove, SplTransfer};
 
 /// Sender
 pub enum Sender {

--- a/evm_loader/program/src/account_storage.rs
+++ b/evm_loader/program/src/account_storage.rs
@@ -478,6 +478,7 @@ impl<'a> ProgramAccountStorage<'a> {
     }
 }
 
+#[allow(clippy::nursery)]
 impl<'a> AccountStorage for ProgramAccountStorage<'a> {
     fn apply_to_account<U, D, F>(&self, address: &H160, _d: D, f: F) -> U
         where F: FnOnce(&SolidityAccount) -> U,

--- a/evm_loader/program/src/error.rs
+++ b/evm_loader/program/src/error.rs
@@ -3,10 +3,9 @@
 
 use num_derive::FromPrimitive;
 use solana_program::{decode_error::DecodeError, program_error::ProgramError};
-use thiserror::Error;
 
 /// Errors that may be returned by the EVM Loader program.
-#[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
+#[derive(thiserror::Error, Clone, Debug, Eq, PartialEq, FromPrimitive)]
 pub enum EvmLoaderError {
     /// Unknown Error.
     #[error("Unknown error. Attention required.")]

--- a/evm_loader/program/src/executor_state.rs
+++ b/evm_loader/program/src/executor_state.rs
@@ -11,16 +11,12 @@ use std::{
     vec::Vec
 };
 
-use evm::{ExitError, H160, H256, Transfer, U256, Valids};
+use evm::{ExitError, gasometer::Gasometer, H160, H256, Transfer, U256, Valids};
 use evm::backend::{Apply, Log};
-use evm::gasometer::Gasometer;
 use serde::{Deserialize, Serialize};
-use solana_program::pubkey::Pubkey;
-use solana_program::keccak::Hash;
+use solana_program::{keccak::Hash, pubkey::Pubkey};
 
-use crate::query;
-use crate::solana_backend::AccountStorage;
-use crate::utils::keccak256_h256;
+use crate::{query, solana_backend::AccountStorage, utils::keccak256_h256};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct ExecutorAccount {

--- a/evm_loader/program/src/hamt.rs
+++ b/evm_loader/program/src/hamt.rs
@@ -89,7 +89,7 @@ impl<'a> Hamt<'a> {
 
     fn release_item(&mut self, item_type: u8, item_pos: u32) {
         let free_pos = u32::from(item_type) * (size_of::<u32>() as u32);
-        if item_type >= 32 || item_type == 0 {panic!("Release unreleased items");};
+        assert!(!(item_type >= 32 || item_type == 0), "Release unreleased items");
         let size:u32 = match item_type {
             0 => (256+256)/8,
             _ => (4 + u32::from(item_type) * 4),

--- a/evm_loader/program/src/lib.rs
+++ b/evm_loader/program/src/lib.rs
@@ -20,6 +20,7 @@ pub mod account_data;
 pub mod account_storage;
 pub mod solidity_account;
 mod storage_account;
+mod query;
 pub mod instruction;
 mod transaction;
 /// Todo: document

--- a/evm_loader/program/src/precompile_contracts.rs
+++ b/evm_loader/program/src/precompile_contracts.rs
@@ -1,16 +1,20 @@
 //! `EVMLoader` precompile contracts
 
 use core::convert::Infallible;
-use std::convert::TryInto;
+use std::convert::TryInto as _;
 
 use arrayref::{array_ref, array_refs};
 use evm::{Capture, ExitReason, H160, U256};
-use solana_program::pubkey::Pubkey;
-use solana_program::secp256k1_recover::secp256k1_recover;
+use solana_program::{
+    pubkey::Pubkey,
+    secp256k1_recover::secp256k1_recover,
+};
 
-use crate::executor_state::ExecutorState;
-use crate::solana_backend::AccountStorage;
-use crate::utils::keccak256_digest;
+use crate::{
+    executor_state::ExecutorState,
+    solana_backend::AccountStorage,
+    utils::keccak256_digest,
+};
 
 const SYSTEM_ACCOUNT_ERC20_WRAPPER: H160 =     H160([0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01]);
 const SYSTEM_ACCOUNT_QUERY: H160 =             H160([0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x02]);

--- a/evm_loader/program/src/query.rs
+++ b/evm_loader/program/src/query.rs
@@ -2,8 +2,7 @@
 
 use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
-use solana_program::keccak::Hash;
-use solana_program::pubkey::Pubkey;
+use solana_program::{keccak::Hash, pubkey::Pubkey};
 
 /// Represents error states of queries.
 #[derive(thiserror::Error, Debug)]

--- a/evm_loader/program/src/query.rs
+++ b/evm_loader/program/src/query.rs
@@ -1,0 +1,50 @@
+//! `EVMLoader` query account cache.
+
+use std::collections::BTreeMap;
+use serde::{Deserialize, Serialize};
+use solana_program::keccak::Hash;
+use solana_program::pubkey::Pubkey;
+
+/// Represents error states of queries.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("account not found")]
+    AccountNotFound,
+    #[error("account was changed")]
+    AccountChanged,
+    #[error("invalid argument")]
+    InvalidArgument,
+}
+
+/// Result type for queries.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Represents cache of queries to Solana accounts.
+#[derive(Serialize, Deserialize, Default, Debug)]
+pub struct AccountCache {
+    cache: BTreeMap<Pubkey, Data>,
+}
+
+impl AccountCache {
+    /// Creates new instance of the cache object.
+    pub fn new() -> Self {
+        Self {
+            cache: BTreeMap::new(),
+        }
+    }
+
+    /// Checks if the hash of an account was changed.
+    /// Adds new entry if missing in the cache.
+    pub fn changed(&mut self, address: &Pubkey, new_hash: Hash) -> bool {
+        if let Some(hash) = self.cache.get(address).map(|d| d.hash) {
+            return hash != new_hash;
+        }
+        self.cache.insert(*address, Data{ hash: new_hash });
+        false
+    }
+}
+
+#[derive(Serialize, Deserialize, Default, Debug)]
+struct Data {
+    hash: Hash,
+}

--- a/evm_loader/program/src/solana_backend.rs
+++ b/evm_loader/program/src/solana_backend.rs
@@ -1,19 +1,22 @@
 //! Solana Backend for rust evm
 
-use crate::{
-    account_data::{AccountData, ACCOUNT_SEED_VERSION},
-    solidity_account::SolidityAccount,
-    token::{get_token_account_data, get_token_mint_data},
-    utils::keccak256_h256,
-};
-use evm::{backend::Basic, H160, H256, U256};
+use std::{cell::RefCell, rc::Rc};
+
 use solana_program::{
     account_info::AccountInfo,
     clock::Epoch,
     keccak::{Hash, Hasher},
     pubkey::Pubkey,
 };
-use std::{cell::RefCell, rc::Rc};
+
+use evm::{backend::Basic, H160, H256, U256};
+
+use crate::{
+    account_data::{AccountData, ACCOUNT_SEED_VERSION},
+    solidity_account::SolidityAccount,
+    token::{get_token_account_data, get_token_mint_data},
+    utils::keccak256_h256,
+};
 
 /// Account information for `apply_to_solana_account`.
 pub struct AccountStorageInfo<'a> {

--- a/evm_loader/program/src/solana_backend.rs
+++ b/evm_loader/program/src/solana_backend.rs
@@ -10,6 +10,7 @@ use evm::{backend::Basic, H160, H256, U256};
 use solana_program::{
     account_info::AccountInfo,
     clock::Epoch,
+    keccak::{Hash, Hasher},
     pubkey::Pubkey,
 };
 use std::{cell::RefCell, rc::Rc};
@@ -39,6 +40,18 @@ impl<'a> AccountStorageInfo<'a> {
             executable: info.executable,
             rent_epoch: info.rent_epoch,
         }
+    }
+
+    /// Calculates hash of the account.
+    #[must_use]
+    pub fn hash(&self) -> Hash {
+        let mut hasher = Hasher::default();
+        hasher.hash(&self.lamports.to_be_bytes());
+        hasher.hash(&self.data.borrow());
+        hasher.hash(&self.owner.to_bytes());
+        hasher.hash(&(self.executable as u8).to_be_bytes());
+        hasher.hash(&self.rent_epoch.to_be_bytes());
+        hasher.result()
     }
 }
 

--- a/evm_loader/program/src/storage_account.rs
+++ b/evm_loader/program/src/storage_account.rs
@@ -185,7 +185,7 @@ impl<'a> StorageAccount<'a> {
 
         let keys_storage = &account_data[begin..end];
         let chunks = keys_storage.chunks_exact(32);
-        let keys = chunks.map(|c| Pubkey::new(c)).collect();
+        let keys = chunks.map(Pubkey::new).collect();
 
         Ok(keys)
     }

--- a/evm_loader/program/src/utils.rs
+++ b/evm_loader/program/src/utils.rs
@@ -29,14 +29,14 @@ pub fn u256_to_h256(value: U256) -> H256 {
     H256::from_slice(&v)
 }
 
-/// Check whether array is zero initialized
+/// Checks whether array is zero initialized.
+/// Uses `align_to` to convert the slice of u8 into a slice of u128,
+/// making the comparison much more efficient. See also:
+/// <https://stackoverflow.com/questions/65367552/checking-a-vecu8-to-see-if-its-all-zero>
 #[must_use]
 pub fn is_zero_initialized(data: &[u8]) -> bool {
-    for d in data {
-        if *d != 0_u8 {
-            return false;
-        }
-    }
-
-    true
+    let (prefix, aligned, suffix) = unsafe { data.align_to::<u128>() };
+    prefix.iter().all(|&x| x == 0)
+        && suffix.iter().all(|&x| x == 0)
+        && aligned.iter().all(|&x| x == 0)
 }


### PR DESCRIPTION
Added protection of QueryAccount from change of accounts during iterative transaction. If an account had changed, the transaction will have been reverted.