### PR TITLE
SELFDESTRUCT Compatibility

### DIFF
--- a/evm_loader/program/src/executor/state.rs
+++ b/evm_loader/program/src/executor/state.rs
@@ -214,13 +214,10 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
         let mut nonce = self.backend.nonce(from_address);
 
         for action in &self.actions {
-            match action {
-                Action::EvmIncrementNonce { address } => {
-                    if from_address == address {
-                        nonce += U256::one();
-                    }
+            if let Action::EvmIncrementNonce { address } = action {
+                if from_address == address {
+                    nonce += U256::one();
                 }
-                _ => {}
             }
         }
 
@@ -232,13 +229,10 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
         let mut known_storage: Option<U256> = None;
 
         for action in &self.actions {
-            match action {
-                Action::EvmSetStorage { address, key, value } => {
-                    if (from_address == address) && (from_key == key) {
-                        known_storage = Some(*value);
-                    }
+            if let Action::EvmSetStorage { address, key, value } = action {
+                if (from_address == address) && (from_key == key) {
+                    known_storage = Some(*value);
                 }
-                _ => {}
             }
         }
 
@@ -250,13 +244,10 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
         let mut code_size = self.backend.code_size(from_address);
 
         for action in &self.actions {
-            match action {
-                Action::EvmSetCode { address, code, valids: _ } => {
-                    if from_address == address {
-                        code_size = code.len();
-                    }
+            if let Action::EvmSetCode { address, code, valids: _ } = action {
+                if from_address == address {
+                    code_size = code.len();
                 }
-                _ => {}
             }
         }
 
@@ -268,13 +259,10 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
         let mut known_code: Option<&[u8]> = None;
 
         for action in &self.actions {
-            match action {
-                Action::EvmSetCode { address, code, valids: _ } => {
-                    if from_address == address {
-                        known_code = Some(code);
-                    }
+            if let Action::EvmSetCode { address, code, valids: _ } = action {
+                if from_address == address {
+                    known_code = Some(code);
                 }
-                _ => {}
             }
         }
 
@@ -286,13 +274,10 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
         let mut known_code: Option<&[u8]> = None;
 
         for action in &self.actions {
-            match action {
-                Action::EvmSetCode { address, code, valids: _ } => {
-                    if from_address == address {
-                        known_code = Some(code);
-                    }
+            if let Action::EvmSetCode { address, code, valids: _ } = action {
+                if from_address == address {
+                    known_code = Some(code);
                 }
-                _ => {}
             }
         }
 
@@ -304,13 +289,10 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
         let mut known_valids: Option<&[u8]> = None;
 
         for action in &self.actions {
-            match action {
-                Action::EvmSetCode { address, code: _, valids } => {
-                    if from_address == address {
-                        known_valids = Some(valids);
-                    }
+            if let Action::EvmSetCode { address, code: _, valids } = action {
+                if from_address == address {
+                    known_valids = Some(valids);
                 }
-                _ => {}
             }
         }
 

--- a/evm_loader/program/src/executor/state.rs
+++ b/evm_loader/program/src/executor/state.rs
@@ -220,11 +220,6 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
                         nonce += U256::one();
                     }
                 }
-                Action::EvmSelfDestruct { address } => {
-                    if from_address == address {
-                        nonce = U256::zero();
-                    }
-                }
                 _ => {}
             }
         }
@@ -241,11 +236,6 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
                 Action::EvmSetStorage { address, key, value } => {
                     if (from_address == address) && (from_key == key) {
                         known_storage = Some(*value);
-                    }
-                }
-                Action::EvmSelfDestruct { address } => {
-                    if from_address == address {
-                        known_storage = Some(U256::zero());
                     }
                 }
                 _ => {}
@@ -266,11 +256,6 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
                         code_size = code.len();
                     }
                 }
-                Action::EvmSelfDestruct { address } => {
-                    if from_address == address {
-                        code_size = 0_usize;
-                    }
-                }
                 _ => {}
             }
         }
@@ -287,11 +272,6 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
                 Action::EvmSetCode { address, code, valids: _ } => {
                     if from_address == address {
                         known_code = Some(code);
-                    }
-                }
-                Action::EvmSelfDestruct { address } => {
-                    if from_address == address {
-                        known_code = Some(&[]);
                     }
                 }
                 _ => {}
@@ -312,11 +292,6 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
                         known_code = Some(code);
                     }
                 }
-                Action::EvmSelfDestruct { address } => {
-                    if from_address == address {
-                        known_code = Some(&[]);
-                    }
-                }
                 _ => {}
             }
         }
@@ -333,11 +308,6 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
                 Action::EvmSetCode { address, code: _, valids } => {
                     if from_address == address {
                         known_valids = Some(valids);
-                    }
-                }
-                Action::EvmSelfDestruct { address } => {
-                    if from_address == address {
-                        known_valids = Some(&[]);
                     }
                 }
                 _ => {}


### PR DESCRIPTION
According to the specification, the selfdestruct(addr) instruction should:
• transfer all Ether the contract owns to the addr account,
• mark the contract as "to be deleted",
• exit the execution context.

All changes (except the Ether transfer) to the contract must be applied when
finalizing the transaction, not right after the selfdestruct instruction.

If the mentioned specification is applied, the functions code, code_size, nonce,
storage, code_hash, and valids in the state.rs behave incorrectly as all these
functions must return the same values as if run before selfdestruct (in the
same transaction).