### PR TITLE
Fix clippy warnings

### DIFF
--- a/evm_loader/program/src/account/ether_account.rs
+++ b/evm_loader/program/src/account/ether_account.rs
@@ -83,7 +83,7 @@ impl Packable for DataV1 {
         ) = array_refs![data, 20, 1, 8, 32, 1, 32, 32, 1];
 
         Self {
-            ether: H160::from_slice(&*ether),
+            ether: H160::from_slice(ether),
             nonce: nonce[0],
             trx_count: u64::from_le_bytes(*trx_count),
             code_account: Pubkey::new_from_array(*code_account),

--- a/evm_loader/program/src/account_storage/apply.rs
+++ b/evm_loader/program/src/account_storage/apply.rs
@@ -186,7 +186,7 @@ impl<'a> ProgramAccountStorage<'a> {
             return Ok(())
         }
 
-        return Err!(ProgramError::InvalidAccountData; "Account {} - expected system or program owned", solana_address);
+        Err!(ProgramError::InvalidAccountData; "Account {} - expected system or program owned", solana_address)
     }
 
 

--- a/evm_loader/program/src/instruction/transaction.rs
+++ b/evm_loader/program/src/instruction/transaction.rs
@@ -34,11 +34,11 @@ pub fn is_new_transaction<'a>(
             if FinalizedState::from_account(program_id, storage_info)?.is_outdated(signature, caller) {
                 Ok(true)
             } else {
-                return Err!(EvmLoaderError::StorageAccountFinalized.into(); "Transaction already finalized")
+                Err!(EvmLoaderError::StorageAccountFinalized.into(); "Transaction already finalized")
             }
         },
         State::TAG => Ok(false),
-        _ => return Err!(ProgramError::InvalidAccountData; "Account {} - expected storage or empty", storage_info.key)
+            _ => Err!(ProgramError::InvalidAccountData; "Account {} - expected storage or empty", storage_info.key)
     }
 }
 


### PR DESCRIPTION
After update rust version clippy generates some errors:
```
error: deref on an immutable reference
--
  | --> program/src/account/ether_account.rs:86:37
  | \|
  | 86 \|             ether: H160::from_slice(&*ether),
  | \|                                     ^^^^^^^ help: if you would like to reborrow, try removing `&*`: `ether`
  | \|
  | note: the lint level is defined here
  | --> program/src/lib.rs:5:9
  | \|
  | 5  \| #![deny(clippy::all, clippy::pedantic, clippy::nursery)]
  | \|         ^^^^^^^^^^^
  | = note: `#[deny(clippy::borrow_deref_ref)]` implied by `#[deny(clippy::all)]`
  | = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#borrow_deref_ref
  |  
  | error: unneeded `return` statement
  | --> program/src/account_storage/apply.rs:189:9
  | \|
  | 189 \|         return Err!(ProgramError::InvalidAccountData; "Account {} - expected system or program owned", solana_address);
  | \|         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `Err!(ProgramError::InvalidAccountData; "Account {} - expected system or program owned", solana_address)`
  | \|
  | = note: `#[deny(clippy::needless_return)]` implied by `#[deny(clippy::all)]`
  | = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
  |  
  | Checking solana-faucet v1.9.12
  | error: unneeded `return` statement
  | --> program/src/instruction/transaction.rs:37:17
  | \|
  | 37 \|                 return Err!(EvmLoaderError::StorageAccountFinalized.into(); "Transaction already finalized")
  | \|                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `Err!(EvmLoaderError::StorageAccountFinalized.into(); "Transaction already finalized")`
  | \|
  | = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
  |  
  | error: unneeded `return` statement
  | --> program/src/instruction/transaction.rs:41:14
  | \|
  | 41 \|         _ => return Err!(ProgramError::InvalidAccountData; "Account {} - expected storage or empty", storage_info.key)
  | \|              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `Err!(ProgramError::InvalidAccountData; "Account {} - expected storage or empty", storage_info.key)`
  | \|
  | = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
  |  
  | error: could not compile `evm-loader` due to 4 previous errors
```