### PR TITLE
Use wrapping subtraction on recovery ID in ecrecover

### DIFF
--- a/evm_loader/program/src/precompile_contracts.rs
+++ b/evm_loader/program/src/precompile_contracts.rs
@@ -538,7 +538,7 @@ pub fn ecrecover(
     } else {
         return Capture::Exit((ExitReason::Succeed(evm::ExitSucceed::Returned), vec![0; 32]));
     };
-    let recovery_id = v - 27;
+    let recovery_id = v.wrapping_sub(27);
     let public_key = match secp256k1_recover(&msg[..], recovery_id, &sig[..]) {
         Ok(key) => key,
         Err(_) => {


### PR DESCRIPTION
This fixes one place where neon's ecrecover implementation disagrees with geth's.

Geth does wrapping subtraction on `v` while neon uses the default rust behavior, which will wrap correctly in release builds but panic in debug builds.

This patch makes the wrapping explicit. In practice it should not have an impact since the release behavior matches geth.

geth: https://github.com/etclabscore/core-geth/blob/e584559d87c6e7680fda8bb1e23bb00d25f47b4a/core/vm/contracts.go#L139

There may be other checks in ecrecover that are not identical to geth, including the handling of the zero bytes in front of `v`, and the signedness checks of `r` and `s`. I don't intend to look closer though.



┆Issue is synchronized with this [Jira Task](https://neonlabs.atlassian.net/browse/NEON-14) by [Unito](https://www.unito.io)
