### PR TITLE
NDEV-1369 empty list in neon elf params

### DIFF
--- a/evm_loader/Cargo.lock
+++ b/evm_loader/Cargo.lock
@@ -1368,24 +1368,24 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32401e89c6446dcd28185931a01b1093726d0356820ac744023e6850689bf926"
-dependencies = [
- "log",
- "plain",
- "scroll 0.10.2",
-]
-
-[[package]]
-name = "goblin"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7666983ed0dd8d21a6f6576ee00053ca0926fb281a5522577a4dbd0f1b54143"
 dependencies = [
  "log",
  "plain",
- "scroll 0.11.0",
+ "scroll",
+]
+
+[[package]]
+name = "goblin"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6b4de4a8eb6c46a8c77e1d3be942cb9a8bf073c22374578e5ba4b08ed0ff68"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
 ]
 
 [[package]]
@@ -2008,13 +2008,14 @@ dependencies = [
  "evm-loader",
  "fern",
  "getrandom 0.1.16",
- "goblin 0.4.3",
+ "goblin 0.6.1",
  "hex",
  "lazy_static",
  "log",
  "postgres",
  "rand 0.8.5",
  "rlp",
+ "scroll",
  "serde",
  "serde_json",
  "sha3 0.10.6",
@@ -2946,31 +2947,11 @@ checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "scroll"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
-dependencies = [
- "scroll_derive 0.10.5",
-]
-
-[[package]]
-name = "scroll"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
 dependencies = [
- "scroll_derive 0.11.0",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
-dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
- "syn 1.0.107",
+ "scroll_derive",
 ]
 
 [[package]]
@@ -3978,7 +3959,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rustc-demangle",
- "scroll 0.11.0",
+ "scroll",
  "thiserror",
 ]
 

--- a/evm_loader/cli/Cargo.toml
+++ b/evm_loader/cli/Cargo.toml
@@ -32,7 +32,8 @@ fern = "0.6"
 rlp = "0.5"
 rand = "0.8"
 ethnum = { version = "1", default_features = false, features = [ "serde" ] }
-goblin = { version = "0.4.2" }
+goblin = { version = "0.6.0" }
+scroll = "0.11.0"
 tokio = { version = "1", features = ["full"] }
 postgres = { version = "0.19", features = ["with-chrono-0_4", "array-impls"] }
 tokio-postgres = {version="0.7", features=["with-uuid-0_8"]}

--- a/evm_loader/cli/src/commands/get_neon_elf.rs
+++ b/evm_loader/cli/src/commands/get_neon_elf.rs
@@ -26,7 +26,20 @@ impl CachedElfParams {
 pub fn read_elf_parameters(_config: &Config, program_data: &[u8]) -> HashMap<String, String> {
     let mut result = HashMap::new();
     let elf = goblin::elf::Elf::parse(program_data).expect("Unable to parse ELF file");
-    elf.dynsyms.iter().for_each(|sym| {
+    let ctx = goblin::container::Ctx::new(
+            if elf.is_64 {goblin::container::Container::Big} else {goblin::container::Container::Little},
+            if elf.little_endian {scroll::Endian::Little} else {scroll::Endian::Big}
+        );
+
+    let (num_syms, offset) = elf.section_headers.into_iter().find(|section| section.sh_type == goblin::elf::section_header::SHT_DYNSYM)
+        .map(|section| (section.sh_size/section.sh_entsize, section.sh_offset)).unwrap();
+    let dynsyms = goblin::elf::Symtab::parse(
+        program_data,
+        offset.try_into().expect("Offset too large"),
+        num_syms.try_into().expect("Count too large"),
+        ctx
+    ).unwrap();
+    dynsyms.iter().for_each(|sym| {
         let name = String::from(&elf.dynstrtab[sym.st_name]);
         if name.starts_with("NEON") {
             let end = program_data.len();

--- a/evm_loader/cli/src/commands/get_neon_elf.rs
+++ b/evm_loader/cli/src/commands/get_neon_elf.rs
@@ -27,18 +27,31 @@ pub fn read_elf_parameters(_config: &Config, program_data: &[u8]) -> HashMap<Str
     let mut result = HashMap::new();
     let elf = goblin::elf::Elf::parse(program_data).expect("Unable to parse ELF file");
     let ctx = goblin::container::Ctx::new(
-            if elf.is_64 {goblin::container::Container::Big} else {goblin::container::Container::Little},
-            if elf.little_endian {scroll::Endian::Little} else {scroll::Endian::Big}
-        );
+        if elf.is_64 {
+            goblin::container::Container::Big
+        } else {
+            goblin::container::Container::Little
+        },
+        if elf.little_endian {
+            scroll::Endian::Little
+        } else {
+            scroll::Endian::Big
+        },
+    );
 
-    let (num_syms, offset) = elf.section_headers.into_iter().find(|section| section.sh_type == goblin::elf::section_header::SHT_DYNSYM)
-        .map(|section| (section.sh_size/section.sh_entsize, section.sh_offset)).unwrap();
+    let (num_syms, offset) = elf
+        .section_headers
+        .into_iter()
+        .find(|section| section.sh_type == goblin::elf::section_header::SHT_DYNSYM)
+        .map(|section| (section.sh_size / section.sh_entsize, section.sh_offset))
+        .unwrap();
     let dynsyms = goblin::elf::Symtab::parse(
         program_data,
         offset.try_into().expect("Offset too large"),
         num_syms.try_into().expect("Count too large"),
-        ctx
-    ).unwrap();
+        ctx,
+    )
+    .unwrap();
     dynsyms.iter().for_each(|sym| {
         let name = String::from(&elf.dynstrtab[sym.st_name]);
         if name.starts_with("NEON") {


### PR DESCRIPTION
**Problem description:** the `neon-cli neon-elf-parameters` command returns an empty list for some images (e.g. emergency images).

**Root cause of the problem:** Goblin library uses a strange algorithm to detect a number of elements in a dynamic table. It takes into account only elements used in other tables. So if the last elements are not used in the code, then these elements aren't returned from the library call.

**Changes to fix:** Get the actual number of elements in the dynamic table from the size of this table and the element size in it.