### PR TITLE
Fix deploy-tokens scripts from infinity loop.

### DIFF
--- a/evm_loader/solidity/scripts/deploy.js
+++ b/evm_loader/solidity/scripts/deploy.js
@@ -11,7 +11,7 @@ function createSplToken(spl_token) {
   let token_keyfile = `./ci-tokens/${spl_token.symbol}.json`;
   if (!fs.existsSync(token_keyfile)) {
     console.log(`Keyfile ${token_keyfile} not found. Will skip token creation.`);
-    return true;
+    return false;
   }
   console.log(`Token keyfile is ${token_keyfile}`);
 


### PR DESCRIPTION
I'm trying to deploy neon cluster from docker-compose file from proxy repo and found that container deploy_contract has infinity loop:
```
Creating SPL token wSOL...
Keyfile ./ci-tokens/wSOL.json not found. Will skip token creation.
Deploying wrapper for SPL token Wrapped SOL (wSOL)
```

Function createSplToken returns true if file doesn't exist but createERC20 wait for false to skip this token https://github.com/neonlabsorg/neon-evm/blob/develop/evm_loader/solidity/scripts/deploy.js#L64