### PR TITLE
411 neon-cli update

### DIFF
--- a/evm_loader/cli/src/account_storage.rs
+++ b/evm_loader/cli/src/account_storage.rs
@@ -54,7 +54,6 @@ use evm_loader::{
     precompile_contracts::is_precompile_address,
     solana_backend::{AccountStorage, AccountStorageInfo},
     solidity_account::SolidityAccount,
-    config::token_mint
 };
 
 use crate::Config;
@@ -157,10 +156,11 @@ pub struct EmulatorAccountStorage<'a> {
     caller_id: H160,
     block_number: u64,
     block_timestamp: i64,
+    token_mint: Pubkey
 }
 
 impl<'a> EmulatorAccountStorage<'a> {
-    pub fn new(config: &'a Config, contract_id: H160, caller_id: H160) -> EmulatorAccountStorage {
+    pub fn new(config: &'a Config, contract_id: H160, caller_id: H160, token_mint: Pubkey) -> EmulatorAccountStorage {
         eprintln!("backend::new");
 
         let slot = if let Ok(slot) = config.rpc_client.get_slot() {
@@ -192,6 +192,7 @@ impl<'a> EmulatorAccountStorage<'a> {
             caller_id,
             block_number: slot,
             block_timestamp: timestamp,
+            token_mint: token_mint
         }
     }
 
@@ -406,7 +407,7 @@ impl<'a> EmulatorAccountStorage<'a> {
         };
     }
 
-    pub fn apply_transfers(&self, transfers: Vec<Transfer>) {
+    pub fn apply_transfers(&self, transfers: Vec<Transfer>, token_mint: &Pubkey) {
         let mut solana_accounts = self.solana_accounts.borrow_mut();
 
         for transfer in transfers {
@@ -414,11 +415,11 @@ impl<'a> EmulatorAccountStorage<'a> {
             self.create_acc_if_not_exists(&transfer.target);
 
             let (source, _) = make_solana_program_address(&transfer.source, &self.config.evm_loader);
-            let source_token = spl_associated_token_account::get_associated_token_address(&source, &token_mint::id());
+            let source_token = spl_associated_token_account::get_associated_token_address(&source, token_mint);
             solana_accounts.insert(source_token, AccountMeta::new(source_token, false));
 
             let (target, _) = make_solana_program_address(&transfer.target, &self.config.evm_loader);
-            let target_token = spl_associated_token_account::get_associated_token_address(&target, &token_mint::id());
+            let target_token = spl_associated_token_account::get_associated_token_address(&target, token_mint);
             solana_accounts.insert(target_token, AccountMeta::new(target_token, false));
         }
     }
@@ -617,7 +618,7 @@ impl<'a> AccountStorage for EmulatorAccountStorage<'a> {
         self.create_acc_if_not_exists(address);
 
         let (account, _) = make_solana_program_address(address, &self.config.evm_loader);
-        let token_account = spl_associated_token_account::get_associated_token_address(&account, &token_mint::id());
+        let token_account = spl_associated_token_account::get_associated_token_address(&account, &self.token_mint);
         
         let mut solana_accounts = self.solana_accounts.borrow_mut();
         solana_accounts.entry(token_account).or_insert_with(|| AccountMeta::new_readonly(token_account, false));

--- a/evm_loader/cli/src/account_storage.rs
+++ b/evm_loader/cli/src/account_storage.rs
@@ -192,7 +192,7 @@ impl<'a> EmulatorAccountStorage<'a> {
             caller_id,
             block_number: slot,
             block_timestamp: timestamp,
-            token_mint: token_mint
+            token_mint
         }
     }
 

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -1279,10 +1279,9 @@ fn read_program_data_from_file(config: &Config,
 }
 
 
-fn read_program_data_from_account(config: &Config) -> CommandResult {
+fn read_program_data_from_account(config: &Config) {
     let elf_params = read_elf_parameters_from_account(config).unwrap();
     print_elf_parameters(&elf_params);
-    Ok(())
 }
 
 
@@ -1291,7 +1290,7 @@ fn command_neon_elf(
     program_location: Option<&str>,
 ) -> CommandResult {
     program_location.map_or_else(
-        || read_program_data_from_account(config),
+        || {read_program_data_from_account(config); Ok(())},
         |program_location| read_program_data_from_file(config, program_location),
     )
 }

--- a/evm_loader/deploy-evm.sh
+++ b/evm_loader/deploy-evm.sh
@@ -10,6 +10,14 @@ solana config set -u "$SOLANA_URL"
 export EVM_LOADER=$(solana address -k evm_loader-keypair.json)
 export $(neon-cli --evm_loader="$EVM_LOADER" neon-elf-params ./evm_loader.so)
 
+
+echo "Deploying evm_loader at address $EVM_LOADER..."
+if ! solana program deploy --upgrade-authority evm_loader-keypair.json evm_loader.so >evm_loader_id; then
+  echo "Failed to deploy evm_loader"
+  exit 1
+fi
+
+
 export ETH_TOKEN_MINT=$(solana address -k neon_token_keypair.json)
 if [ "$ETH_TOKEN_MINT" != "$NEON_TOKEN_MINT" ]; then
   echo "Token address in evm_loader.so is $NEON_TOKEN_MINT"
@@ -39,9 +47,3 @@ fi
 echo "Creating collateral pool $NEON_POOL_BASE..."
 solana -k collateral-pool-keypair.json airdrop 1000
 python3 collateral_pool_generator.py collateral-pool-keypair.json
-
-echo "Deploying evm_loader at address $EVM_LOADER..."
-if ! solana program deploy --upgrade-authority evm_loader-keypair.json evm_loader.so >evm_loader_id; then
-  echo "Failed to deploy evm_loader"
-  exit 1
-fi

--- a/evm_loader/deploy-evm.sh
+++ b/evm_loader/deploy-evm.sh
@@ -16,7 +16,7 @@ if ! solana program deploy --upgrade-authority evm_loader-keypair.json evm_loade
   echo "Failed to deploy evm_loader"
   exit 1
 fi
-
+sleep 30
 
 export ETH_TOKEN_MINT=$(solana address -k neon_token_keypair.json)
 if [ "$ETH_TOKEN_MINT" != "$NEON_TOKEN_MINT" ]; then


### PR DESCRIPTION
Neon-cli should read token_mind::id, collateral_pool_base::id, chain_id from the  evm_loader.so or from the evm_loader account data.
List command that was affected:
 - deploy,
 - emulate
 - cancel-trx
 - create-ether_account

There were added parameters:
--token_mint
--collateral_pool_base
--chain_id

If parameter was not defined, then its value would be taken from evm_loader contract.