### PR TITLE
Decimals calculation in neon withdraw precompile

### DIFF
--- a/evm_loader/program/src/config.rs
+++ b/evm_loader/program/src/config.rs
@@ -7,6 +7,7 @@ use evm_loader_macro::{
     common_config_parser, declare_param_id, elf_config_parser, neon_elf_param,
     net_specific_config_parser, operators_whitelist,
 };
+use static_assertions::const_assert;
 
 cfg_if! {
     if #[cfg(feature = "mainnet")] {
@@ -33,3 +34,5 @@ cfg_if! {
 }
 
 elf_config_parser!("config/elf_params.toml");
+
+const_assert!(token_mint::decimals() <= 18);

--- a/evm_loader/program/src/executor/precompile_extension/neon_token.rs
+++ b/evm_loader/program/src/executor/precompile_extension/neon_token.rs
@@ -68,7 +68,9 @@ fn withdraw<B: AccountStorage>(
         return Err(Error::Custom("Neon Withdraw: value == 0".to_string()));
     }
 
-    let min_amount = u128::pow(10, u32::from(crate::config::token_mint::decimals()));
+    let additional_decimals: u32 = (18 - crate::config::token_mint::decimals()).into();
+    let min_amount: u128 = u128::pow(10, additional_decimals);
+
     let spl_amount = value / min_amount;
     let remainder = value % min_amount;
 
@@ -79,9 +81,9 @@ fn withdraw<B: AccountStorage>(
     }
 
     if remainder != 0 {
-        return Err(Error::Custom(
-            "Neon Withdraw: value must be divisible by 10^9".to_string(),
-        ));
+        return Err(Error::Custom(std::format!(
+            "Neon Withdraw: value must be divisible by 10^{additional_decimals}"
+        )));
     }
 
     let target_token = get_associated_token_address(&target, state.backend.neon_token_mint());

--- a/evm_loader/program/src/instruction/neon_tokens_deposit.rs
+++ b/evm_loader/program/src/instruction/neon_tokens_deposit.rs
@@ -163,10 +163,8 @@ fn execute(
         )?;
     }
 
-    assert!(crate::config::token_mint::decimals() <= 18);
     let additional_decimals: u32 = (18 - crate::config::token_mint::decimals()).into();
-    let deposit =
-        U256::from(accounts.source.delegated_amount) * U256::from(10_u64.pow(additional_decimals));
+    let deposit = U256::from(accounts.source.delegated_amount) * 10_u128.pow(additional_decimals);
     let mut ethereum_account =
         EthereumAccount::from_account(program_id, accounts.ethereum_account)?;
     ethereum_account.balance = ethereum_account


### PR DESCRIPTION
The “decimal-truncation” in the withdrawal method of the neon_token precompiled contract is the wrong way around.

Internally, Neon uses 18 decimals, as seen in the neon_tokens_deposit instruction. The calculation there is correct:

`additional_decimals = 18 - token_mint::decimals()`
followed by `deposit = amount * 10**additional_decimals`

However, the neon token precompiled contract simply does

`withdraw = amount / 10**token_mint::decimals()`

Consider token_mint decimals being 0. Deposit now does a multiple of 10**18, while withdraw divides by 1.