### PR TITLE
#599 Added NEON_ADDITIONAL_FEE as ELF parameter

### DIFF
--- a/evm_loader/program/src/config.rs
+++ b/evm_loader/program/src/config.rs
@@ -412,3 +412,4 @@ neon_elf_param!( NEON_POOL_COUNT            , formatcp!("{:?}", collateral_pool_
 neon_elf_param!( NEON_HOLDER_MSG_SIZE       , formatcp!("{:?}", HOLDER_MSG_SIZE));
 neon_elf_param!( NEON_COMPUTE_UNITS         , formatcp!("{:?}", COMPUTE_BUDGET_UNITS));
 neon_elf_param!( NEON_HEAP_FRAME            , formatcp!("{:?}", COMPUTE_BUDGET_HEAP_FRAME));
+neon_elf_param!( NEON_ADDITIONAL_FEE        , formatcp!("{:?}", REQUEST_UNITS_ADDITIONAL_FEE));


### PR DESCRIPTION
#### Problem
Additional Fee is a new parameter for Compute Budget, and we didn't export it as neon elf param. So, external faucet didn't know the actual value of this parameter.

#### Proposed Solution
Export Additional Fee as an ELF parameter.