### PR TITLE
460 Throw an exception on any attempt to change state in static context

### DIFF
--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -1209,6 +1209,7 @@ fn invoke_on_return<'a>(
                 ExitError::OutOfFund => {("ExitError: Not enough fund to start the execution (runtime).", 0xeb)},
                 ExitError::PCUnderflow => {("ExitError: PC underflowed (unused).", 0xec)},
                 ExitError::CreateEmpty => {("ExitError: Attempt to create an empty account (runtime, unused).", 0xed)},
+                ExitError::StaticModeViolation => {("ExitError: STATICCALL tried to change state", 0xee)}
             }
         },
         ExitReason::Revert(_) => {("Revert", 0xd0)},

--- a/evm_loader/program/src/executor_state.rs
+++ b/evm_loader/program/src/executor_state.rs
@@ -106,7 +106,6 @@ impl ExecutorMetadata {
         &mut self.gasometer
     }
 
-    #[allow(dead_code)]
     #[must_use]
     pub const fn is_static(&self) -> bool {
         self.is_static

--- a/evm_loader/program/src/precompile_contracts.rs
+++ b/evm_loader/program/src/precompile_contracts.rs
@@ -194,6 +194,11 @@ pub fn erc20_wrapper<'a, B: AccountStorage>(
         ERC20_METHOD_TRANSFER_ID => {
             debug_print!("erc20_wrapper transfer");
 
+            if state.metadata().is_static() {
+                let revert_message = b"ERC20 transfer is not allowed in static context".to_vec();
+                return Capture::Exit((ExitReason::Revert(evm::ExitRevert::Reverted), revert_message))
+            }
+
             let arguments = array_ref![rest, 0, 64];
             let (_, address, value) = array_refs!(arguments, 12, 20, 32);
 
@@ -213,6 +218,11 @@ pub fn erc20_wrapper<'a, B: AccountStorage>(
         },
         ERC20_METHOD_TRANSFER_FROM_ID => {
             debug_print!("erc20_wrapper transferFrom");
+
+            if state.metadata().is_static() {
+                let revert_message = b"ERC20 transferFrom is not allowed in static context".to_vec();
+                return Capture::Exit((ExitReason::Revert(evm::ExitRevert::Reverted), revert_message))
+            }
 
             let arguments = array_ref![rest, 0, 96];
             let (_, source, _, target, value) = array_refs!(arguments, 12, 20, 12, 20, 32);
@@ -234,6 +244,11 @@ pub fn erc20_wrapper<'a, B: AccountStorage>(
         },
         ERC20_METHOD_APPROVE_ID => {
             debug_print!("erc20_wrapper approve");
+
+            if state.metadata().is_static() {
+                let revert_message = b"ERC20 approve is not allowed in static context".to_vec();
+                return Capture::Exit((ExitReason::Revert(evm::ExitRevert::Reverted), revert_message))
+            }
 
             let arguments = array_ref![rest, 0, 64];
             let (_, spender, value) = array_refs!(arguments, 12, 20, 32);
@@ -266,6 +281,11 @@ pub fn erc20_wrapper<'a, B: AccountStorage>(
         },
         ERC20_METHOD_APPROVE_SOLANA_ID => {
             debug_print!("erc20_wrapper approve solana");
+
+            if state.metadata().is_static() {
+                let revert_message = b"ERC20 approveSolana is not allowed in static context".to_vec();
+                return Capture::Exit((ExitReason::Revert(evm::ExitRevert::Reverted), revert_message))
+            }
 
             let arguments = array_ref![rest, 0, 64];
             let (spender, _, value) = array_refs!(arguments, 32, 24, 8);


### PR DESCRIPTION
Return an error on any attempts to make state-changing operations inside of the static context.
These operations include CREATE, CREATE2, LOG0, LOG1, LOG2, LOG3, LOG4, SSTORE, and SELFDESTRUCT.
They also include CALL with a non-zero value and ERC20 wrapper precompile.