### PR TITLE
Optimize Resize Account

### DIFF
--- a/evm_loader/program/src/instruction/account_create.rs
+++ b/evm_loader/program/src/instruction/account_create.rs
@@ -59,10 +59,6 @@ fn validate(program_id: &Pubkey, accounts: &Accounts, address: &H160, bump_seed:
         if *contract.key != expected_code_address {
             return Err!(ProgramError::InvalidArgument; "Account {} - expected create_with_seed {}", contract.key, expected_code_address);
         }
-
-        if !crate::utils::is_zero_initialized(&contract.data.borrow()) {
-            return Err!(ProgramError::InvalidArgument; "Account {} - is not zero initialized", contract.key);
-        }
     }
 
     Ok(())

--- a/evm_loader/program/src/instruction/account_resize.rs
+++ b/evm_loader/program/src/instruction/account_resize.rs
@@ -63,8 +63,9 @@ fn validate(program_id: &Pubkey, accounts: &Accounts, seed: &str) -> ProgramResu
         return Err!(ProgramError::InvalidArgument; "Account {} - expected program owned", new_code_account.key);
     }
 
-    if !crate::utils::is_zero_initialized(&new_code_account.try_borrow_data()?) {
-        return Err!(ProgramError::InvalidArgument; "Account {} - expected zero initialized", new_code_account.key);
+    let tag = crate::account::tag(program_id, new_code_account)?;
+    if tag != crate::account::TAG_EMPTY {
+        return Err!(ProgramError::InvalidArgument; "Account {} - expected tag empty", new_code_account.key);
     }
 
     let rent = Rent::get()?;

--- a/evm_loader/program/src/utils.rs
+++ b/evm_loader/program/src/utils.rs
@@ -28,15 +28,3 @@ pub fn u256_to_h256(value: U256) -> H256 {
     value.to_big_endian(&mut v);
     H256::from_slice(&v)
 }
-
-/// Check whether array is zero initialized
-#[must_use]
-pub fn is_zero_initialized(data: &[u8]) -> bool {
-    for d in data {
-        if *d != 0_u8 {
-            return false;
-        }
-    }
-
-    true
-}

--- a/evm_loader/test_resize.py
+++ b/evm_loader/test_resize.py
@@ -1,0 +1,64 @@
+from solana.transaction import AccountMeta, TransactionInstruction, Transaction
+import unittest
+from base58 import b58encode
+import web3
+from solana_utils import *
+
+solana_url = os.environ.get("SOLANA_URL", "http://localhost:8899")
+client = Client(solana_url)
+evm_loader_id = os.environ.get("EVM_LOADER")
+
+
+class ResizeTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        print("\ntest_resize.py setUpClass")
+
+        wallet = OperatorAccount(operator1_keypair_path())
+        cls.loader = EvmLoader(wallet, evm_loader_id)
+        cls.acc = wallet.get_acc()
+
+
+    def sol_instr_17_resize(self, address, size) -> Transaction:
+        solana_address = PublicKey(self.loader.ether2program(address)[0])
+        account_data: bytes = getAccountData(client, solana_address, ACCOUNT_INFO_LAYOUT.sizeof())
+        account: AccountInfo = AccountInfo.frombytes(account_data)
+
+        seed = b58encode(ACCOUNT_SEED_VERSION + os.urandom(20)).decode('utf8')
+        code_account_new = accountWithSeed(self.acc.public_key(), seed, PublicKey(evm_loader_id))
+        minimum_balance = client.get_minimum_balance_for_rent_exemption(size)["result"]
+
+        create_with_seed = createAccountWithSeed(self.acc.public_key(), self.acc.public_key(), seed, minimum_balance, size, PublicKey(evm_loader_id))
+        resize = TransactionInstruction(
+            program_id=evm_loader_id,
+            data=bytearray.fromhex("11") + seed.encode('utf-8'),  # 17- ResizeStorageAccount
+            keys=[
+                AccountMeta(pubkey=solana_address, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=account.code_account, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=code_account_new, is_signer=False, is_writable=True),
+                AccountMeta(pubkey=self.acc.public_key(), is_signer=True, is_writable=False)
+            ]
+        )
+
+        trx = Transaction()
+        trx.add(create_with_seed)
+        trx.add(resize)
+
+        return trx
+
+
+
+    def test_resize(self):
+        account = web3.Account.create()
+        self.loader.createEtherAccount(account.address)
+
+        for size in range(1*1024*1024, 10*1024*1024 + 1, 1*1024*1024):
+            print("resize account, size = ", size)
+
+            resize_trx = self.sol_instr_17_resize(account.address, size)
+            result = send_transaction(client, resize_trx, self.acc)
+            print(result)
+ 
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Reduce BPF instruction count for Resize and Create Account instructions.

Resizing from 9mb to 10mb uses 100k BPF instructions.