### PR TITLE
Correct system program emulation

### DIFF
--- a/evm_loader/program/src/external_programs/system.rs
+++ b/evm_loader/program/src/external_programs/system.rs
@@ -54,6 +54,10 @@ pub fn emulate(instruction: &[u8], meta: &[AccountMeta], accounts: &mut BTreeMap
 
             {
                 let mut from = accounts.get_mut(from_key).unwrap();
+                if !from.data.is_empty() {
+                    return Err!(ProgramError::InvalidArgument; "Transfer: `from` must not carry data");
+                }
+
                 if from.lamports < lamports {
                     return Err!(ProgramError::InsufficientFunds; "Transfer: insufficient lamports");
                 }


### PR DESCRIPTION
In the SystemInstruction::Transfer emulator, there is no check that the source account (i.e., from field) contains any data. So the emulator returns a different result than the actual execution.