### PR TITLE
Disable clippy::missing_const_for_fn

### DIFF
--- a/evm_loader/program/src/executor_state.rs
+++ b/evm_loader/program/src/executor_state.rs
@@ -1,7 +1,6 @@
 //! # Neon EVM Executor State
 //!
 //! Executor State is a struct that stores the state during execution.
-#![allow(missing_docs, clippy::missing_panics_doc, clippy::missing_errors_doc)]
 
 use core::mem;
 use std::{

--- a/evm_loader/program/src/lib.rs
+++ b/evm_loader/program/src/lib.rs
@@ -1,11 +1,9 @@
 //! # Neon EVM
 //!
 //! Neon EVM is an implementation of Ethereum Virtual Machine on Solana.
-
-#![deny(missing_docs)]
 #![deny(warnings)]
 #![deny(clippy::all, clippy::pedantic, clippy::nursery)]
-#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::module_name_repetitions, clippy::missing_const_for_fn)]
 #![allow(missing_docs, clippy::missing_panics_doc, clippy::missing_errors_doc)]
 
 


### PR DESCRIPTION
This check generates a lot of false positive and in general useless for evm_loader