### PR TITLE
Last changes from develop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 ARG SOLANA_IMAGE
 # Install BPF SDK
-FROM solanalabs/rust:1.63.0 AS builder
-RUN rustup toolchain install nightly
-RUN rustup component add clippy --toolchain nightly
+FROM solanalabs/rust:1.64.0 AS builder
 WORKDIR /opt
 ARG SOLANA_REVISION
 RUN sh -c "$(curl -sSfL https://release.solana.com/"${SOLANA_REVISION}"/install)" && \
@@ -17,7 +15,7 @@ COPY ./evm_loader/ /opt/evm_loader/
 WORKDIR /opt/evm_loader
 ARG REVISION
 ENV NEON_REVISION=${REVISION}
-RUN cargo +nightly clippy && \
+RUN cargo clippy --release && \
     cargo build --release && \
     cargo build-sbf --arch bpf --features no-logs,devnet && cp target/deploy/evm_loader.so target/deploy/evm_loader-devnet.so && \
     cargo build-sbf --arch bpf --features no-logs,testnet && cp target/deploy/evm_loader.so target/deploy/evm_loader-testnet.so && \

--- a/evm_loader/Cargo.lock
+++ b/evm_loader/Cargo.lock
@@ -1133,7 +1133,6 @@ dependencies = [
  "arrayref",
  "bincode",
  "borsh",
- "bytes",
  "cfg-if",
  "const_format",
  "environmental",

--- a/evm_loader/cli/src/account_storage.rs
+++ b/evm_loader/cli/src/account_storage.rs
@@ -11,12 +11,12 @@ use solana_sdk::{
     account_info::AccountInfo,
     pubkey::{Pubkey},
     pubkey,
-    sysvar::recent_blockhashes,
+    sysvar::{recent_blockhashes, Sysvar}, rent::Rent,
 };
 use solana_sdk::entrypoint::MAX_PERMITTED_DATA_INCREASE;
 use evm_loader::{
-    config::STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT,
-    executor::{Action, OwnedAccountInfo, OwnedAccountInfoPartial},
+    config::{STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT, PAYMENT_TO_TREASURE},
+    executor::{Action, OwnedAccountInfo, OwnedAccountInfoPartial, LAMPORTS_PER_SIGNATURE},
     account::{ACCOUNT_SEED_VERSION, EthereumAccount, EthereumStorage},
     account_storage::{AccountStorage}, precompile::is_precompile_address,
 };
@@ -175,7 +175,11 @@ impl<'a> EmulatorAccountStorage<'a> {
         }
     }
 
