### PR TITLE
Cleanup docker containers if it exists on test-agent #522

### DIFF
--- a/.buildkite/steps/deploy-test.sh
+++ b/.buildkite/steps/deploy-test.sh
@@ -16,15 +16,23 @@ EVM_LOADER_IMAGE=neonlabsorg/evm_loader:${IMAGETAG:-$REVISION}
 echo "Currently runned Docker-containers"
 docker ps -a
 
-docker-compose -f evm_loader/docker-compose-test.yml up -d
-
 function cleanup_docker {
     docker logs solana >solana.log 2>&1
     echo "Cleanup docker-compose..."
-    docker-compose -f evm_loader/docker-compose-test.yml down --rmi 'all'
+    docker-compose -f evm_loader/docker-compose-test.yml down --timeout 60
     echo "Cleanup docker-compose done."
 }
 trap cleanup_docker EXIT
+
+echo "\nCleanup docker-compose..."
+docker-compose -f evm_loader/docker-compose-test.yml down
+
+if ! docker-compose -f evm_loader/docker-compose-test.yml up -d; then
+    echo "docker-compose failed to start"
+    exit 1;
+fi
+
+# waiting for solana to launch
 sleep 10
 
 echo "Run tests..."


### PR DESCRIPTION
Cleanup `docker`-containers before tests (like in neonlabsorg/proxy-model.py#525)