### PR TITLE
Speed up CI neonlabsorg/Solana-EVM#376 (#508)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,6 +9,8 @@ steps:
   - label: ":cop::skin-tone-2: deploy check"
     command: ".buildkite/steps/deploy-test.sh"
     timeout: 60
+    agents:
+      queue: "testing"
     artifact_paths:
       - "solana.log"
 


### PR DESCRIPTION
* Use "testing" queue for deploy checks #342

* Trigger 342-speedup-ci branch to check CI #342

* Dummy commit to check build cache #342

* Fix triggered proxy branch #342

* Restore trigger develop branch #342

Co-authored-by: Semen Medvedev <sm@neonlabs.org>