-    pub fn apply_actions(&self, actions: Vec<Action>) {
+    #[must_use]
+    pub fn apply_actions(&self, actions: Vec<Action>) -> u64 {
+        let mut gas = 0_u64;
+        let rent = Rent::get().unwrap();
+
         for action in actions {
             #[allow(clippy::match_same_arms)]
             match action {
@@ -187,7 +191,7 @@ impl<'a> EmulatorAccountStorage<'a> {
                     self.add_ethereum_account(&source, true);
                 },
                 Action::EvmLog { .. } => {},
-                Action::EvmSetStorage { address, key, .. } => {
+                Action::EvmSetStorage { address, key, value } => {
                     if key < U256::from(STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT) {
                         self.add_ethereum_account(&address, true);
                     } else {
@@ -195,6 +199,11 @@ impl<'a> EmulatorAccountStorage<'a> {
 
                         let (storage_account, _) = self.get_storage_address(&address, &index);
                         self.add_solana_account(storage_account, true);
+
+                        if self.storage(&address, &index).is_zero() {
+                            let cost = rent.minimum_balance(2 + std::mem::size_of_val(&value));
+                            gas = gas.saturating_add(cost);
+                        }
                     }
                 },
                 Action::EvmIncrementNonce { address } => {
@@ -206,18 +215,29 @@ impl<'a> EmulatorAccountStorage<'a> {
                 Action::EvmSelfDestruct { address } => {
                     self.add_ethereum_account(&address, true);
                 },
-                Action::ExternalInstruction { program_id, accounts, .. } => {
+                Action::ExternalInstruction { program_id, accounts, allocate, .. } => {
                     self.add_solana_account(program_id, false);
 
                     for account in &accounts {
                         self.add_solana_account(account.key, account.is_writable);
                     }
+
+                    let cost = rent.minimum_balance(allocate);
+                    gas = gas.saturating_add(cost);
                 }
             }
         }
+
+        gas
     }
 
-    pub fn apply_accounts_operations(&self, operations: AccountsOperations) {
+    #[must_use]
+    pub fn apply_accounts_operations(&self, operations: AccountsOperations) -> u64 {
+        let mut gas = 0_u64;
+        let rent = Rent::get().unwrap();
+
+        let mut iterations = 0_usize;
+
         let mut accounts = self.accounts.borrow_mut();
         for (address, operation) in operations {
             let new_size = match operation {
@@ -232,8 +252,18 @@ impl<'a> EmulatorAccountStorage<'a> {
                         .saturating_sub(1)
                         / MAX_PERMITTED_DATA_INCREASE,
                 );
+
+                iterations = iterations.max(a.additional_resize_steps);
             });
+
+            let allocate_cost = rent.minimum_balance(new_size);
+            gas = gas.saturating_add(allocate_cost);
         }
+
+        let iterations_cost = (iterations as u64) * (LAMPORTS_PER_SIGNATURE + PAYMENT_TO_TREASURE);
+        gas = gas.saturating_add(iterations_cost);
+
+        gas
     }
 
     fn ethereum_account_map_or<F, R>(&self, address: &H160, default: R, f: F) -> R

--- a/evm_loader/cli/src/account_storage.rs
+++ b/evm_loader/cli/src/account_storage.rs
@@ -15,7 +15,7 @@ use solana_sdk::{
 };
 use solana_sdk::entrypoint::MAX_PERMITTED_DATA_INCREASE;
 use evm_loader::{
-    config::{STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT, PAYMENT_TO_TREASURE},
+    config::{STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT},
     executor::{Action, OwnedAccountInfo, OwnedAccountInfoPartial, LAMPORTS_PER_SIGNATURE},
     account::{ACCOUNT_SEED_VERSION, EthereumAccount, EthereumStorage},
     account_storage::{AccountStorage}, precompile::is_precompile_address,
@@ -260,7 +260,7 @@ impl<'a> EmulatorAccountStorage<'a> {
             gas = gas.saturating_add(allocate_cost);
         }
 
-        let iterations_cost = (iterations as u64) * (LAMPORTS_PER_SIGNATURE + PAYMENT_TO_TREASURE);
+        let iterations_cost = (iterations as u64) * LAMPORTS_PER_SIGNATURE;
         gas = gas.saturating_add(iterations_cost);
 
         gas

--- a/evm_loader/cli/src/commands/emulate.rs
+++ b/evm_loader/cli/src/commands/emulate.rs
@@ -109,7 +109,7 @@ pub fn execute(
     let accounts_operations = storage.calc_accounts_operations(&actions);
 
     let max_iterations = (steps_executed + (EVM_STEPS_MIN - 1)) / EVM_STEPS_MIN;
-    let steps_gas = max_iterations * (LAMPORTS_PER_SIGNATURE + PAYMENT_TO_TREASURE);
+    let steps_gas = (max_iterations + 2) * (LAMPORTS_PER_SIGNATURE + PAYMENT_TO_TREASURE);
     let actions_gas = storage.apply_actions(actions);
     let accounts_gas = storage.apply_accounts_operations(accounts_operations);
     debug!("Gas - steps: {steps_gas}, actions: {actions_gas}, accounts: {accounts_gas}");

--- a/evm_loader/cli/src/commands/emulate.rs
+++ b/evm_loader/cli/src/commands/emulate.rs
@@ -109,7 +109,8 @@ pub fn execute(
     let accounts_operations = storage.calc_accounts_operations(&actions);
 
     let max_iterations = (steps_executed + (EVM_STEPS_MIN - 1)) / EVM_STEPS_MIN;
-    let steps_gas = (max_iterations + 2) * (LAMPORTS_PER_SIGNATURE + PAYMENT_TO_TREASURE);
+    let steps_gas = max_iterations * (LAMPORTS_PER_SIGNATURE + PAYMENT_TO_TREASURE);
+    let begin_end_gas = 2 * LAMPORTS_PER_SIGNATURE;
     let actions_gas = storage.apply_actions(actions);
     let accounts_gas = storage.apply_accounts_operations(accounts_operations);
     debug!("Gas - steps: {steps_gas}, actions: {actions_gas}, accounts: {accounts_gas}");
@@ -146,7 +147,7 @@ pub fn execute(
         "exit_status": status,
         "exit_reason": exit_reason,
         "steps_executed": steps_executed,
-        "used_gas": steps_gas + actions_gas + accounts_gas
+        "used_gas": steps_gas + begin_end_gas + actions_gas + accounts_gas
     });
 
     println!("{}", js);

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -292,27 +292,6 @@ fn is_valid_u256<T>(string: T) -> Result<(), String> where T: AsRef<str>,
         .map_err(|e| e.to_string())
 }
 
-// Return hexdata for an argument
-fn hexdata_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<u8>> {
-    matches.value_of(name).and_then(|value| {
-        if value.to_lowercase() == "none" {
-            return None;
-        }
-        hex::decode(make_clean_hex(value)).ok()
-    })
-}
-
-// Return an error if string cannot be parsed as a hexdata
-fn is_valid_hexdata<T>(string: T) -> Result<(), String> where T: AsRef<str>,
-{
-    if string.as_ref().to_lowercase() == "none" {
-        return Ok(());
-    }
-
-    hex::decode(make_clean_hex(string.as_ref())).map(|_| ())
-        .map_err(|e| e.to_string())
-}
-
 fn is_amount<T, U>(amount: U) -> Result<(), String>
     where
         T: std::str::FromStr,
@@ -325,6 +304,22 @@ fn is_amount<T, U>(amount: U) -> Result<(), String>
             "Unable to parse input amount as {}, provided: {}",
             std::any::type_name::<T>(), amount
         ))
+    }
+}
+
+fn read_stdin() -> Option<Vec<u8>>{
+    let mut data = String::new();
+
+    if let Ok(len) = std::io::stdin().read_line(&mut data){
+        if len == 0{
+            return None
+        }
+        let data = make_clean_hex(data.as_str());
+        let bin = hex::decode(data).unwrap();
+        Some(bin)
+    }
+    else{
+        None
     }
 }
 
@@ -450,19 +445,10 @@ fn main() {
                         .help("The contract that executes the transaction or 'deploy'")
                 )
                 .arg(
-                    Arg::with_name("data")
-                        .value_name("DATA")
-                        .takes_value(true)
-                        .index(3)
-                        .required(false)
-                        .validator(is_valid_hexdata)
-                        .help("Transaction data or 'None'")
-                )
-                .arg(
                     Arg::with_name("value")
                         .value_name("VALUE")
                         .takes_value(true)
-                        .index(4)
+                        .index(3)
                         .required(false)
                         .validator(is_amount::<U256, _>)
                         .help("Transaction value")
@@ -691,7 +677,7 @@ fn main() {
             ("emulate", Some(arg_matches)) => {
                 let contract = h160_or_deploy_of(arg_matches, "contract");
                 let sender = h160_of(arg_matches, "sender").unwrap();
-                let data = hexdata_of(arg_matches, "data");
+                let data = read_stdin();
                 let value = value_of(arg_matches, "value");
 
                 // Read ELF params only if token_mint or chain_id is not set.

--- a/evm_loader/program-macro/src/lib.rs
+++ b/evm_loader/program-macro/src/lib.rs
@@ -13,7 +13,7 @@ struct OperatorsWhitelistInput {
 
 impl Parse for OperatorsWhitelistInput {
     fn parse(input: ParseStream) -> Result<Self> {
-        let list = Punctuated::parse_terminated(&input)?;
+        let list = Punctuated::parse_terminated(input)?;
         Ok(Self{list})
     }
 }

--- a/evm_loader/program/Cargo.toml
+++ b/evm_loader/program/Cargo.toml
@@ -49,7 +49,6 @@ arrayref = "0.3.6"
 hex = "0.4.2"
 ripemd160 = "0.9.1"
 rlp = "0.5"
-bytes = "1.2.1"
 borsh = "0.9"
 bincode = "1.3.3"
 evm = { version = "0.18.0", path = "../rust-evm", default_features = false }

--- a/evm_loader/program/src/account_storage/apply.rs
+++ b/evm_loader/program/src/account_storage/apply.rs
@@ -24,7 +24,6 @@ impl<'a> ProgramAccountStorage<'a> {
     ) -> ProgramResult {
         let origin_balance = self.balance(&origin);
         if origin_balance < value {
-            self.transfer_gas_payment(origin, operator, origin_balance)?;
             return Err!(ProgramError::InsufficientFunds; "Account {} - insufficient funds", origin);
         }
 
@@ -52,10 +51,10 @@ impl<'a> ProgramAccountStorage<'a> {
         system_program: &program::System<'a>,
         operator: &Operator<'a>,
         actions: Vec<Action>,
-        accounts_operations: AccountsOperations,
     ) -> Result<AccountsReadiness, ProgramError> {
         debug_print!("Applies begin");
 
+        let accounts_operations = self.calc_accounts_operations(&actions);
         if self.process_accounts_operations(
             system_program,
             neon_program,
@@ -103,7 +102,7 @@ impl<'a> ProgramAccountStorage<'a> {
 
                     self.delete_account(address)?;
                 },
-                Action::ExternalInstruction { program_id, instruction, accounts, seeds } => {
+                Action::ExternalInstruction { program_id, instruction, accounts, seeds, .. } => {
                     let seeds: Vec<&[u8]> = seeds.iter().map(|seed| &seed[..]).collect();
                     let accounts: Vec<_> = accounts.into_iter().map(AccountMeta::into_solana_meta).collect();
 

--- a/evm_loader/program/src/account_storage/mod.rs
+++ b/evm_loader/program/src/account_storage/mod.rs
@@ -115,13 +115,8 @@ pub trait AccountStorage {
 
     fn calc_accounts_operations(
         &self,
-        actions: &Option<Vec<Action>>,
+        actions: &[Action],
     ) -> AccountsOperations {
-        let actions = match actions {
-            None => return vec![],
-            Some(actions) => actions,
-        };
-
         let mut accounts = HashMap::new();
         for action in actions {
             let (address, code_size) = match action {

--- a/evm_loader/program/src/config.rs
+++ b/evm_loader/program/src/config.rs
@@ -853,6 +853,8 @@ pub const GAS_LIMIT_MULTIPLIER_NO_CHAINID: u32 = 1000;
 pub const STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT: u32 = 64;
 /// Minimum number of EVM steps for iterative transaction
 pub const EVM_STEPS_MIN: u64 = 500;
+/// Maximum number of EVM steps in a last iteration
+pub const EVM_STEPS_LAST_ITERATION_MAX: u64 = 0;
 
 cfg_if! {
     if #[cfg(feature = "emergency")] {

--- a/evm_loader/program/src/config.rs
+++ b/evm_loader/program/src/config.rs
@@ -851,6 +851,8 @@ pub const REQUEST_UNITS_ADDITIONAL_FEE: u64 = 0;
 pub const GAS_LIMIT_MULTIPLIER_NO_CHAINID: u32 = 1000;
 /// Amount of storage entries stored in the contract account
 pub const STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT: u32 = 64;
+/// Minimum number of EVM steps for iterative transaction
+pub const EVM_STEPS_MIN: u64 = 500;
 
 cfg_if! {
     if #[cfg(feature = "emergency")] {
@@ -875,6 +877,7 @@ neon_elf_param!( NEON_HEAP_FRAME            , formatcp!("{:?}", COMPUTE_BUDGET_H
 neon_elf_param!( NEON_ADDITIONAL_FEE        , formatcp!("{:?}", REQUEST_UNITS_ADDITIONAL_FEE));
 neon_elf_param!( NEON_GAS_LIMIT_MULTIPLIER_NO_CHAINID, formatcp!("{:?}", GAS_LIMIT_MULTIPLIER_NO_CHAINID));
 neon_elf_param!( NEON_STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT, formatcp!("{:?}", STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT));
+neon_elf_param!( NEON_EVM_STEPS_MIN, formatcp!("{:?}", EVM_STEPS_MIN));
 
 /// Chain ID
 #[must_use]

--- a/evm_loader/program/src/executor/action.rs
+++ b/evm_loader/program/src/executor/action.rs
@@ -1,5 +1,3 @@
-use std::fmt::{Display, Formatter};
-
 use borsh::{BorshDeserialize, BorshSerialize};
 use evm::{H160, H256, U256};
 use solana_program::pubkey::Pubkey;
@@ -12,7 +10,8 @@ pub enum Action {
         program_id: Pubkey,
         instruction: Vec<u8>,
         accounts: Vec<AccountMeta>,
-        seeds: Vec<Vec<u8>>
+        seeds: Vec<Vec<u8>>,
+        allocate: usize
     },
     NeonTransfer {
         source: H160,
@@ -44,51 +43,4 @@ pub enum Action {
     EvmSelfDestruct {
         address: H160,
     },
-}
-
-impl Display for Action {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let msg = match self {
-            Action::ExternalInstruction { program_id, instruction, accounts, seeds } =>
-                format!(
-                    "ExternalInstruction (\
-                        program_id = {}, \
-                        instruction.len() = {}, \
-                        accounts.len() = {}, \
-                        seeds.len() = {}",
-                    program_id,
-                    instruction.len(),
-                    accounts.len(),
-                    seeds.len(),
-                ),
-            Action::NeonTransfer { source, target, value } =>
-                format!("NeonTransfer (value = {}) from {} to {}", value, source, target),
-            Action::NeonWithdraw { source, value } =>
-                format!("NeonWithdraw from {} (value = {})", source, value),
-            Action::EvmLog { address, topics, data } =>
-                format!(
-                    "EvmLog for {} (topics.len() = {}, data.len() = {})",
-                    address,
-                    topics.len(),
-                    data.len(),
-                ),
-            Action::EvmSetStorage { address, key, value } =>
-                format!("EvmSetStorage for {}, key = {}, value = {}", address, key, value),
-            Action::EvmIncrementNonce { address } =>
-                format!("EvmIncrementNonce for {}", address),
-            Action::EvmSetCode { address, code, valids } =>
-                format!(
-                    "EvmSetCode for {} (code.len() = {}, valids.len() = {})",
-                    address,
-                    code.len(),
-                    valids.len(),
-                ),
-            Action::EvmSelfDestruct { address } =>
-                format!("EvmSelfDestruct for {}", address),
-        };
-
-        f.write_str(&msg)?;
-
-        Ok(())
-    }
 }

--- a/evm_loader/program/src/executor/gasometer.rs
+++ b/evm_loader/program/src/executor/gasometer.rs
@@ -1,20 +1,15 @@
 use std::convert::TryInto;
 
-use evm::{U256, H160};
+use evm::{U256};
+use solana_program::account_info::AccountInfo;
 use solana_program::{
-    sysvar::Sysvar, 
-    rent::Rent,
     program_error::ProgramError,
 };
-use solana_program::entrypoint::MAX_PERMITTED_DATA_INCREASE;
+use crate::account::Operator;
 use crate::{
-    config::{HOLDER_MSG_SIZE, PAYMENT_TO_TREASURE, STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT},
-    account_storage::AccountStorage,
+    config::{HOLDER_MSG_SIZE},
     transaction::Transaction, 
 };
-use crate::account_storage::{AccountOperation, AccountsOperations};
-
-use super::ExecutorState;
 
 pub const LAMPORTS_PER_SIGNATURE: u64 = 5000;
 
@@ -22,23 +17,19 @@ const WRITE_TO_HOLDER_TRX_COST: u64 = LAMPORTS_PER_SIGNATURE;
 const CANCEL_TRX_COST: u64 = LAMPORTS_PER_SIGNATURE;
 const LAST_ITERATION_COST: u64 = LAMPORTS_PER_SIGNATURE;
 
-const EVM_STEPS_MIN: u64 = 500;
-const EVM_STEP_COST: u64 = (LAMPORTS_PER_SIGNATURE / EVM_STEPS_MIN) + (PAYMENT_TO_TREASURE / EVM_STEPS_MIN);
 
 pub struct Gasometer {
     paid_gas: U256,
     gas: u64,
-    rent: Rent
+    operator_balance: u64
 }
 
 impl Gasometer {
-    pub fn new(paid_gas: Option<U256>) -> Result<Self, ProgramError> {
-        let rent = Rent::get()?;
-
-        Ok( Self { 
+    pub fn new(paid_gas: Option<U256>, operator: &Operator) -> Result<Self, ProgramError> {
+        Ok( Self {
             paid_gas: paid_gas.unwrap_or(U256::zero()), 
-            gas: 0_u64, 
-            rent,
+            gas: 0_u64,
+            operator_balance: operator.lamports()
         } )
     }
 
@@ -52,6 +43,16 @@ impl Gasometer {
         self.paid_gas.saturating_add(U256::from(self.gas))
     }
 
+    pub fn record_operator_expenses(&mut self, operator: &Operator) {
+        let expenses = self.operator_balance.saturating_sub(operator.lamports());
+
+        self.gas = self.gas.saturating_add(expenses);
+    }
+
+    pub fn record_solana_transaction_cost(&mut self) {
+        self.gas = self.gas.saturating_add(LAMPORTS_PER_SIGNATURE);
+    }
+
     pub fn record_iterative_overhead(&mut self) {
         // High chance of last iteration to fail with solana error
         // Consume gas for it in the first iteration
@@ -60,107 +61,26 @@ impl Gasometer {
             .saturating_add(CANCEL_TRX_COST);
     }
 
-    pub fn record_transaction_size(&mut self, trx: &Transaction) {
-        let overhead = 65/*vrs*/ + 8/*u64 len*/;
-        let size = trx.rlp_len.saturating_add(overhead);
-
-        let size: u64 = size.try_into().expect("usize is 8 bytes");
-        let cost: u64 = (size / HOLDER_MSG_SIZE)
-            .saturating_add(1)
+    pub fn record_write_to_holder(&mut self, trx: &Transaction) {
+        let size: u64 = trx.rlp_len.try_into().expect("usize is 8 bytes");
+        let cost: u64 = (size + (HOLDER_MSG_SIZE - 1)) / HOLDER_MSG_SIZE
             .saturating_mul(WRITE_TO_HOLDER_TRX_COST);
 
         self.gas = self.gas.saturating_add(cost);
     }
 
-    pub fn record_evm_steps(&mut self, steps: u64) {
-        let cost = steps.saturating_mul(EVM_STEP_COST);
+    pub fn record_address_lookup_table(&mut self, accounts: &[AccountInfo]) {
+        const MIN_ACCOUNTS_TO_USE_ALT: usize = 30;
+        const ACCOUNTS_PER_ALT_EXTEND: usize = 30;
+
+        if accounts.len() < MIN_ACCOUNTS_TO_USE_ALT {
+            return;
+        }
+
+        let extend_count = (accounts.len() + (ACCOUNTS_PER_ALT_EXTEND - 1) ) / ACCOUNTS_PER_ALT_EXTEND;
+        // create_alt + extend_alt + deactivate_alt + close_alt
+        let cost = (extend_count + 3) as u64 * LAMPORTS_PER_SIGNATURE;
 
         self.gas = self.gas.saturating_add(cost);
     }
-
-    pub fn pad_evm_steps(&mut self, steps: u64) {
-        if steps >= EVM_STEPS_MIN {
-            return;
-        }
-
-        self.record_evm_steps(EVM_STEPS_MIN - steps);
-    }
-
-    pub fn record_storage_write<B>(&mut self, state: &ExecutorState<B>, address: H160, key: U256, value: U256)
-    where
-        B: AccountStorage
-    {
-        if key < U256::from(STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT) {
-            return;
-        }
-
-        if value.is_zero() {
-            return;
-        }
-
-        if !state.storage(&address, &key).is_zero() {
-            return;
-        }
-
-        let data_len = 1/*tag*/ + 1/*subindex*/ + 32/*value*/;
-        self.record_account_rent(data_len);
-    }
-
-    pub fn record_accounts_operations_for_emulation(
-        &mut self,
-        accounts_operations: &AccountsOperations,
-    ) {
-        for (_address, operation) in accounts_operations {
-            match operation {
-                AccountOperation::Create { space } => self.record_account_rent(*space),
-
-                AccountOperation::Resize { from, to } => {
-                    self.record_account_rent_diff(*from, *to);
-                }
-            }
-        }
-    }
-
-    pub fn record_accounts_operations(&mut self, accounts_operations: &AccountsOperations) {
-        for (_address, operation) in accounts_operations {
-            match operation {
-                AccountOperation::Create { space } => self.record_account_rent(
-                    (*space).min(MAX_PERMITTED_DATA_INCREASE),
-                ),
-
-                AccountOperation::Resize { from, to } => {
-                    self.record_account_rent_diff(
-                        *from,
-                        (*to).min(from.saturating_add(MAX_PERMITTED_DATA_INCREASE)),
-                    );
-                }
-            }
-        }
-    }
-
-    pub fn record_additional_resize_iterations(&mut self, iteration_count: usize) {
-        let cost = (PAYMENT_TO_TREASURE + LAMPORTS_PER_SIGNATURE).saturating_mul(
-            iteration_count as u64,
-        );
-        self.gas = self.gas.saturating_add(cost);
-    }
-
-    pub fn record_account_rent(&mut self, data_len: usize) {
-        let account_rent = self.rent.minimum_balance(data_len);
-        self.gas = self.gas.saturating_add(account_rent);
-    }
-
-    pub fn record_account_rent_diff(&mut self, data_len_old: usize, data_len_new: usize) {
-        assert!(data_len_new >= data_len_old);
-        let account_rent_old = self.rent.minimum_balance(data_len_old);
-        let account_rent_new = self.rent.minimum_balance(data_len_new);
-        self.gas = self.gas.saturating_add(account_rent_new.saturating_sub(account_rent_old));
-    }
-
-    pub fn record_lamports_used(&mut self, lamports: u64)
-    {
-        self.gas = self.gas.saturating_add(lamports);
-    }
-
-    pub fn record_alt_cost(&mut self, alt_cost: u64) { self.gas = self.gas.saturating_add(alt_cost); }
 }

--- a/evm_loader/program/src/executor/state.rs
+++ b/evm_loader/program/src/executor/state.rs
@@ -155,12 +155,18 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
         self.actions.push(withdraw);
     }
 
-    pub fn queue_external_instruction(&mut self, instruction: Instruction, seeds: Vec<Vec<u8>>) {
+    pub fn queue_external_instruction(
+        &mut self,
+        instruction: Instruction,
+        seeds: Vec<Vec<u8>>,
+        allocate: usize
+    ) {
         let action = Action::ExternalInstruction {
             program_id: instruction.program_id,
             instruction: instruction.data,
             accounts: instruction.accounts.into_iter().map(AccountMeta::from_solana_meta).collect(),
-            seeds
+            seeds,
+            allocate
         };
         
         self.actions.push(action);

--- a/evm_loader/program/src/instruction/transaction.rs
+++ b/evm_loader/program/src/instruction/transaction.rs
@@ -1,17 +1,14 @@
-use evm::{ExitError, ExitReason, H160, U256};
+use evm::{ExitReason, H160, U256};
 use solana_program::account_info::AccountInfo;
 use solana_program::entrypoint::ProgramResult;
 use solana_program::program_error::ProgramError;
 
 use crate::account::{EthereumAccount, Operator, program, State, Treasury};
-use crate::account_storage::{AccountsReadiness, AccountStorage, ProgramAccountStorage};
+use crate::account_storage::{AccountsReadiness, ProgramAccountStorage};
+use crate::config::EVM_STEPS_MIN;
 use crate::executor::{Action, Gasometer, Machine};
 use crate::state_account::Deposit;
 use crate::transaction::{check_ethereum_transaction, Transaction};
-use crate::executor::LAMPORTS_PER_SIGNATURE;
-
-/// Current cap of transaction accounts
-const TX_ACCOUNT_CNT: u64 = 30;
 
 pub struct Accounts<'a> {
     pub operator: Operator<'a>,
@@ -20,6 +17,7 @@ pub struct Accounts<'a> {
     pub system_program: program::System<'a>,
     pub neon_program: program::Neon<'a>,
     pub remaining_accounts: &'a [AccountInfo<'a>],
+    pub all_accounts: &'a [AccountInfo<'a>],
 }
 
 
@@ -28,11 +26,15 @@ pub fn do_begin<'a>(
     accounts: Accounts<'a>,
     mut storage: State<'a>,
     account_storage: &mut ProgramAccountStorage<'a>,
+    gasometer: Gasometer,
     trx: Transaction,
     caller: H160,
-    alt_cost: u64,
 ) -> ProgramResult {
     debug_print!("do_begin");
+
+    if (step_count < EVM_STEPS_MIN) && (trx.gas_price > U256::zero()) {
+        return Err!(ProgramError::InvalidArgument; "Step limit {step_count} below minimum {EVM_STEPS_MIN}");
+    }
 
     accounts.system_program.transfer(&accounts.operator, &accounts.treasury, crate::config::PAYMENT_TO_TREASURE)?;
 
@@ -41,33 +43,19 @@ pub fn do_begin<'a>(
     account_storage.block_accounts(true)?;
 
 
-    let (results, gasometer) = {
+    let results = {
         let mut executor = Machine::new(caller, account_storage)?;
-        executor.gasometer_mut().record_iterative_overhead();
-        executor.gasometer_mut().record_transaction_size(&trx);
-        executor.gasometer_mut().record_alt_cost(alt_cost);
 
-        let begin_result = if let Some(code_address) = trx.to {
+        if let Some(code_address) = trx.to {
             executor.call_begin(caller, code_address, trx.call_data, trx.value, trx.gas_limit, trx.gas_price)
         } else {
             executor.create_begin(caller, trx.call_data, trx.value, trx.gas_limit, trx.gas_price)
-        };
+        }?;
 
-        match begin_result {
-            Ok(()) => {
-                execute_steps(executor, step_count, &mut storage)
-            }
-            Err(ProgramError::InsufficientFunds) => {
-                let result = vec![];
-                let exit_reason = ExitError::OutOfFund.into();
-
-                (Some((result, exit_reason, None)), executor.take_gasometer())
-            }
-            Err(e) => return Err(e)
-        }
+        execute_steps(executor, step_count, &mut storage)
     };
 
-    finalize(accounts, storage, account_storage, results, gasometer.used_gas(), gasometer)
+    finalize(accounts, storage, account_storage, results, gasometer)
 }
 
 pub fn do_continue<'a>(
@@ -75,46 +63,43 @@ pub fn do_continue<'a>(
     accounts: Accounts<'a>,
     mut storage: State<'a>,
     account_storage: &mut ProgramAccountStorage<'a>,
+    gasometer: Gasometer,
 ) -> ProgramResult {
     debug_print!("do_continue");
 
+    if (step_count < EVM_STEPS_MIN) && (storage.gas_price > U256::zero()) {
+        return Err!(ProgramError::InvalidArgument; "Step limit {step_count} below minimum {EVM_STEPS_MIN}");
+    }
+
     accounts.system_program.transfer(&accounts.operator, &accounts.treasury, crate::config::PAYMENT_TO_TREASURE)?;
 
-    let (results, gasometer) = {
+    let results = {
         let executor = Machine::restore(&storage, account_storage)?;
         execute_steps(executor, step_count, &mut storage)
     };
 
-    finalize(accounts, storage, account_storage, results, gasometer.used_gas(), gasometer)
+    finalize(accounts, storage, account_storage, results, gasometer)
 }
 
 
-type EvmResults = (Vec<u8>, ExitReason, Option<Vec<Action>>);
+type EvmResults = (Vec<u8>, ExitReason, Vec<Action>);
 
 fn execute_steps(
     mut executor: Machine<ProgramAccountStorage>,
     step_count: u64,
     storage: &mut State
-) -> (Option<EvmResults>, Gasometer) {
-    match executor.execute_n_steps(step_count) {
-        Ok(_) => { // step limit
-            executor.save_into(storage);
+) -> Option<EvmResults> {
+    let result = executor.execute_n_steps(step_count);
+    executor.save_into(storage);
 
-            (None, executor.take_gasometer())
+    match result {
+        Ok(()) => { // step limit
+            None
         },
         Err((result, reason)) => { // transaction complete
-            let (apply_state, gasometer) = if reason.is_succeed() {
-                // TODO: Save only when there is needed to repeat transaction.
-                executor.save_into(storage);
+            let actions = executor.into_state_actions();
 
-                let (actions, gasometer) = executor.into_state_actions_and_gasometer();
-
-                (Some(actions), gasometer)
-            } else {
-                (None, executor.take_gasometer())
-            };
-
-            (Some((result, reason, apply_state)), gasometer)
+            Some((result, reason, actions))
         }
     }
 }
@@ -145,70 +130,45 @@ fn finalize<'a>(
     mut storage: State<'a>,
     account_storage: &mut ProgramAccountStorage<'a>,
     results: Option<EvmResults>,
-    mut used_gas: U256,
     mut gasometer: Gasometer,
 ) -> ProgramResult {
     debug_print!("finalize");
 
-    let accounts_operations = match results {
-        None => vec![],
-        Some((_, _, ref actions)) => {
-            let accounts_operations = account_storage.calc_accounts_operations(actions);
-            gasometer.record_accounts_operations(&accounts_operations);
-            used_gas = gasometer.used_gas();
-
-            accounts_operations
-        },
-    };
-
-    // The only place where checked math is required.
-    // Saturating math should be used everywhere else for gas calculation.
-    let total_used_gas = storage.gas_used.checked_add(used_gas);
-
-    // Integer overflow or more than gas_limit. Consume remaining gas and revert transaction with Out of Gas
-    if total_used_gas.is_none() || (total_used_gas > Some(storage.gas_limit)) {
-        let out_of_gas = Some((vec![], ExitError::OutOfGas.into(), None));
-        let remaining_gas = storage.gas_limit.saturating_sub(storage.gas_used);
-
-        return finalize(accounts, storage, account_storage, out_of_gas, remaining_gas, gasometer);
-    }
-
-    let (results, accounts_operations) = match pay_gas_cost(used_gas, accounts.operator_ether_account, &mut storage, account_storage) {
-        Ok(()) => (results, accounts_operations),
-        Err(ProgramError::InsufficientFunds) => (Some((vec![], ExitError::OutOfFund.into(), None)), vec![]),
-        Err(e) => return Err(e)
-    };
-    solana_program::log::sol_log_data(&[b"IX_GAS", used_gas.as_u64().to_le_bytes().as_slice()]);
-
-    if let Some((result, exit_reason, apply_state)) = results {
-        let apply_state = apply_state.unwrap_or_else(
-            || vec![Action::EvmIncrementNonce { address: storage.caller }],
-        );
+    let results = if let Some((result, exit_reason, apply_state)) = results {
         if account_storage.apply_state_change(
             &accounts.neon_program,
             &accounts.system_program,
             &accounts.operator,
             apply_state,
-            accounts_operations,
         )? == AccountsReadiness::Ready {
-            accounts.neon_program.on_return(exit_reason, storage.gas_used, &result);
-
-            account_storage.block_accounts(false)?;
-            storage.finalize(Deposit::ReturnToOperator(accounts.operator))?;
+            Some((result, exit_reason))
+        } else {
+            None
         }
+    } else {
+        None
+    };
+
+    gasometer.record_operator_expenses(&accounts.operator);
+
+    let total_used_gas = gasometer.used_gas_total();
+    let gas_limit = storage.gas_limit;
+    if total_used_gas > gas_limit {
+        return Err!(ProgramError::InvalidArgument; "Out of gas used - {total_used_gas}, limit - {gas_limit}")
+    }
+
+    let used_gas = gasometer.used_gas();
+    solana_program::log::sol_log_data(&[b"IX_GAS", &used_gas.as_u64().to_le_bytes()]);
+
+    pay_gas_cost(used_gas, accounts.operator_ether_account, &mut storage, account_storage)?;
+
+
+    if let Some((result, status)) = results {
+        accounts.neon_program.on_return(status, total_used_gas, &result);
+
+        account_storage.block_accounts(false)?;
+        storage.finalize(Deposit::ReturnToOperator(accounts.operator))?;
     }
 
     Ok(())
-}
-
-#[must_use]
-pub fn alt_cost(tx_acc_count: u64) -> u64 {
-    if tx_acc_count > TX_ACCOUNT_CNT {
-        let extend = tx_acc_count /TX_ACCOUNT_CNT+1;
-        // create_alt + extend_alt + deactivate_alt + close_alt
-        (extend+3) * LAMPORTS_PER_SIGNATURE
-    }
-    else{
-        0
-    }
 }

--- a/evm_loader/program/src/instruction/transaction_step_from_account.rs
+++ b/evm_loader/program/src/instruction/transaction_step_from_account.rs
@@ -78,7 +78,7 @@ pub fn execute<'a>(
             gasometer.record_iterative_overhead();
             gasometer.record_write_to_holder(&trx);
 
-            do_begin(step_count, accounts, storage, account_storage, gasometer, trx, caller)
+            do_begin(accounts, storage, account_storage, gasometer, trx, caller)
         }
         State::TAG => {
             let storage = State::restore(program_id, holder_or_storage_info, &accounts.operator, accounts.remaining_accounts)?;

--- a/evm_loader/program/src/instruction/transaction_step_from_account_no_chainid.rs
+++ b/evm_loader/program/src/instruction/transaction_step_from_account_no_chainid.rs
@@ -6,7 +6,7 @@ use solana_program::{
     account_info::AccountInfo, entrypoint::ProgramResult,
     pubkey::Pubkey,
 };
-use crate::instruction::transaction::{Accounts, alt_cost};
+use crate::instruction::transaction::Accounts;
 use evm::U256;
 
 
@@ -15,7 +15,6 @@ pub fn process<'a>(program_id: &'a Pubkey, accounts: &'a [AccountInfo<'a>], inst
 
     let treasury_index = u32::from_le_bytes(*array_ref![instruction, 0, 4]);
     let step_count = u64::from(u32::from_le_bytes(*array_ref![instruction, 4, 4]));
-    let alt_gas_used = alt_cost(accounts.len() as u64);
 
     let holder_or_storage_info = &accounts[0];
 
@@ -25,7 +24,8 @@ pub fn process<'a>(program_id: &'a Pubkey, accounts: &'a [AccountInfo<'a>], inst
         operator_ether_account: EthereumAccount::from_account(program_id, &accounts[3])?,
         system_program: program::System::from_account(&accounts[4])?,
         neon_program: program::Neon::from_account(program_id, &accounts[5])?,
-        remaining_accounts: &accounts[6..]
+        remaining_accounts: &accounts[6..],
+        all_accounts: accounts,
     };
 
     let mut account_storage = ProgramAccountStorage::new(
@@ -37,6 +37,6 @@ pub fn process<'a>(program_id: &'a Pubkey, accounts: &'a [AccountInfo<'a>], inst
 
     let gas_multiplier = U256::from(GAS_LIMIT_MULTIPLIER_NO_CHAINID);
     super::transaction_step_from_account::execute(
-        program_id, holder_or_storage_info, accounts, &mut account_storage, step_count, Some(gas_multiplier), alt_gas_used
+        program_id, holder_or_storage_info, accounts, &mut account_storage, step_count, Some(gas_multiplier)
     )
 }

--- a/evm_loader/program/src/instruction/transaction_step_from_instruction.rs
+++ b/evm_loader/program/src/instruction/transaction_step_from_instruction.rs
@@ -52,7 +52,7 @@ pub fn process<'a>(program_id: &'a Pubkey, accounts: &'a [AccountInfo<'a>], inst
             gasometer.record_address_lookup_table(accounts.all_accounts);
             gasometer.record_iterative_overhead();
 
-            do_begin(step_count, accounts, storage, &mut account_storage, gasometer, trx, caller)
+            do_begin(accounts, storage, &mut account_storage, gasometer, trx, caller)
         },
         State::TAG => {
             let storage = State::restore(program_id, storage_info, &accounts.operator, accounts.remaining_accounts)?;

--- a/evm_loader/program/src/instruction/transaction_step_from_instruction.rs
+++ b/evm_loader/program/src/instruction/transaction_step_from_instruction.rs
@@ -1,4 +1,5 @@
 use crate::account::{Operator, program, EthereumAccount, Treasury, State, Holder, FinalizedState};
+use crate::executor::Gasometer;
 use crate::transaction::{Transaction, recover_caller_address};
 use crate::account_storage::ProgramAccountStorage;
 use arrayref::{array_ref};
@@ -25,7 +26,8 @@ pub fn process<'a>(program_id: &'a Pubkey, accounts: &'a [AccountInfo<'a>], inst
         operator_ether_account: EthereumAccount::from_account(program_id, &accounts[3])?,
         system_program: program::System::from_account(&accounts[4])?,
         neon_program: program::Neon::from_account(program_id, &accounts[5])?,
-        remaining_accounts: &accounts[6..]
+        remaining_accounts: &accounts[6..],
+        all_accounts: accounts
     };
 
     let mut account_storage = ProgramAccountStorage::new(
@@ -45,13 +47,21 @@ pub fn process<'a>(program_id: &'a Pubkey, accounts: &'a [AccountInfo<'a>], inst
 
             let storage = State::new(program_id, storage_info, &accounts, caller, &trx)?;
 
-            do_begin(step_count, accounts, storage, &mut account_storage, trx, caller, 0)
+            let mut gasometer = Gasometer::new(None, &accounts.operator)?;
+            gasometer.record_solana_transaction_cost();
+            gasometer.record_address_lookup_table(accounts.all_accounts);
+            gasometer.record_iterative_overhead();
+
+            do_begin(step_count, accounts, storage, &mut account_storage, gasometer, trx, caller)
         },
         State::TAG => {
             let storage = State::restore(program_id, storage_info, &accounts.operator, accounts.remaining_accounts)?;
             solana_program::log::sol_log_data(&[b"HASH", &storage.transaction_hash]);
 
-            do_continue(step_count, accounts, storage, &mut account_storage)
+            let mut gasometer = Gasometer::new(Some(storage.gas_used), &accounts.operator)?;
+            gasometer.record_solana_transaction_cost();
+
+            do_continue(step_count, accounts, storage, &mut account_storage, gasometer)
         },
         _ => Err!(ProgramError::InvalidAccountData; "Account {} - expected Holder or State", storage_info.key)
     }

--- a/evm_loader/program/src/precompile/mod.rs
+++ b/evm_loader/program/src/precompile/mod.rs
@@ -2,7 +2,7 @@ use std::convert::Infallible;
 
 use evm::{H160, Capture, ExitReason};
 
-use crate::{account_storage::AccountStorage, executor::{ExecutorState, Gasometer}};
+use crate::{account_storage::AccountStorage, executor::ExecutorState};
 
 
 mod ecrecover;
@@ -62,20 +62,19 @@ pub fn call_precompile<B: AccountStorage>(
     address: H160,
     input: &[u8],
     context: &evm::Context,
-    state: &mut ExecutorState<B>,
-    gasometer: &mut Gasometer
+    state: &mut ExecutorState<B>
 ) -> Option<PrecompileResult> {
     if address == SYSTEM_ACCOUNT_QUERY {
         return Some(query_account::query_account(input, state));
     }
     if address == SYSTEM_ACCOUNT_NEON_TOKEN {
-        return Some(neon_token::neon_token(input, context, state, gasometer));
+        return Some(neon_token::neon_token(input, context, state));
     }
     if address == SYSTEM_ACCOUNT_SPL_TOKEN {
-        return Some(spl_token::spl_token(input, context, state, gasometer));
+        return Some(spl_token::spl_token(input, context, state));
     }
     if address == SYSTEM_ACCOUNT_METAPLEX {
-        return Some(metaplex::metaplex(input, context, state, gasometer));
+        return Some(metaplex::metaplex(input, context, state));
     }
     if address == SYSTEM_ACCOUNT_ECRECOVER {
         return Some(ecrecover::ecrecover(input));

--- a/evm_loader/solidity/contracts/erc20_for_spl.sol
+++ b/evm_loader/solidity/contracts/erc20_for_spl.sol
@@ -171,10 +171,14 @@ contract ERC20ForSpl {
     }
 
     function claim(bytes32 from, uint64 amount) external returns (bool) {
-        bytes32 toSolana = _solanaAccount(msg.sender);
+        return claimTo(from, msg.sender, amount);
+    }
+
+    function claimTo(bytes32 from, address to, uint64 amount) public returns (bool) {
+        bytes32 toSolana = _solanaAccount(to);
 
         if (!_splToken.exists(toSolana)) {
-            _splToken.initializeAccount(_salt(msg.sender), tokenMint);
+            _splToken.initializeAccount(_salt(to), tokenMint);
         }
 
         // spl-token transaction will be signed by tx.origin
@@ -185,7 +189,7 @@ contract ERC20ForSpl {
 
         require(status, "ERC20: claim failed");
 
-        emit Transfer(address(0), msg.sender, amount);
+        emit Transfer(address(0), to, amount);
 
         return true;
     }

--- a/evm_loader/tests/test_deploy.py
+++ b/evm_loader/tests/test_deploy.py
@@ -10,6 +10,13 @@ def test_deploy_contract(user_account, evm_loader, operator_keypair, treasury_po
     assert contract.eth_address
     assert get_solana_balance(contract.solana_address) > 0
     data = abi.function_signature_to_4byte_selector('call_hello_world()')
-    result = json.loads(neon_cli().emulate(evm_loader.loader_id, f"{user_account.eth_address.hex()} {contract.eth_address.hex()} {data.hex()}"))
+    result = json.loads(
+        neon_cli().emulate(
+            evm_loader.loader_id,
+            user_account.eth_address.hex(),
+            contract.eth_address.hex(),
+            data.hex()
+        )
+    )
     assert result["exit_status"] == "succeed"
     assert "Hello World" in to_text(result["result"])


### PR DESCRIPTION
- Gas meter uses SOL balances to calculate gas usage
- Disable EVM steps processing on the first and last iterations
- Reduce iterations costs for a user
- Read tx from stdin in neon-cli
- Add claimTo method to erc20_to_spl contract
- Reduce HEAP usage on neon tx signature verification