### PR TITLE
Add integer overflow checks

### DIFF
--- a/evm_loader/program/src/executor/state.rs
+++ b/evm_loader/program/src/executor/state.rs
@@ -197,7 +197,7 @@ impl<'a, B: AccountStorage> Database for ExecutorState<'a, B> {
         for action in &self.actions {
             if let Action::EvmIncrementNonce { address } = action {
                 if from_address == address {
-                    nonce += 1;
+                    nonce = nonce.checked_add(1).ok_or(Error::IntegerOverflow)?;
                 }
             }
         }
@@ -223,16 +223,16 @@ impl<'a, B: AccountStorage> Database for ExecutorState<'a, B> {
                     value,
                 } => {
                     if from_address == source {
-                        balance -= value;
+                        balance = balance.checked_sub(*value).ok_or(Error::IntegerOverflow)?;
                     }
 
                     if from_address == target {
-                        balance += value;
+                        balance = balance.checked_add(*value).ok_or(Error::IntegerOverflow)?;
                     }
                 }
                 Action::NeonWithdraw { source, value } => {
                     if from_address == source {
-                        balance -= value;
+                        balance = balance.checked_sub(*value).ok_or(Error::IntegerOverflow)?;
                     }
                 }
                 _ => {}


### PR DESCRIPTION
- Calculating the new balance from NeonTransfer and NeonWithdraw actions can (look at in isolation) overflow here.
- Neon loops through all EvmIncrementNonce actions. technically they can overflow.