### PR TITLE
`Neon-cli` option `emulate --max_steps_to_execute`

### DIFF
--- a/evm_loader/Cargo.lock
+++ b/evm_loader/Cargo.lock
@@ -892,7 +892,6 @@ name = "evm"
 version = "0.18.0"
 dependencies = [
  "evm-core",
- "evm-gasometer",
  "evm-runtime",
  "log",
  "rlp",
@@ -912,15 +911,6 @@ dependencies = [
  "serde",
  "serde_bytes",
  "uint",
-]
-
-[[package]]
-name = "evm-gasometer"
-version = "0.18.0"
-dependencies = [
- "evm-core",
- "evm-runtime",
- "serde",
 ]
 
 [[package]]

--- a/evm_loader/cli/src/commands/emulate.rs
+++ b/evm_loader/cli/src/commands/emulate.rs
@@ -15,7 +15,7 @@ use crate::{
 use solana_sdk::pubkey::Pubkey;
 use crate::{errors};
 
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 pub fn execute(
     config: &Config, 
     contract_id: Option<H160>, 
@@ -24,6 +24,7 @@ pub fn execute(
     value: Option<U256>,
     token_mint: &Pubkey,
     chain_id: u64,
+    max_steps_to_execute: u64,
 ) -> NeonCliResult {
     debug!("command_emulate(config={:?}, contract_id={:?}, caller_id={:?}, data={:?}, value={:?})",
         config,
@@ -67,7 +68,7 @@ pub fn execute(
                     data.unwrap_or_default(),
                     value.unwrap_or_default(),
                     gas_limit, U256::zero())?;
-                match executor.execute_n_steps(100_000){
+                match executor.execute_n_steps(max_steps_to_execute){
                     Ok(()) => {
                         info!("too many steps");
                         return Err(errors::NeonCliError::TooManySteps)
@@ -84,7 +85,7 @@ pub fn execute(
                     data.unwrap_or_default(),
                     value.unwrap_or_default(),
                     gas_limit, U256::zero())?;
-                match executor.execute_n_steps(100_000){
+                match executor.execute_n_steps(max_steps_to_execute){
                     Ok(()) => {
                         info!("too many steps");
                         return Err(errors::NeonCliError::TooManySteps)

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -557,6 +557,15 @@ fn main() {
                         .required(false)
                         .help("Network chain_id"),
                 )
+                .arg(
+                    Arg::with_name("max_steps_to_execute")
+                        .long("max_steps_to_execute")
+                        .value_name("NUMBER_OF_STEPS")
+                        .takes_value(true)
+                        .required(false)
+                        .default_value("100_000")
+                        .help("Maximal number of steps to execute in a single run"),
+                )
         )
         .subcommand(
             SubCommand::with_name("create-ether-account")
@@ -823,8 +832,16 @@ fn main() {
                 }
                 let token_mint = token_mint.unwrap();
                 let chain_id = chain_id.unwrap();
+                let max_steps_to_execute = value_of::<u64>(arg_matches, "max_steps_to_execute").unwrap();
 
-                emulate::execute(&config, contract, sender, data, value, &token_mint, chain_id)
+                emulate::execute(&config,
+                                 contract,
+                                 sender,
+                                 data,
+                                 value,
+                                 &token_mint,
+                                 chain_id,
+                                 max_steps_to_execute)
             }
             ("create-program-address", Some(arg_matches)) => {
                 let ether = h160_of(arg_matches, "seed").unwrap();


### PR DESCRIPTION
Emulator restricts number of steps to execute in a single run. This protects proxy from entering infinite loop in case of gas limit exceeded. This parameter was hardcoded as `100_000`.

An option `--max_steps_to_execute` has been added to the command `emulate` of the `neon-cli` program.
