### PR TITLE
Make commitment `confirmed` for migration of accounts

### DIFF
--- a/evm_loader/cli/src/commands/migrate_account.rs
+++ b/evm_loader/cli/src/commands/migrate_account.rs
@@ -1,6 +1,7 @@
 use log::{error, info, debug};
 
 use solana_sdk::{
+    commitment_config::{CommitmentConfig},
     instruction::{AccountMeta, Instruction},
     message::Message,
     pubkey::Pubkey,
@@ -59,7 +60,10 @@ pub fn execute(
     finalize_tx.try_sign(&[&*config.signer], blockhash)?;
     debug!("signed: {:x?}", finalize_tx);
 
-    config.rpc_client.send_and_confirm_transaction_with_spinner(&finalize_tx)?;
+    config.rpc_client.send_and_confirm_transaction_with_spinner_and_commitment(
+        &finalize_tx,
+        CommitmentConfig::confirmed(),
+    )?;
 
     info!("{}", serde_json::json!({
         "ether address": hex::encode(ether_address),

--- a/evm_loader/program/src/instruction/migrate_account.rs
+++ b/evm_loader/program/src/instruction/migrate_account.rs
@@ -55,7 +55,7 @@ pub fn process<'a>(program_id: &'a Pubkey, accounts: &'a [AccountInfo<'a>], _ins
     msg!("Instruction: MigrateAccount");
 
     let parsed_accounts = Accounts {
-        operator: Operator::from_account(&accounts[0])?,
+        operator: unsafe { Operator::from_account_not_whitelisted(&accounts[0]) }?,
         ethereum_account: EthereumAccountV1::from_account(program_id, &accounts[1])?,
         token_balance_account: token::State::from_account(&accounts[2])?,
         token_pool_account: token::State::from_account(&accounts[3])?,


### PR DESCRIPTION
Small important changes:

1. Make commitment `confirmed` for migration of accounts.
2. Skip test operator against the whitelist in migration.