### PR TITLE
#420 Do not require neon token accounts

### DIFF
--- a/evm_loader/cli/src/account_storage.rs
+++ b/evm_loader/cli/src/account_storage.rs
@@ -124,7 +124,6 @@ struct SolanaAccount {
     writable: bool,
     code_size: Option<usize>,
     code_size_current: Option<usize>,
-    balance: u64,
 }
 
 struct SolanaNewAccount {
@@ -134,9 +133,9 @@ struct SolanaNewAccount {
 }
 
 impl SolanaAccount {
-    pub fn new(account: Account, key: Pubkey, balance: u64, code_account: Option<Account>) -> Self {
+    pub fn new(account: Account, key: Pubkey, code_account: Option<Account>) -> Self {
         eprintln!("SolanaAccount::new");
-        Self{account, key, balance, writable: false, code_account, code_size: None, code_size_current : None}
+        Self{account, key, writable: false, code_account, code_size: None, code_size_current : None}
     }
 }
 
@@ -246,8 +245,8 @@ impl<'a> EmulatorAccountStorage<'a> {
         let mut new_accounts = self.new_accounts.borrow_mut(); 
         if accounts.get(address).is_none() {
             let (solana_address, _solana_nonce) = make_solana_program_address(address, &self.config.evm_loader);
-            if let Some((acc, balance, code_account)) = Self::get_account_from_solana(self.config, address) {
-                accounts.insert(*address, SolanaAccount::new(acc, solana_address, balance, code_account));
+            if let Some((acc, _balance, code_account)) = Self::get_account_from_solana(self.config, address) {
+                accounts.insert(*address, SolanaAccount::new(acc, solana_address, code_account));
                 true
             }
             else {
@@ -566,10 +565,10 @@ impl<'a> AccountStorage for EmulatorAccountStorage<'a> {
                         Err(_) => return d(),
                     };
                     let code_data: std::rc::Rc<std::cell::RefCell<&mut [u8]>> = Rc::new(RefCell::new(&mut code_data));
-                    let account = SolidityAccount::new(&acc.key, acc.balance, account_data, Some((contract_data, code_data)));
+                    let account = SolidityAccount::new(&acc.key, account_data, Some((contract_data, code_data)));
                     f(&account)
                 } else {
-                    let account = SolidityAccount::new(&acc.key, acc.balance, account_data, None);
+                    let account = SolidityAccount::new(&acc.key, account_data, None);
                     f(&account)
                 }
             },

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -1068,7 +1068,7 @@ fn command_get_storage_at(
     index: &U256
 ) -> CommandResult {
     match EmulatorAccountStorage::get_account_from_solana(config, ether_address) {
-        Some((acc, balance, code_account)) => {
+        Some((acc, _balance, code_account)) => {
             let account_data = AccountData::unpack(&acc.data)?;
             let mut code_data = match code_account.as_ref() {
                 Some(code) => code.data.clone(),
@@ -1077,7 +1077,7 @@ fn command_get_storage_at(
             let contract_data = AccountData::unpack(&code_data)?;
             let (solana_address, _solana_nonce) = make_solana_program_address(ether_address, &config.evm_loader);
             let code_data: std::rc::Rc<std::cell::RefCell<&mut [u8]>> = Rc::new(RefCell::new(&mut code_data));
-            let solidity_account = SolidityAccount::new(&solana_address, balance, account_data,
+            let solidity_account = SolidityAccount::new(&solana_address, account_data,
                                                         Some((contract_data, code_data)));
             let value = solidity_account.get_storage(index);
             print!("{:#x}", value);
@@ -1096,15 +1096,15 @@ fn command_cancel_trx(
     let storage = config.rpc_client.get_account_with_commitment(storage_account, CommitmentConfig::processed()).unwrap().value;
 
     if let Some(acc) = storage {
-        let keys:Vec<Pubkey> = {
-            if acc.owner != config.evm_loader {
-                return Err(format!("Invalid owner {} for storage account", acc.owner.to_string()).into());
-            }
-            let data = AccountData::unpack(&acc.data)?;
-            let data_end = data.size();
-            let storage = if let AccountData::Storage(storage) = data {storage}
-                    else {return Err("Not storage account".to_string().into());};
+        if acc.owner != config.evm_loader {
+            return Err(format!("Invalid owner {} for storage account", acc.owner.to_string()).into());
+        }
+        let data = AccountData::unpack(&acc.data)?;
+        let data_end = data.size();
+        let storage = if let AccountData::Storage(storage) = data {storage}
+                else {return Err("Not storage account".to_string().into());};
 
+        let keys: Vec<Pubkey> = {
             println!("{:?}", storage);
             let accounts_begin = data_end;
             let accounts_end = accounts_begin + storage.accounts_len * 32;
@@ -1115,7 +1115,8 @@ fn command_cancel_trx(
             acc.data[accounts_begin..accounts_end].chunks_exact(32).map(|c| Pubkey::new(c)).collect()
         };
 
-        let (trx_count, _caller_ether, caller_token) = get_ether_account_nonce(config, &keys[3])?;
+        let (caller_solana, _) = make_solana_program_address(&storage.caller, &config.evm_loader);
+        let (trx_count, _caller_ether, caller_token) = get_ether_account_nonce(config, &caller_solana)?;
 
         let operator = &config.signer.pubkey();
         let operator_token = spl_associated_token_account::get_associated_token_address(operator, &token_mint::id());

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -213,9 +213,10 @@ fn command_emulate(config: &Config, contract_id: Option<H160>, caller_id: H160, 
     debug!("Call done");
     let status = match exit_reason {
         ExitReason::Succeed(_) => {
-            let (applies, _logs, _transfers, spl_transfers, spl_approves, erc20_approves) = applies_logs.unwrap();
+            let (applies, _logs, transfers, spl_transfers, spl_approves, erc20_approves) = applies_logs.unwrap();
 
             storage.apply(applies);
+            storage.apply_transfers(transfers);
             storage.apply_spl_approves(spl_approves);
             storage.apply_spl_transfers(spl_transfers);
             storage.apply_erc20_approves(erc20_approves);

--- a/evm_loader/program/src/account_storage.rs
+++ b/evm_loader/program/src/account_storage.rs
@@ -4,7 +4,7 @@ use crate::{
     solana_backend::{AccountStorage, AccountStorageInfo},
     solidity_account::SolidityAccount,
     // utils::keccak256_h256,
-    token::{transfer_token},
+    token::{transfer_token, get_token_account_data},
     precompile_contracts::is_precompile_address,
     system::create_pda_account
 };
@@ -357,6 +357,16 @@ impl<'a> AccountStorage for ProgramAccountStorage<'a> {
 
     fn origin(&self) -> H160 {
         self.caller
+    }
+
+    fn balance(&self, address: &H160) -> U256 {
+        let account = self.get_solidity_account(address);
+        let token_account = &self.solana_accounts[account.get_neon_token_solana_address()];
+
+        let token = get_token_account_data(&token_account.data.borrow(), token_account.owner)
+            .expect("Invalid token account");
+
+        U256::from(token.amount) * crate::token::eth::min_transfer_value()
     }
 
     fn block_number(&self) -> U256 {

--- a/evm_loader/program/src/account_storage.rs
+++ b/evm_loader/program/src/account_storage.rs
@@ -4,7 +4,7 @@ use crate::{
     solana_backend::{AccountStorage, AccountStorageInfo},
     solidity_account::SolidityAccount,
     // utils::keccak256_h256,
-    token::{transfer_token, get_token_account_data},
+    token::{transfer_neon_token, get_token_account_data},
     precompile_contracts::is_precompile_address,
     system::create_pda_account
 };
@@ -196,7 +196,7 @@ impl<'a> ProgramAccountStorage<'a> {
             let target = self.get_solidity_account(&transfer.target);
             let target_token_account = self.solana_accounts[target.get_neon_token_solana_address()];
 
-            transfer_token(
+            transfer_neon_token(
                 accounts,
                 source_token_account,
                 target_token_account,

--- a/evm_loader/program/src/account_storage.rs
+++ b/evm_loader/program/src/account_storage.rs
@@ -4,14 +4,14 @@ use crate::{
     solana_backend::{AccountStorage, AccountStorageInfo},
     solidity_account::SolidityAccount,
     // utils::keccak256_h256,
-    token::{get_token_account_balance, check_token_account, transfer_token},
+    token::{transfer_token},
     precompile_contracts::is_precompile_address,
     system::create_pda_account
 };
 use evm::backend::Apply;
 use evm::{H160,  U256};
 use solana_program::{
-    account_info::{AccountInfo, next_account_info},
+    account_info::{AccountInfo},
     pubkey::Pubkey,
     program_error::ProgramError,
     sysvar::{clock::Clock, Sysvar},
@@ -19,49 +19,25 @@ use solana_program::{
     entrypoint::ProgramResult,
 };
 use std::{
-    cell::RefCell,
     collections::BTreeMap
 };
 use crate::executor_state::{SplTransfer, ERC20Approve, SplApprove};
 use crate::account_data::ERC20Allowance;
 
-/// Sender
-pub enum Sender {
-    /// Ethereum account address
-    Ethereum (H160),
-    /// Solana account ethereum address
-    Solana (H160),
-}
 
-struct AccountMeta<'a> {
-    account: &'a AccountInfo<'a>,
-    #[allow(dead_code)]
-    token: &'a AccountInfo<'a>,
-    code: Option<&'a AccountInfo<'a>>
-}
 
 /// `AccountStorage` for solana program realization
 pub struct ProgramAccountStorage<'a> {
     solana_accounts: BTreeMap<Pubkey, &'a AccountInfo<'a>>,
-    accounts: Vec<SolidityAccount<'a>>,
-    aliases: RefCell<Vec<(H160, usize)>>,
-    account_metas: Vec<AccountMeta<'a>>,
-    contract_id: H160,
-    sender: Sender,
+    solidity_accounts: Vec<SolidityAccount<'a>>,
+    contract: H160,
+    caller: H160,
     program_id: Pubkey
 }
 
-
 impl<'a> ProgramAccountStorage<'a> {
     /// `ProgramAccountStorage` constructor
-    /// 
-    /// `account_infos` expectations: 
-    /// 
-    /// 0. contract account info
-    /// 1. contract code info
-    /// 2. caller or caller account info(for ether account)
-    /// 3. ... other accounts
-    /// 
+    ///
     /// # Errors
     ///
     /// Will return: 
@@ -77,172 +53,73 @@ impl<'a> ProgramAccountStorage<'a> {
             solana_accounts.insert(*info.key, info);
         }
 
-        let account_info_iter = &mut account_infos.iter();
-
-        let mut accounts = Vec::with_capacity(account_infos.len());
-        let mut aliases = Vec::with_capacity(account_infos.len());
-        let mut account_metas = Vec::with_capacity(account_infos.len());
-
-        let mut push_account = |sol_account: SolidityAccount<'a>, account_info: &'a AccountInfo<'a>, token_info: &'a AccountInfo<'a>, code_info: Option<&'a AccountInfo<'a>>| {
-            aliases.push((sol_account.get_ether(), accounts.len()));
-            accounts.push(sol_account);
-            account_metas.push(AccountMeta{account: account_info, token: token_info, code: code_info});
-        };
-
-        let construct_contract_account = |account_info: &'a AccountInfo<'a>, token_info: &'a AccountInfo<'a>, code_info: &'a AccountInfo<'a>,| -> Result<SolidityAccount<'a>, ProgramError>
-        {
-            if account_info.owner != program_id || code_info.owner != program_id {
-                return Err!(ProgramError::InvalidArgument; "Invalid owner! account_info.owner={:?}, code_info.owner={:?}, program_id={:?}", account_info.owner, code_info.owner, program_id);
+        let mut solidity_accounts = Vec::new();
+        for account_info in account_infos {
+            if account_info.owner != program_id {
+                continue;
             }
 
             let account_data = AccountData::unpack(&account_info.data.borrow())?;
-            let account = account_data.get_account()?;
-    
-            if *code_info.key != account.code_account {
-                return Err!(ProgramError::InvalidAccountData; "code_info.key={:?}, account.code_account={:?}", *code_info.key, account.code_account)
-            }
-    
-            let code_data = code_info.data.clone();
-            let code_acc = AccountData::unpack(&code_data.borrow())?;
-            code_acc.get_contract()?;
-    
-            Ok(SolidityAccount::new(account_info.key, get_token_account_balance(token_info)?, account_data, Some((code_acc, code_data))))
-        };
-
-        let contract_id = {
-            let program_info = next_account_info(account_info_iter)?;
-            if program_info.owner != program_id {
-                return Err!(ProgramError::InvalidArgument; "Invalid owner! program_info.owner={:?}, program_id={:?}", program_info.owner, program_id);
-            }
-
-            let program_token = next_account_info(account_info_iter)?;
-            check_token_account(program_token, program_info)?;
-
-            let account_data = AccountData::unpack(&program_info.data.borrow())?;
-            let account = account_data.get_account()?;
-
-            let (contract_acc, program_code) = if account.code_account == Pubkey::new_from_array([0_u8; 32]) {
-                (SolidityAccount::new(program_info.key, get_token_account_balance(program_token)?, account_data, None) , None)
-            } else {
-                let program_code = next_account_info(account_info_iter)?;
-                (construct_contract_account(program_info, program_token, program_code)?, Some(program_code))
+            let account = match account_data.get_account() {
+                Ok(account) => account,
+                Err(_) => continue
             };
-            
-            let contract_id = contract_acc.get_ether();
-            push_account(contract_acc, program_info, program_token, program_code);
 
-            contract_id
-        };
-
-        let sender = {
-            let caller_info = next_account_info(account_info_iter)?;
-            
-            if caller_info.owner == program_id {
-                let caller_token_info = next_account_info(account_info_iter)?;
-                check_token_account(caller_token_info, caller_info)?;
-
-                let account_data = AccountData::unpack(&caller_info.data.borrow())?;
-                account_data.get_account()?;
-                
-                let caller_acc = SolidityAccount::new(caller_info.key, get_token_account_balance(caller_token_info)?, account_data, None);
-                let caller_address = caller_acc.get_ether();
-                push_account(caller_acc, caller_info, caller_token_info, None);
-                Sender::Ethereum(caller_address)
+            let code = if account.code_account == Pubkey::new_from_array([0_u8; 32]) {
+                None
             } else {
-                // TODO: EvmInstruction::Call
-                // https://github.com/neonlabsorg/neon-evm/issues/188
-                // Does not fit in current vision.
-                // It is needed to update behavior for all system in whole.
-                return Err!(ProgramError::InvalidArgument; "Caller could not be Solana user. It must be neon-evm owned account");
+                let code_info = solana_accounts[&account.code_account];
+                let code_data = AccountData::unpack(&code_info.data.borrow())?;
+                Some((code_data, code_info.data.clone()))
+            };
 
-                // if !caller_info.is_signer {
-                //     return Err!(ProgramError::InvalidArgument; "Caller must be signer. Caller pubkey: {} ", &caller_info.key.to_string());
-                // }
-
-                // Sender::Solana(keccak256_h256(&caller_info.key.to_bytes()).into())
-            }
-        };
-
-        while let Ok(account_info) = next_account_info(account_info_iter) {
-            if account_info.owner == program_id {
-                let account_data = AccountData::unpack(&account_info.data.borrow())?;
-                let account = match account_data {
-                    AccountData::Account(ref acc) => acc,
-                    _ => { continue; },
-                };
-
-                let token_info = next_account_info(account_info_iter)?;
-                check_token_account(token_info, account_info)?;
-
-                let (sol_account, code_info) = if account.code_account == Pubkey::new_from_array([0_u8; 32]) {
-                    debug_print!("User account");
-                    (SolidityAccount::new(account_info.key, get_token_account_balance(token_info)?, account_data, None) , None)
-                } else {
-                    debug_print!("Contract account");
-                    let code_info = next_account_info(account_info_iter)?;
-
-                    (construct_contract_account(account_info, token_info, code_info)?, Some(code_info))
-                };
-
-                push_account(sol_account, account_info, token_info, code_info);
-            }
+            let solidity_account = SolidityAccount::new(account_info.key, account_data, code);
+            solidity_accounts.push(solidity_account);
         }
 
-        debug_print!("Accounts was read");
-        aliases.sort_by_key(|v| v.0);
+        let contract = solidity_accounts[0].get_ether();
+        let caller = solidity_accounts[1].get_ether();
 
-        Ok(Self {
+        solidity_accounts.sort_by_key(SolidityAccount::get_ether);
+
+        Ok(ProgramAccountStorage{
             solana_accounts,
-            accounts,
-            aliases: RefCell::new(aliases),
-            account_metas,
-            contract_id,
-            sender,
+            solidity_accounts,
+            contract,
+            caller,
             program_id: *program_id
         })
     }
 
-    /// Get sender address
-    pub const fn get_sender(&self) -> &Sender {
-        &self.sender
+    #[must_use]
+    fn get_solidity_account_index(&self, address: &H160) -> usize {
+        self.solidity_accounts.binary_search_by_key(address,SolidityAccount::get_ether)
+            .unwrap_or_else(|_| panic!("Solidity account {} must be present in the transaction", address))
+    }
+
+    #[must_use]
+    fn get_solidity_account(&self, address: &H160) -> &SolidityAccount<'a> {
+        let index = self.get_solidity_account_index(address);
+        &self.solidity_accounts[index]
     }
 
     /// Get contract `SolidityAccount`
-    pub fn get_contract_account(&self) -> Option<&SolidityAccount<'a>> {
-        self.get_account(&self.contract_id)
+    #[must_use]
+    pub fn get_contract_account(&self) -> &SolidityAccount<'a> {
+        self.get_solidity_account(&self.contract)
     }
 
     /// Get caller `SolidityAccount`
-    pub fn get_caller_account(&self) -> Option<&SolidityAccount<'a>> {
-        match self.sender {
-            Sender::Ethereum(addr) => self.get_account(&addr),
-            Sender::Solana(_addr) => None,
-        }
+    #[must_use]
+    pub fn get_caller_account(&self) -> &SolidityAccount<'a> {
+        self.get_solidity_account(&self.caller)
     }
 
-    fn find_account(&self, address: &H160) -> Option<usize> {
-        let aliases = self.aliases.borrow();
-        if let Ok(pos) = aliases.binary_search_by_key(&address, |v| &v.0) {
-            debug_print!("Found account for {:?} on position {}", &address, &pos.to_string());
-            Some(aliases[pos].1)
-        }
-        else {
-            debug_print!("Not found account for {:?}", &address);
-            None
-        }
-    }
-
-    fn get_account(&self, address: &H160) -> Option<&SolidityAccount<'a>> {
-        self.find_account(address).map(|pos| &self.accounts[pos])
-    }
-
-    /// Get caller account info
-    pub fn get_caller_account_info(&self) -> Option<&AccountInfo<'a>> {
-        if let Some(account_index) = self.find_account(&self.origin()) {
-            let AccountMeta{ account, token: _, code: _ } = &self.account_metas[account_index];
-            return Some(account);
-        }
-        None
+    /// Get caller `AccountInfo`
+    #[must_use]
+    pub fn get_caller_account_info(&self) -> &AccountInfo<'a> {
+        let caller = self.get_caller_account();
+        self.solana_accounts[caller.get_solana_address()]
     }
 
     /// Apply contact execution results
@@ -254,7 +131,7 @@ impl<'a> ProgramAccountStorage<'a> {
     /// or `account.update` errors
     pub fn apply<A, I>(
         &mut self, values: A,
-        operator: Option<&AccountInfo<'a>>,
+        operator: &AccountInfo<'a>,
         _delete_empty: bool
     ) -> Result<(), ProgramError>
     where
@@ -267,58 +144,36 @@ impl<'a> ProgramAccountStorage<'a> {
                     if is_precompile_address(&address) {
                         continue;
                     }
-                    if let Some(pos) = self.find_account(&address) {
-                        let account = &mut self.accounts[pos];
-                        let AccountMeta{ account: account_info, token: _, code: _ } = &self.account_metas[pos];
-                        account.update(account_info, address, nonce, &code_and_valids, storage, reset_storage)?;
-                    } else {
-                        if let Sender::Solana(addr) = self.sender {
-                            if addr == address {
-                                debug_print!("This is solana user, because {:?} == {:?}.", address, addr);
-                                continue;
-                            }
-                        }
-                        return Err!(ProgramError::NotEnoughAccountKeys; "Apply can't be done. Not found account for address = {:?}.", address);
-                    }
+
+                    let index = self.get_solidity_account_index(&address);
+                    let account = &mut self.solidity_accounts[index];
+                    let account_info = self.solana_accounts[account.get_solana_address()];
+                    account.update(account_info, address, nonce, &code_and_valids, storage, reset_storage)?;
                 },
                 Apply::Delete { address } => {
                     debug_print!("Going to delete address = {:?}.", address);
 
-                    if let Some(pos) = self.find_account(&address) {
-                        let AccountMeta{ account: account_info, token: _, code: code_info } = &self.account_metas[pos];
-                        let code_info = if let Some(code_info) = code_info {
-                            code_info
-                        } else {
-                            return Err!(ProgramError::InvalidAccountData; "Only contract account could be deleted. account = {:?} -> {:?}.", address, account_info.key);
-                        };
+                    let index = self.get_solidity_account_index(&address);
+                    let account = &mut self.solidity_accounts[index];
+                    let account_info = self.solana_accounts[account.get_solana_address()];
+                    let code_info = self.solana_accounts[account.get_code_solana_address()];
 
-                        let recipient = if let Some(some_operator) = operator {
-                            some_operator
-                        } else {
-                            self.get_caller_account_info().ok_or_else(|| E!(ProgramError::InvalidArgument))?
-                        };
+                    debug_print!("Move funds from account");
+                    **operator.lamports.borrow_mut() += account_info.lamports();
+                    **account_info.lamports.borrow_mut() = 0;
 
-                        debug_print!("Move funds from account");
-                        **recipient.lamports.borrow_mut() += account_info.lamports();
-                        **account_info.lamports.borrow_mut() = 0;
+                    debug_print!("Move funds from code");
+                    **operator.lamports.borrow_mut() += code_info.lamports();
+                    **code_info.lamports.borrow_mut() = 0;
 
-                        debug_print!("Move funds from code");
-                        **recipient.lamports.borrow_mut() += code_info.lamports();
-                        **code_info.lamports.borrow_mut() = 0;
-
-                        debug_print!("Mark accounts empty");
-                        let mut account_data = account_info.try_borrow_mut_data()?;
-                        AccountData::pack(&AccountData::Empty, &mut account_data)?;
-                        let mut code_data = code_info.try_borrow_mut_data()?;
-                        AccountData::pack(&AccountData::Empty, &mut code_data)?;
-                    } else {
-                        return Err!(ProgramError::NotEnoughAccountKeys; "Apply can't be done. Not found account for address = {:?}.", address);
-                    }
+                    debug_print!("Mark accounts empty");
+                    let mut account_data = account_info.try_borrow_mut_data()?;
+                    AccountData::pack(&AccountData::Empty, &mut account_data)?;
+                    let mut code_data = code_info.try_borrow_mut_data()?;
+                    AccountData::pack(&AccountData::Empty, &mut code_data)?;
                 }
             }
         }
-
-        //for log in logs {};
 
         Ok(())
     }
@@ -334,19 +189,19 @@ impl<'a> ProgramAccountStorage<'a> {
         debug_print!("apply_transfers {:?}", transfers);
 
         for transfer in transfers {
-            let source_account_index = self.find_account(&transfer.source).ok_or_else(||E!(ProgramError::NotEnoughAccountKeys))?;
-            let AccountMeta{ account: source_account, token: source_token_account, code: _ } = &self.account_metas[source_account_index];
-            let source_solidity_account = &self.accounts[source_account_index];
+            let source = self.get_solidity_account(&transfer.source);
+            let source_account = self.solana_accounts[source.get_solana_address()];
+            let source_token_account = self.solana_accounts[source.get_neon_token_solana_address()];
 
-            let target_account_index = self.find_account(&transfer.target).ok_or_else(||E!(ProgramError::NotEnoughAccountKeys))?;
-            let AccountMeta{ account: _, token: target_token_account, code: _ } = &self.account_metas[target_account_index];
+            let target = self.get_solidity_account(&transfer.target);
+            let target_token_account = self.solana_accounts[target.get_neon_token_solana_address()];
 
             transfer_token(
                 accounts,
                 source_token_account,
                 target_token_account,
                 source_account,
-                source_solidity_account,
+                source,
                 &transfer.value,
             )?;
         }
@@ -367,13 +222,13 @@ impl<'a> ProgramAccountStorage<'a> {
         debug_print!("apply_spl_transfers {:?}", transfers);
 
         for transfer in transfers {
-            let source = self.get_account(&transfer.source).ok_or_else(||E!(ProgramError::NotEnoughAccountKeys))?;
+            let source = self.get_solidity_account(&transfer.source);
 
             let instruction = spl_token::instruction::transfer(
                 &spl_token::id(),
                 &transfer.source_token,
                 &transfer.target_token,
-                &source.get_solana_address(),
+                source.get_solana_address(),
                 &[],
                 transfer.value
             )?;
@@ -399,14 +254,14 @@ impl<'a> ProgramAccountStorage<'a> {
         debug_print!("apply_spl_approves {:?}", approves);
 
         for approve in approves {
-            let source = self.get_account(&approve.owner).ok_or_else(||E!(ProgramError::NotEnoughAccountKeys))?;
+            let source = self.get_solidity_account(&approve.owner);
             let (source_token, _) = self.get_erc20_token_address(&approve.owner, &approve.contract, &approve.mint);
 
             let instruction = spl_token::instruction::approve(
                 &spl_token::id(),
                 &source_token,
                 &approve.spender,
-                &source.get_solana_address(),
+                source.get_solana_address(),
                 &[],
                 approve.value
             )?;
@@ -428,7 +283,7 @@ impl<'a> ProgramAccountStorage<'a> {
     /// Will return:
     /// `ProgramError::NotEnoughAccountKeys` if need to apply changes to missing account
     /// or `account.update` errors
-    pub fn apply_erc20_approves(&mut self, accounts: &[AccountInfo], operator: Option<&AccountInfo>, approves: Vec<ERC20Approve>) -> ProgramResult {
+    pub fn apply_erc20_approves(&mut self, accounts: &[AccountInfo], operator: &AccountInfo, approves: Vec<ERC20Approve>) -> ProgramResult {
         debug_print!("apply_erc20_approves {:?}", approves);
 
         for approve in approves {
@@ -454,17 +309,12 @@ impl<'a> ProgramAccountStorage<'a> {
 
             let account = self.solana_accounts[&account_address];
             if account.data_is_empty() {
-                let operator = match operator {
-                    Some(operator) => operator.key,
-                    None => return Err!(ProgramError::NotEnoughAccountKeys)
-                };
-
                 create_pda_account(
                     self.program_id(),
                     accounts,
                     account,
                     seeds,
-                    operator,
+                    operator.key,
                     data.size()
                 )?;
             }
@@ -483,12 +333,8 @@ impl<'a> AccountStorage for ProgramAccountStorage<'a> {
         where F: FnOnce(&SolidityAccount) -> U,
               D: FnOnce() -> U
     {
-        let account = self.get_account(address);
-        if let Some(account) = account {
-            f(account)
-        } else {
-            panic!("Solidity account {} must be present in the transaction", address)
-        }
+        let account = self.get_solidity_account(address);
+        f(account)
     }
 
     fn apply_to_solana_account<U, D, F>(&self, address: &Pubkey, _d: D, f: F) -> U
@@ -504,11 +350,13 @@ impl<'a> AccountStorage for ProgramAccountStorage<'a> {
     }
 
     fn program_id(&self) -> &Pubkey { &self.program_id }
-    fn contract(&self) -> H160 { self.contract_id }
+    
+    fn contract(&self) -> H160 {
+        self.contract
+    }
+
     fn origin(&self) -> H160 {
-        match self.sender {
-            Sender::Ethereum(value) | Sender::Solana(value) => value,
-        }
+        self.caller
     }
 
     fn block_number(&self) -> U256 {
@@ -522,15 +370,11 @@ impl<'a> AccountStorage for ProgramAccountStorage<'a> {
     }
 
     fn exists(&self, address: &H160) -> bool {
-        self.find_account(address).is_some()
+        self.solidity_accounts.binary_search_by_key(address,SolidityAccount::get_ether).is_ok()
     }
 
     fn get_account_solana_address(&self, address: &H160) -> Pubkey {
-        let account = self.get_account(address);
-        if let Some(account) = account {
-            account.get_solana_address()
-        } else {
-            panic!("Solidity account {} must be present in the transaction", address)
-        }
+        let account = self.get_solidity_account(address);
+        *account.get_solana_address()
     }
 }

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -405,7 +405,7 @@ fn process_instruction<'a>(
                 program_id,
                 &mut account_storage,
                 accounts,
-                Some(operator_sol_info),
+                operator_sol_info,
                 evm_results.unwrap(),
                 used_gas)?;
 
@@ -501,7 +501,7 @@ fn process_instruction<'a>(
 
             let account_storage = ProgramAccountStorage::new(program_id, trx_accounts)?;
 
-            let caller_account_info = account_storage.get_caller_account_info().ok_or_else(||E!(ProgramError::InvalidArgument))?;
+            let caller_account_info = account_storage.get_caller_account_info();
             let mut caller_account_data = AccountData::unpack(&caller_account_info.try_borrow_data()?)?;
             let mut caller_account = caller_account_data.get_mut_account()?;
 
@@ -1027,7 +1027,7 @@ fn do_continue_top_level<'a>(
             program_id,
             &mut account_storage,
             accounts,
-            Some(operator_sol_info),
+            operator_sol_info,
             evm_results,
             used_gas)?;
 
@@ -1151,7 +1151,7 @@ fn applies_and_invokes<'a>(
     program_id: &Pubkey,
     account_storage: &mut ProgramAccountStorage<'a>,
     accounts: &'a [AccountInfo<'a>],
-    operator: Option<&AccountInfo<'a>>,
+    operator: &AccountInfo<'a>,
     evm_results: EvmResults,
     used_gas: UsedGas
 ) -> ProgramResult {
@@ -1246,7 +1246,7 @@ fn check_ethereum_transaction(
    transaction: &UnsignedTransaction
 ) -> ProgramResult
 {
-    let sender_account = account_storage.get_caller_account().ok_or_else(||E!(ProgramError::InvalidArgument))?;
+    let sender_account = account_storage.get_caller_account();
 
     if sender_account.get_ether() != *recovered_address {
         return Err!(ProgramError::InvalidArgument; "Invalid sender: actual {}, recovered {}", sender_account.get_ether(), recovered_address);
@@ -1265,7 +1265,7 @@ fn check_ethereum_transaction(
         },
         |to| to
     );
-    let contract_account = account_storage.get_contract_account().ok_or_else(||E!(ProgramError::InvalidArgument))?;
+    let contract_account = account_storage.get_contract_account();
 
     if contract_account.get_ether() != contract_address {
         return Err!(ProgramError::InvalidArgument; "Invalid contract: actual {}, expected {}", contract_account.get_ether(), contract_address);

--- a/evm_loader/program/src/executor.rs
+++ b/evm_loader/program/src/executor.rs
@@ -189,7 +189,7 @@ impl<'a, B: AccountStorage> Handler for Executor<'a, B> {
         }
 
         let value = token::eth::round(value);
-        if self.balance(caller) < value {
+        if !value.is_zero() && (self.balance(caller) < value) {
             return Capture::Exit((ExitError::OutOfFund.into(), None, Vec::new()))
         }
 

--- a/evm_loader/program/src/executor_state.rs
+++ b/evm_loader/program/src/executor_state.rs
@@ -241,7 +241,7 @@ impl ExecutorSubstate {
             let apply = {
                 let account = self.accounts.remove(&address).unwrap_or_else(
                     || ExecutorAccount {
-                        nonce: backend.basic(&address).nonce,
+                        nonce: backend.nonce(&address),
                         code: None,
                         valids: None,
                         reset: false,
@@ -463,7 +463,7 @@ impl ExecutorSubstate {
         if !self.accounts.contains_key(&address) {
             let account = self.known_account(address).cloned().map_or_else(
                 || ExecutorAccount {
-                    nonce: backend.basic(&address).nonce,
+                    nonce: backend.nonce(&address),
                     code: None,
                     valids: None,
                     reset: false,
@@ -541,7 +541,7 @@ impl ExecutorSubstate {
 
         value.map_or_else(
             || {
-                let balance = backend.basic(address).balance;
+                let balance = backend.balance(address);
                 self.balances.borrow_mut().insert(*address, balance);
 
                 balance
@@ -783,7 +783,7 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
     pub fn nonce(&self, address: H160) -> U256 {
         self.substate
             .known_nonce(address)
-            .unwrap_or_else(|| self.backend.basic(&address).nonce)
+            .unwrap_or_else(|| self.backend.nonce(&address))
     }
 
     #[must_use]
@@ -856,8 +856,8 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
             return known_empty;
         }
 
-        self.backend.basic(&address).balance == U256::zero()
-            && self.backend.basic(&address).nonce == U256::zero()
+        self.backend.balance(&address) == U256::zero()
+            && self.backend.nonce(&address) == U256::zero()
             && self.backend.code_size(&address) == 0
     }
 

--- a/evm_loader/program/src/solana_backend.rs
+++ b/evm_loader/program/src/solana_backend.rs
@@ -64,6 +64,8 @@ pub trait AccountStorage {
     fn contract(&self) -> H160;
     /// Get caller address
     fn origin(&self) -> H160;
+    /// Get account balance
+    fn balance(&self, address: &H160) -> U256;
     /// Get block number
     fn block_number(&self) -> U256;
     /// Get block timestamp
@@ -140,28 +142,6 @@ pub trait AccountStorage {
         );
 
         U256::from(nonce)
-    }
-
-    /// Get account balance
-    fn balance(&self, address: &H160) -> U256 {
-        let token_account = self.apply_to_account(
-            address,
-            || None,
-            |account| Some(*account.get_neon_token_solana_address())
-        ).and_then(|token_address| {
-            self.apply_to_solana_account(
-                &token_address,
-                || None,
-                |info| get_token_account_data(&info.data.borrow(), info.owner).ok()
-            )
-        });
-
-        let balance = match token_account {
-            Some(account) => U256::from(account.amount),
-            None => U256::zero()
-        };
-
-        balance * crate::token::eth::min_transfer_value()
     }
 
     /// Get code hash

--- a/evm_loader/program/src/token.rs
+++ b/evm_loader/program/src/token.rs
@@ -154,6 +154,23 @@ pub fn check_token_account(token: &AccountInfo, account: &AccountInfo) -> Result
     Ok(())
 }
 
+/// Validate Token Account Mint
+/// 
+/// # Errors
+///
+/// Will return: 
+/// `ProgramError::IncorrectProgramId` if account is not token account
+pub fn check_token_mint(token: &AccountInfo, mint: &Pubkey) -> Result<(), ProgramError> {
+    debug_print!("check_token_mint");
+
+    let token_data = get_token_account_data(&token.data.borrow(), token.owner)?;
+    if token_data.mint == *mint {
+        Ok(())
+    } else {
+        Err!(ProgramError::IncorrectProgramId; "token_data.mint<{}> == *mint<{}>", token_data.mint, mint)
+    }
+}
+
 
 /// Transfer Tokens
 /// 
@@ -161,7 +178,7 @@ pub fn check_token_account(token: &AccountInfo, account: &AccountInfo) -> Result
 ///
 /// Could return: 
 /// `ProgramError::InvalidInstructionData`
-pub fn transfer_token(
+pub fn transfer_neon_token(
     accounts: &[AccountInfo],
     source_token_account: &AccountInfo,
     target_token_account: &AccountInfo,
@@ -169,13 +186,16 @@ pub fn transfer_token(
     source_solidity_account: &SolidityAccount,
     value: &U256,
 ) -> Result<(), ProgramError> {
-    debug_print!("transfer_token");
+    debug_print!("transfer_neon_token");
     if get_token_account_owner(source_token_account)? != *source_account.key {
         return Err!(ProgramError::InvalidInstructionData;
             "Invalid account owner; source_token_account = {:?}, source_account = {:?}",
             source_token_account, source_account
         );
     }
+
+    check_token_mint(source_token_account, &token_mint::id())?;
+    check_token_mint(target_token_account, &token_mint::id())?;
 
     let value = value / eth::min_transfer_value();
     let value = u64::try_from(value).map_err(|_| E!(ProgramError::InvalidInstructionData))?;
@@ -228,7 +248,7 @@ pub fn user_pays_operator<'a>(
         .checked_mul(gas_price_wei)
         .ok_or_else(|| E!(ProgramError::InvalidArgument))?;
 
-    transfer_token(
+    transfer_neon_token(
         accounts,
         user_token_account,
         operator_token_account,

--- a/evm_loader/program/src/token.rs
+++ b/evm_loader/program/src/token.rs
@@ -190,15 +190,13 @@ pub fn transfer_token(
 
     debug_print!("Transfer NEON tokens from {} to {} value {}", source_token_account.key, target_token_account.key, value);
 
-    let instruction = spl_token::instruction::transfer_checked(
+    let instruction = spl_token::instruction::transfer(
         &spl_token::id(),
         source_token_account.key,
-        &token_mint::id(),
         target_token_account.key,
         source_account.key,
         &[],
-        value,
-        token_mint::decimals(),
+        value
     )?;
 
     let (ether, nonce) = source_solidity_account.get_seeds();

--- a/evm_loader/program/src/token.rs
+++ b/evm_loader/program/src/token.rs
@@ -234,8 +234,8 @@ pub fn user_pays_operator<'a>(
         accounts,
         user_token_account,
         operator_token_account,
-        account_storage.get_caller_account_info().ok_or_else(||E!(ProgramError::InvalidArgument))?,
-        account_storage.get_caller_account().ok_or_else(|| E!(ProgramError::InvalidArgument))?,
+        account_storage.get_caller_account_info(),
+        account_storage.get_caller_account(),
         &fee)?;
 
     Ok(())

--- a/evm_loader/solana_utils.py
+++ b/evm_loader/solana_utils.py
@@ -542,10 +542,8 @@ def create_neon_evm_instr_05_single(evm_loader_program_id,
             AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
 
             AccountMeta(pubkey=contract_sol_acc, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(contract_sol_acc), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
             AccountMeta(pubkey=code_sol_acc, is_signer=False, is_writable=True),
             AccountMeta(pubkey=caller_sol_acc, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(caller_sol_acc), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
 
             AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
             AccountMeta(pubkey=evm_loader_program_id, is_signer=False, is_writable=False),
@@ -585,10 +583,8 @@ def create_neon_evm_instr_13_partial_call_or_continue(evm_loader_program_id,
             AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
 
             AccountMeta(pubkey=contract_sol_acc, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(contract_sol_acc), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
             AccountMeta(pubkey=code_sol_acc, is_signer=False, is_writable=writable_code),
             AccountMeta(pubkey=caller_sol_acc, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(caller_sol_acc), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
 
             AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
              ]
@@ -632,10 +628,8 @@ def create_neon_evm_instr_19_partial_call(evm_loader_program_id,
             AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
 
             AccountMeta(pubkey=contract_sol_acc, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(contract_sol_acc), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
             AccountMeta(pubkey=code_sol_acc, is_signer=False, is_writable=writable_code),
             AccountMeta(pubkey=caller_sol_acc, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(caller_sol_acc), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
 
             AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
              ]
@@ -676,10 +670,8 @@ def create_neon_evm_instr_20_continue(evm_loader_program_id,
             AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
 
             AccountMeta(pubkey=contract_sol_acc, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(contract_sol_acc), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
             AccountMeta(pubkey=code_sol_acc, is_signer=False, is_writable=writable_code),
             AccountMeta(pubkey=caller_sol_acc, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(caller_sol_acc), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
 
             AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
              ]
@@ -720,10 +712,8 @@ def create_neon_evm_instr_22_begin(evm_loader_program_id,
             AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
 
             AccountMeta(pubkey=contract_sol_acc, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(contract_sol_acc), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
             AccountMeta(pubkey=code_sol_acc, is_signer=False, is_writable=True),
             AccountMeta(pubkey=caller_sol_acc, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(caller_sol_acc), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
 
             AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
             AccountMeta(pubkey=evm_loader_program_id, is_signer=False, is_writable=False),
@@ -757,10 +747,8 @@ def create_neon_evm_instr_21_cancel(evm_loader_program_id,
             AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
 
             AccountMeta(pubkey=contract_sol_acc, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(contract_sol_acc), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
             AccountMeta(pubkey=code_sol_acc, is_signer=False, is_writable=True),
             AccountMeta(pubkey=caller_sol_acc, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(caller_sol_acc), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
 
             AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
             AccountMeta(pubkey=evm_loader_program_id, is_signer=False, is_writable=False),
@@ -798,10 +786,8 @@ def create_neon_evm_instr_14_combined_continue(evm_loader_program_id,
             AccountMeta(pubkey=PublicKey(system), is_signer=False, is_writable=False),
 
             AccountMeta(pubkey=contract_sol_acc, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(contract_sol_acc), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
             AccountMeta(pubkey=code_sol_acc, is_signer=False, is_writable=True),
             AccountMeta(pubkey=caller_sol_acc, is_signer=False, is_writable=True),
-            AccountMeta(pubkey=get_associated_token_address(PublicKey(caller_sol_acc), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
 
             AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
             AccountMeta(pubkey=evm_loader_program_id, is_signer=False, is_writable=False),

--- a/evm_loader/solana_utils.py
+++ b/evm_loader/solana_utils.py
@@ -547,7 +547,6 @@ def create_neon_evm_instr_05_single(evm_loader_program_id,
 
             AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
             AccountMeta(pubkey=evm_loader_program_id, is_signer=False, is_writable=False),
-            AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
             AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
         ])
 
@@ -591,7 +590,6 @@ def create_neon_evm_instr_13_partial_call_or_continue(evm_loader_program_id,
              + add_meta +
              [
             AccountMeta(pubkey=evm_loader_program_id, is_signer=False, is_writable=False),
-            AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
             AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
         ])
 
@@ -636,7 +634,6 @@ def create_neon_evm_instr_19_partial_call(evm_loader_program_id,
              + add_meta +
              [
             AccountMeta(pubkey=evm_loader_program_id, is_signer=False, is_writable=False),
-            AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
             AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
         ])
 
@@ -678,7 +675,6 @@ def create_neon_evm_instr_20_continue(evm_loader_program_id,
              + add_meta +
              [
             AccountMeta(pubkey=evm_loader_program_id, is_signer=False, is_writable=False),
-            AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
             AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
         ])
 
@@ -717,7 +713,6 @@ def create_neon_evm_instr_22_begin(evm_loader_program_id,
 
             AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
             AccountMeta(pubkey=evm_loader_program_id, is_signer=False, is_writable=False),
-            AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
             AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
         ])
 
@@ -752,7 +747,6 @@ def create_neon_evm_instr_21_cancel(evm_loader_program_id,
 
             AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
             AccountMeta(pubkey=evm_loader_program_id, is_signer=False, is_writable=False),
-            AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
             AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
         ])
 
@@ -791,7 +785,6 @@ def create_neon_evm_instr_14_combined_continue(evm_loader_program_id,
 
             AccountMeta(pubkey=PublicKey(sysinstruct), is_signer=False, is_writable=False),
             AccountMeta(pubkey=evm_loader_program_id, is_signer=False, is_writable=False),
-            AccountMeta(pubkey=ETH_TOKEN_MINT_ID, is_signer=False, is_writable=False),
             AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
         ])
 #

--- a/evm_loader/test_delete_account.py
+++ b/evm_loader/test_delete_account.py
@@ -121,7 +121,7 @@ class EvmLoaderTestsNewAccount(unittest.TestCase):
 
         trx = Transaction().add( keccak_tx_1 ).add( call_tx_1 ).add( keccak_tx_2 ).add( call_tx_2 )
 
-        err = "invalid account data for instruction"
+        err = "Program failed to complete"
         with self.assertRaisesRegex(Exception,err):
             result = send_transaction(client, trx, self.acc)
             print(result)

--- a/evm_loader/test_deploy.py
+++ b/evm_loader/test_deploy.py
@@ -314,8 +314,8 @@ class DeployTest(unittest.TestCase):
         trx = Transaction()
         trx.add(self.sol_instr_14_partial_call_or_continue(storage, 50, holder, contract_sol, code_sol))
         print(trx.instructions[-1].keys)
-        print("Expecting Exception: invalid program argument")
-        with self.assertRaisesRegex(Exception, 'invalid program argument'):
+        print("Expecting Exception: Program failed to complete")
+        with self.assertRaisesRegex(Exception, 'Program failed to complete'):
             response = send_transaction(client, trx, self.operator_acc)
             print('response:', response)
 

--- a/evm_loader/test_eth_token.py
+++ b/evm_loader/test_eth_token.py
@@ -66,7 +66,11 @@ class EthTokenTest(unittest.TestCase):
             self.collateral_pool_index_buf,
             self.collateral_pool_address,
             step_count,
-            evm_instruction
+            evm_instruction,
+            add_meta=[
+                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.reId), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+            ]
         )
         print('neon_evm_instr_19_partial_call:', neon_evm_instr_19_partial_call)
         return neon_evm_instr_19_partial_call
@@ -81,7 +85,11 @@ class EthTokenTest(unittest.TestCase):
             self.re_code,
             self.collateral_pool_index_buf,
             self.collateral_pool_address,
-            step_count
+            step_count,
+            add_meta=[
+                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.reId), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+                AccountMeta(pubkey=get_associated_token_address(PublicKey(self.caller), ETH_TOKEN_MINT_ID), is_signer=False, is_writable=True),
+            ]
         )
         print('neon_evm_instr_20_continue:', neon_evm_instr_20_continue)
         return neon_evm_instr_20_continue


### PR DESCRIPTION
Refactor ProgramAccountStorage, so
- Accounts can be specified in arbitrary order, except contract and caller
- Neon token accounts no longer required