### PR TITLE
Fix QueryAccount.cache warnings

### DIFF
--- a/evm_loader/solidity/contracts/lib_query_account.sol
+++ b/evm_loader/solidity/contracts/lib_query_account.sol
@@ -15,8 +15,8 @@ library QueryAccount {
      * @param offset Offset in bytes from the beginning of the data.
      * @param len Length in bytes of the chunk.
      */
-    function cache(uint256 solana_address, uint64 offset, uint64 len) internal returns (bool) {
-        (bool success, bytes memory _dummy) = precompiled.staticcall(abi.encodeWithSignature("cache(uint256,uint64,uint64)", solana_address, offset, len));
+    function cache(uint256 solana_address, uint64 offset, uint64 len) internal view returns (bool) {
+        (bool success,) = precompiled.staticcall(abi.encodeWithSignature("cache(uint256,uint64,uint64)", solana_address, offset, len));
         return success;
     }
 


### PR DESCRIPTION


We can make QueryAccount.cache be a view function since it does not affect the Ethereum state. Additionally, unused variable is removed.

Proof:

> Compilation warnings encountered:

    Warning: Unused local variable.
  --> project:/contracts/libraries/external/QueryAccount.sol:19:24:
   |
19 |         (bool success, bytes memory _dummy) = precompiled.staticcall(abi.enco ...
   |                        ^^^^^^^^^^^^^^^^^^^

,Warning: Function state mutability can be restricted to view
  --> project:/contracts/libraries/external/QueryAccount.sol:18:5:
   |
18 |     function cache(uint256 solana_address, uint64 offset, uint64 len) internal returns (bool) {
   |     ^ (Relevant source part starts here and spans across multiple lines).

(from sponomarev)