### PR TITLE
Fix clippy warnings in faucet

### DIFF
--- a/evm_loader/Cargo.lock
+++ b/evm_loader/Cargo.lock
@@ -1376,7 +1376,6 @@ name = "evm"
 version = "0.18.0"
 dependencies = [
  "evm-core",
- "evm-gasometer",
  "evm-runtime",
  "log",
  "rlp",
@@ -1396,15 +1395,6 @@ dependencies = [
  "serde",
  "serde_bytes",
  "uint",
-]
-
-[[package]]
-name = "evm-gasometer"
-version = "0.18.0"
-dependencies = [
- "evm-core",
- "evm-runtime",
- "serde",
 ]
 
 [[package]]
@@ -1501,6 +1491,7 @@ dependencies = [
  "ed25519-dalek",
  "evm-loader",
  "eyre",
+ "futures-locks",
  "hex",
  "lazy_static",
  "md5",
@@ -1673,6 +1664,17 @@ name = "futures-io"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
+
+[[package]]
+name = "futures-locks"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb42d4fb72227be5778429f9ef5240a38a358925a49f05b5cf702ce7c7e558a"
+dependencies = [
+ "futures-channel",
+ "futures-task",
+ "tokio",
+]
 
 [[package]]
 name = "futures-macro"

--- a/evm_loader/faucet/Cargo.toml
+++ b/evm_loader/faucet/Cargo.toml
@@ -14,6 +14,7 @@ derive-new = "0.5"
 ed25519-dalek = "1.0"
 evm-loader = { path = "../program", default_features = false, features = ["no-entrypoint"] }
 eyre = "0.6"
+futures-locks = "0.7"
 hex = "0.4"
 lazy_static = "1.4"
 minimad = "0.9"

--- a/evm_loader/faucet/src/erc20_tokens.rs
+++ b/evm_loader/faucet/src/erc20_tokens.rs
@@ -39,7 +39,7 @@ pub async fn airdrop(id: ReqId, params: Airdrop) -> Result<()> {
     let http = web3::transports::Http::new(&config::web3_rpc_url())?;
     let web3 = web3::Web3::new(http);
 
-    if TOKENS.write().await.is_empty() {
+    if TOKENS.read().await.is_empty() {
         init(id.clone(), web3.eth().clone(), config::tokens()).await?;
     }
 

--- a/evm_loader/faucet/src/erc20_tokens.rs
+++ b/evm_loader/faucet/src/erc20_tokens.rs
@@ -5,7 +5,7 @@ use eyre::{eyre, Result};
 use tracing::{error, info};
 
 use secp256k1::SecretKey;
-use std::sync::RwLock;
+use futures_locks::RwLock;
 use web3::api::Eth;
 use web3::contract::{Contract, Options};
 use web3::signing::Key;
@@ -39,7 +39,7 @@ pub async fn airdrop(id: ReqId, params: Airdrop) -> Result<()> {
     let http = web3::transports::Http::new(&config::web3_rpc_url())?;
     let web3 = web3::Web3::new(http);
 
-    if TOKENS.write().unwrap().is_empty() {
+    if TOKENS.write().await.is_empty() {
         init(id.clone(), web3.eth().clone(), config::tokens()).await?;
     }
 
@@ -47,7 +47,7 @@ pub async fn airdrop(id: ReqId, params: Airdrop) -> Result<()> {
     let amount = U256::from(params.amount);
 
     for token in &config::tokens() {
-        let factor = U256::from(multiplication_factor(token)?);
+        let factor = U256::from(multiplication_factor(token).await?);
         let internal_amount = amount
             .checked_mul(factor)
             .ok_or_else(|| eyre!("Overflow {} * {}", amount, factor))?;
@@ -76,7 +76,7 @@ async fn init<T: Transport>(id: ReqId, eth: Eth<T>, addresses: Vec<String>) -> R
 
     for token_address in addresses {
         let a = ethereum::address_from_str(&token_address)?;
-        TOKENS.write().unwrap().insert(
+        TOKENS.write().await.insert(
             token_address,
             Token::new(get_decimals(id.clone(), eth.clone(), a).await?),
         );
@@ -152,11 +152,11 @@ async fn get_decimals<T: Transport>(
 }
 
 /// Returns multiplication factor to convert whole token value to fractions.
-fn multiplication_factor(token_address: &str) -> Result<u64> {
+async fn multiplication_factor(token_address: &str) -> Result<u64> {
     let decimals = {
         TOKENS
             .read()
-            .unwrap()
+            .await
             .get(token_address)
             .ok_or_else(|| eyre!("Token info in cache not found: {}", token_address))?
             .decimals

--- a/evm_loader/faucet/src/solana.rs
+++ b/evm_loader/faucet/src/solana.rs
@@ -40,7 +40,7 @@ pub fn convert_whole_to_fractions(amount: u64) -> Result<u64> {
         .checked_pow(decimals as u32)
         .ok_or_else(|| eyre!("Overflow 10^{}", decimals))?;
     amount
-        .checked_mul(factor as u64)
+        .checked_mul(factor)
         .ok_or_else(|| eyre!("Overflow {}*{}", amount, factor))
 }
 


### PR DESCRIPTION
Fixed "consider using an async-aware `Mutex` type" warning. Used `futures_locks::RwLock` instead of `std::sync::RwLock` for shared collection of tokens.