### PR TITLE
spl_token audit fixes

### DIFF
--- a/evm_loader/program/src/error.rs
+++ b/evm_loader/program/src/error.rs
@@ -131,6 +131,9 @@ pub enum Error {
     #[error("Checked Integer Math Overflow")]
     IntegerOverflow,
 
+    #[error("Index out of bounds")]
+    OutOfBounds,
+
     #[error("Holder Account - invalid owner {0}, expected = {1}")]
     HolderInvalidOwner(Pubkey, Pubkey),
 

--- a/evm_loader/program/src/executor/precompile_extension/metaplex.rs
+++ b/evm_loader/program/src/executor/precompile_extension/metaplex.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::unnecessary_wraps)]
 
-use std::convert::TryInto;
+use std::convert::{Into, TryInto};
 
 use ethnum::U256;
 use mpl_token_metadata::state::{Creator, Metadata, TokenMetadataAccount, TokenStandard};
@@ -49,10 +49,10 @@ pub fn metaplex<B: AccountStorage>(
                 return Err(Error::StaticModeViolation(*address));
             }
 
-            let mint = read_pubkey(input);
-            let name = read_string(input, 32)?;
-            let symbol = read_string(input, 64)?;
-            let uri = read_string(input, 96)?;
+            let mint = read_pubkey(input)?;
+            let name = read_string(input, 32, 256)?;
+            let symbol = read_string(input, 64, 256)?;
+            let uri = read_string(input, 96, 1024)?;
 
             create_metadata(context, state, mint, name, symbol, uri)
         }
@@ -62,34 +62,34 @@ pub fn metaplex<B: AccountStorage>(
                 return Err(Error::StaticModeViolation(*address));
             }
 
-            let mint = read_pubkey(input);
+            let mint = read_pubkey(input)?;
             let max_supply = read_u64(&input[32..])?;
 
             create_master_edition(context, state, mint, Some(max_supply))
         }
         [0xf7, 0xb6, 0x37, 0xbb] => {
             // "isInitialized(bytes32)"
-            let mint = read_pubkey(input);
+            let mint = read_pubkey(input)?;
             is_initialized(context, state, mint)
         }
         [0x23, 0x5b, 0x2b, 0x94] => {
             // "isNFT(bytes32)"
-            let mint = read_pubkey(input);
+            let mint = read_pubkey(input)?;
             is_nft(context, state, mint)
         }
         [0x9e, 0xd1, 0x9d, 0xdb] => {
             // "uri(bytes32)"
-            let mint = read_pubkey(input);
+            let mint = read_pubkey(input)?;
             uri(context, state, mint)
         }
         [0x69, 0x1f, 0x34, 0x31] => {
             // "name(bytes32)"
-            let mint = read_pubkey(input);
+            let mint = read_pubkey(input)?;
             token_name(context, state, mint)
         }
         [0x6b, 0xaa, 0x03, 0x30] => {
             // "symbol(bytes32)"
-            let mint = read_pubkey(input);
+            let mint = read_pubkey(input)?;
             symbol(context, state, mint)
         }
         _ => Err(Error::UnknownPrecompileMethodSelector(*address, selector)),
@@ -98,28 +98,43 @@ pub fn metaplex<B: AccountStorage>(
 
 #[inline]
 fn read_u64(input: &[u8]) -> Result<u64> {
+    if input.len() < 32 {
+        return Err(Error::OutOfBounds);
+    }
     U256::from_be_bytes(*arrayref::array_ref![input, 0, 32])
         .try_into()
-        .map_err(|_| Error::IntegerOverflow)
+        .map_err(Into::into)
 }
 
 #[inline]
-fn read_pubkey(input: &[u8]) -> Pubkey {
-    Pubkey::new_from_array(*arrayref::array_ref![input, 0, 32])
+fn read_pubkey(input: &[u8]) -> Result<Pubkey> {
+    if input.len() < 32 {
+        return Err(Error::OutOfBounds);
+    }
+    Ok(Pubkey::new_from_array(*arrayref::array_ref![input, 0, 32]))
 }
 
 #[inline]
-fn read_string(input: &[u8], offset_position: usize) -> Result<String> {
-    let offset = U256::from_be_bytes(*arrayref::array_ref![input, offset_position, 32])
-        .try_into()
-        .map_err(|_| Error::IntegerOverflow)?;
-    let length = U256::from_be_bytes(*arrayref::array_ref![input, offset, 32])
-        .try_into()
-        .map_err(|_| Error::IntegerOverflow)?;
+fn read_string(input: &[u8], offset_position: usize, max_length: usize) -> Result<String> {
+    if input.len() < offset_position + 32 {
+        return Err(Error::OutOfBounds);
+    }
+    let offset =
+        U256::from_be_bytes(*arrayref::array_ref![input, offset_position, 32]).try_into()?;
+    if input.len() < offset + 32 {
+        return Err(Error::OutOfBounds);
+    }
+    let length = U256::from_be_bytes(*arrayref::array_ref![input, offset, 32]).try_into()?;
+    if length > max_length {
+        return Err(Error::OutOfBounds);
+    }
 
     let begin = offset.saturating_add(32);
     let end = begin.saturating_add(length);
 
+    if input.len() < end {
+        return Err(Error::OutOfBounds);
+    }
     let data = input[begin..end].to_vec();
     String::from_utf8(data).map_err(|_| Error::Custom("Invalid utf8 string".to_string()))
 }

--- a/evm_loader/program/src/executor/precompile_extension/metaplex.rs
+++ b/evm_loader/program/src/executor/precompile_extension/metaplex.rs
@@ -119,9 +119,9 @@ fn read_string(input: &[u8], offset_position: usize, max_length: usize) -> Resul
     if input.len() < offset_position + 32 {
         return Err(Error::OutOfBounds);
     }
-    let offset =
+    let offset: usize =
         U256::from_be_bytes(*arrayref::array_ref![input, offset_position, 32]).try_into()?;
-    if input.len() < offset + 32 {
+    if input.len() < offset.saturating_add(32) {
         return Err(Error::OutOfBounds);
     }
     let length = U256::from_be_bytes(*arrayref::array_ref![input, offset, 32]).try_into()?;

--- a/evm_loader/program/src/executor/precompile_extension/metaplex.rs
+++ b/evm_loader/program/src/executor/precompile_extension/metaplex.rs
@@ -98,7 +98,9 @@ pub fn metaplex<B: AccountStorage>(
 
 #[inline]
 fn read_u64(input: &[u8]) -> Result<u64> {
-    U256::from_be_bytes(*arrayref::array_ref![input, 0, 32]).try_into().map_err(|_| Error::IntegerOverflow)
+    U256::from_be_bytes(*arrayref::array_ref![input, 0, 32])
+        .try_into()
+        .map_err(|_| Error::IntegerOverflow)
 }
 
 #[inline]
@@ -109,9 +111,11 @@ fn read_pubkey(input: &[u8]) -> Pubkey {
 #[inline]
 fn read_string(input: &[u8], offset_position: usize) -> Result<String> {
     let offset = U256::from_be_bytes(*arrayref::array_ref![input, offset_position, 32])
-        .try_into().map_err(|_| Error::IntegerOverflow)?;
+        .try_into()
+        .map_err(|_| Error::IntegerOverflow)?;
     let length = U256::from_be_bytes(*arrayref::array_ref![input, offset, 32])
-        .try_into().map_err(|_| Error::IntegerOverflow)?;
+        .try_into()
+        .map_err(|_| Error::IntegerOverflow)?;
 
     let begin = offset.saturating_add(32);
     let end = begin.saturating_add(length);

--- a/evm_loader/program/src/executor/precompile_extension/spl_token.rs
+++ b/evm_loader/program/src/executor/precompile_extension/spl_token.rs
@@ -657,6 +657,8 @@ fn get_account<B: AccountStorage>(
     let account = state.external_account(account)?;
     let token = if spl_token::check_id(&account.owner) {
         spl_token::state::Account::unpack(&account.data)?
+    } else if system_program::check_id(&account.owner) {
+        spl_token::state::Account::default()
     } else {
         return Err(ProgramError::IllegalOwner.into());
     };

--- a/evm_loader/program/src/executor/precompile_extension/spl_token.rs
+++ b/evm_loader/program/src/executor/precompile_extension/spl_token.rs
@@ -256,33 +256,22 @@ fn create_account<B: AccountStorage>(
     let rent = Rent::get()?;
     let minimum_balance = rent.minimum_balance(space);
 
-    if account.lamports > 0 {
-        let required_lamports = minimum_balance.saturating_sub(account.lamports);
+    let required_lamports = minimum_balance.saturating_sub(account.lamports);
 
-        if required_lamports > 0 {
-            let transfer = system_instruction::transfer(
-                state.backend.operator(),
-                &account.key,
-                required_lamports,
-            );
-            state.queue_external_instruction(transfer, vec![], 0);
-        }
-
-        let allocate = system_instruction::allocate(&account.key, space.try_into().unwrap());
-        state.queue_external_instruction(allocate, seeds.clone(), space);
-
-        let assign = system_instruction::assign(&account.key, &spl_token::ID);
-        state.queue_external_instruction(assign, seeds, 0);
-    } else {
-        let create_account = system_instruction::create_account(
+    if required_lamports > 0 {
+        let transfer = system_instruction::transfer(
             state.backend.operator(),
             &account.key,
-            minimum_balance,
-            space.try_into().unwrap(),
-            &spl_token::ID,
+            required_lamports,
         );
-        state.queue_external_instruction(create_account, seeds, space);
+        state.queue_external_instruction(transfer, vec![], 0);
     }
+
+    let allocate = system_instruction::allocate(&account.key, space.try_into().unwrap());
+    state.queue_external_instruction(allocate, seeds.clone(), space);
+
+    let assign = system_instruction::assign(&account.key, &spl_token::ID);
+    state.queue_external_instruction(assign, seeds, 0);
 
     Ok(())
 }

--- a/evm_loader/program/src/executor/precompile_extension/spl_token.rs
+++ b/evm_loader/program/src/executor/precompile_extension/spl_token.rs
@@ -17,7 +17,7 @@ use crate::{
 // [0xa9, 0xc1, 0x58, 0x06] : "approve(bytes32,bytes32,uint64)",
 // [0xe3, 0x41, 0x08, 0x55] : "burn(bytes32,uint64)",
 // [0x57, 0x82, 0xa0, 0x43] : "closeAccount(bytes32)",
-// [0x38, 0xa6, 0x99, 0xa4] : "exists(bytes32)",
+// [0x6d, 0xa9, 0xde, 0x75] : "isSystemAccount(bytes32)",
 // [0xeb, 0x7d, 0xa7, 0x8c] : "findAccount(bytes32)",
 // [0xec, 0x13, 0xcc, 0x7b] : "freeze(bytes32)",
 // [0xd1, 0xde, 0x50, 0x11] : "getAccount(bytes32)",
@@ -208,10 +208,10 @@ pub fn spl_token<B: AccountStorage>(
             let seed = read_salt(input);
             find_account(context, state, seed)
         }
-        [0x38, 0xa6, 0x99, 0xa4] => {
-            // exists(bytes32 account)
+        [0x6d, 0xa9, 0xde, 0x75] => {
+            // isSystemAccount(bytes32 account)
             let account = read_pubkey(input);
-            exists(context, state, account)
+            is_system_account(context, state, account)
         }
         [0xd1, 0xde, 0x50, 0x11] => {
             // getAccount(bytes32 account)
@@ -662,19 +662,19 @@ fn find_account<B: AccountStorage>(
     Ok(account_key.to_bytes().to_vec())
 }
 
-fn exists<B: AccountStorage>(
+fn is_system_account<B: AccountStorage>(
     _context: &crate::evm::Context,
     state: &mut ExecutorState<B>,
     account: Pubkey,
 ) -> Result<Vec<u8>> {
     let account = state.external_account(account)?;
     if system_program::check_id(&account.owner) {
-        Ok(vec![0_u8; 32])
-    } else {
         let mut result = vec![0_u8; 32];
         result[31] = 1; // return true
 
         Ok(result)
+    } else {
+        Ok(vec![0_u8; 32])
     }
 }
 

--- a/evm_loader/program/src/executor/precompile_extension/spl_token.rs
+++ b/evm_loader/program/src/executor/precompile_extension/spl_token.rs
@@ -2,8 +2,8 @@ use std::convert::TryInto;
 
 use ethnum::U256;
 use solana_program::{
-    program_pack::Pack, pubkey::Pubkey, rent::Rent, system_instruction, system_program,
-    sysvar::Sysvar,
+    program_error::ProgramError, program_pack::Pack, pubkey::Pubkey, rent::Rent,
+    system_instruction, system_program, sysvar::Sysvar,
 };
 
 use crate::{
@@ -685,9 +685,9 @@ fn get_account<B: AccountStorage>(
 ) -> Result<Vec<u8>> {
     let account = state.external_account(account)?;
     let token = if spl_token::check_id(&account.owner) {
-        spl_token::state::Account::unpack_unchecked(&account.data)?
+        spl_token::state::Account::unpack(&account.data)?
     } else {
-        spl_token::state::Account::default()
+        return Err(ProgramError::IllegalOwner.into());
     };
 
     debug_print!("spl_token get_account: {:?}", token);
@@ -717,9 +717,9 @@ fn get_mint<B: AccountStorage>(
 ) -> Result<Vec<u8>> {
     let account = state.external_account(account)?;
     let mint = if spl_token::check_id(&account.owner) {
-        spl_token::state::Mint::unpack_unchecked(&account.data)?
+        spl_token::state::Mint::unpack(&account.data)?
     } else {
-        spl_token::state::Mint::default()
+        return Err(ProgramError::IllegalOwner.into());
     };
 
     debug_print!("spl_token get_mint: {:?}", mint);

--- a/evm_loader/program/src/executor/precompile_extension/spl_token.rs
+++ b/evm_loader/program/src/executor/precompile_extension/spl_token.rs
@@ -44,15 +44,9 @@ pub fn spl_token<B: AccountStorage>(
         return Err(Error::Custom("SplToken: value != 0".to_string()));
     }
 
-    if context.contract == context.caller {
-        return Err(Error::Custom(
-            "SplToken: callcode is not allowed".to_string(),
-        ));
-    }
-
     if &context.contract != address {
         return Err(Error::Custom(
-            "SplToken: delegatecall is not allowed".to_string(),
+            "SplToken: callcode or delegatecall is not allowed".to_string(),
         ));
     }
 

--- a/evm_loader/program/src/executor/precompile_extension/spl_token.rs
+++ b/evm_loader/program/src/executor/precompile_extension/spl_token.rs
@@ -1,4 +1,4 @@
-use std::convert::TryInto;
+use std::convert::{Into, TryInto};
 
 use ethnum::U256;
 use solana_program::{
@@ -60,7 +60,7 @@ pub fn spl_token<B: AccountStorage>(
                 return Err(Error::StaticModeViolation(*address));
             }
 
-            let seed = read_salt(input);
+            let seed = read_salt(input)?;
             let decimals = read_u8(&input[32..])?;
 
             initialize_mint(context, state, seed, decimals, None, None)
@@ -71,10 +71,10 @@ pub fn spl_token<B: AccountStorage>(
                 return Err(Error::StaticModeViolation(*address));
             }
 
-            let seed = read_salt(input);
+            let seed = read_salt(input)?;
             let decimals = read_u8(&input[32..])?;
-            let mint_authority = read_pubkey(&input[64..]);
-            let freeze_authority = read_pubkey(&input[96..]);
+            let mint_authority = read_pubkey(&input[64..])?;
+            let freeze_authority = read_pubkey(&input[96..])?;
             initialize_mint(
                 context,
                 state,
@@ -90,8 +90,8 @@ pub fn spl_token<B: AccountStorage>(
                 return Err(Error::StaticModeViolation(*address));
             }
 
-            let seed = read_salt(input);
-            let mint = read_pubkey(&input[32..]);
+            let seed = read_salt(input)?;
+            let mint = read_pubkey(&input[32..])?;
 
             initialize_account(context, state, seed, mint, None)
         }
@@ -101,9 +101,9 @@ pub fn spl_token<B: AccountStorage>(
                 return Err(Error::StaticModeViolation(*address));
             }
 
-            let seed = read_salt(input);
-            let mint = read_pubkey(&input[32..]);
-            let owner = read_pubkey(&input[64..]);
+            let seed = read_salt(input)?;
+            let mint = read_pubkey(&input[32..])?;
+            let owner = read_pubkey(&input[64..])?;
             initialize_account(context, state, seed, mint, Some(owner))
         }
         [0x57, 0x82, 0xa0, 0x43] => {
@@ -112,7 +112,7 @@ pub fn spl_token<B: AccountStorage>(
                 return Err(Error::StaticModeViolation(*address));
             }
 
-            let account = read_pubkey(input);
+            let account = read_pubkey(input)?;
             close_account(context, state, account)
         }
         [0xa9, 0xc1, 0x58, 0x06] => {
@@ -121,8 +121,8 @@ pub fn spl_token<B: AccountStorage>(
                 return Err(Error::StaticModeViolation(*address));
             }
 
-            let source = read_pubkey(input);
-            let target = read_pubkey(&input[32..]);
+            let source = read_pubkey(input)?;
+            let target = read_pubkey(&input[32..])?;
             let amount = read_u64(&input[64..])?;
             approve(context, state, source, target, amount)
         }
@@ -132,7 +132,7 @@ pub fn spl_token<B: AccountStorage>(
                 return Err(Error::StaticModeViolation(*address));
             }
 
-            let source = read_pubkey(input);
+            let source = read_pubkey(input)?;
             revoke(context, state, source)
         }
         [0x78, 0x42, 0x3b, 0xcf] => {
@@ -141,8 +141,8 @@ pub fn spl_token<B: AccountStorage>(
                 return Err(Error::StaticModeViolation(*address));
             }
 
-            let source = read_pubkey(input);
-            let target = read_pubkey(&input[32..]);
+            let source = read_pubkey(input)?;
+            let target = read_pubkey(&input[32..])?;
             let amount = read_u64(&input[64..])?;
             transfer(context, state, source, target, amount)
         }
@@ -152,9 +152,9 @@ pub fn spl_token<B: AccountStorage>(
                 return Err(Error::StaticModeViolation(*address));
             }
 
-            let seed = arrayref::array_ref![input, 0, 32];
-            let source = read_pubkey(&input[32..]);
-            let target = read_pubkey(&input[64..]);
+            let seed = read_salt(input)?;
+            let source = read_pubkey(&input[32..])?;
+            let target = read_pubkey(&input[64..])?;
             let amount = read_u64(&input[96..])?;
 
             transfer_with_seed(context, state, seed, source, target, amount)
@@ -165,8 +165,8 @@ pub fn spl_token<B: AccountStorage>(
                 return Err(Error::StaticModeViolation(*address));
             }
 
-            let mint = read_pubkey(input);
-            let account = read_pubkey(&input[32..]);
+            let mint = read_pubkey(input)?;
+            let account = read_pubkey(&input[32..])?;
             let amount = read_u64(&input[64..])?;
             mint_to(context, state, mint, account, amount)
         }
@@ -176,8 +176,8 @@ pub fn spl_token<B: AccountStorage>(
                 return Err(Error::StaticModeViolation(*address));
             }
 
-            let mint = read_pubkey(input);
-            let account = read_pubkey(&input[32..]);
+            let mint = read_pubkey(input)?;
+            let account = read_pubkey(&input[32..])?;
             let amount = read_u64(&input[64..])?;
             burn(context, state, mint, account, amount)
         }
@@ -187,8 +187,8 @@ pub fn spl_token<B: AccountStorage>(
                 return Err(Error::StaticModeViolation(*address));
             }
 
-            let mint = read_pubkey(input);
-            let account = read_pubkey(&input[32..]);
+            let mint = read_pubkey(input)?;
+            let account = read_pubkey(&input[32..])?;
             freeze(context, state, mint, account)
         }
         [0x3d, 0x71, 0x8c, 0x9a] => {
@@ -197,28 +197,28 @@ pub fn spl_token<B: AccountStorage>(
                 return Err(Error::StaticModeViolation(*address));
             }
 
-            let mint = read_pubkey(input);
-            let account = read_pubkey(&input[32..]);
+            let mint = read_pubkey(input)?;
+            let account = read_pubkey(&input[32..])?;
             thaw(context, state, mint, account)
         }
         [0xeb, 0x7d, 0xa7, 0x8c] => {
             // findAccount(bytes32 seed)
-            let seed = read_salt(input);
+            let seed = read_salt(input)?;
             find_account(context, state, seed)
         }
         [0x6d, 0xa9, 0xde, 0x75] => {
             // isSystemAccount(bytes32 account)
-            let account = read_pubkey(input);
+            let account = read_pubkey(input)?;
             is_system_account(context, state, account)
         }
         [0xd1, 0xde, 0x50, 0x11] => {
             // getAccount(bytes32 account)
-            let account = read_pubkey(input);
+            let account = read_pubkey(input)?;
             get_account(context, state, account)
         }
         [0xa2, 0xce, 0x9c, 0x1f] => {
             // getMint(bytes32 account)
-            let account = read_pubkey(input);
+            let account = read_pubkey(input)?;
             get_mint(context, state, account)
         }
         _ => Err(Error::UnknownPrecompileMethodSelector(*address, selector)),
@@ -229,24 +229,30 @@ pub fn spl_token<B: AccountStorage>(
 fn read_u8(input: &[u8]) -> Result<u8> {
     U256::from_be_bytes(*arrayref::array_ref![input, 0, 32])
         .try_into()
-        .map_err(|_| Error::IntegerOverflow)
+        .map_err(Into::into)
 }
 
 #[inline]
 fn read_u64(input: &[u8]) -> Result<u64> {
     U256::from_be_bytes(*arrayref::array_ref![input, 0, 32])
         .try_into()
-        .map_err(|_| Error::IntegerOverflow)
+        .map_err(Into::into)
 }
 
 #[inline]
-fn read_pubkey(input: &[u8]) -> Pubkey {
-    Pubkey::new_from_array(*arrayref::array_ref![input, 0, 32])
+fn read_pubkey(input: &[u8]) -> Result<Pubkey> {
+    if input.len() < 32 {
+        return Err(Error::OutOfBounds);
+    }
+    Ok(Pubkey::new_from_array(*arrayref::array_ref![input, 0, 32]))
 }
 
 #[inline]
-fn read_salt(input: &[u8]) -> &[u8; 32] {
-    arrayref::array_ref![input, 0, 32]
+fn read_salt(input: &[u8]) -> Result<&[u8; 32]> {
+    if input.len() < 32 {
+        return Err(Error::OutOfBounds);
+    }
+    Ok(arrayref::array_ref![input, 0, 32])
 }
 
 fn create_account<B: AccountStorage>(
@@ -556,8 +562,15 @@ fn burn<B: AccountStorage>(
         vec![bump_seed],
     ];
 
-    let burn =
-        spl_token::instruction::burn(&spl_token::ID, &source, &mint, &signer_pubkey, &[], amount)?;
+    #[rustfmt::skip]
+    let burn = spl_token::instruction::burn(
+        &spl_token::ID,
+        &source,
+        &mint,
+        &signer_pubkey,
+        &[],
+        amount
+    )?;
     state.queue_external_instruction(burn, seeds, 0);
 
     Ok(vec![])
@@ -605,8 +618,14 @@ fn thaw<B: AccountStorage>(
         vec![bump_seed],
     ];
 
-    let thaw =
-        spl_token::instruction::thaw_account(&spl_token::ID, &target, &mint, &signer_pubkey, &[])?;
+    #[rustfmt::skip]
+    let thaw = spl_token::instruction::thaw_account(
+        &spl_token::ID,
+        &target,
+        &mint,
+        &signer_pubkey,
+        &[]
+    )?;
     state.queue_external_instruction(thaw, seeds, 0);
 
     Ok(vec![])
@@ -691,6 +710,8 @@ fn get_mint<B: AccountStorage>(
     let account = state.external_account(account)?;
     let mint = if spl_token::check_id(&account.owner) {
         spl_token::state::Mint::unpack(&account.data)?
+    } else if system_program::check_id(&account.owner) {
+        spl_token::state::Mint::default()
     } else {
         return Err(ProgramError::IllegalOwner.into());
     };

--- a/evm_loader/solidity/SPLToken.sol
+++ b/evm_loader/solidity/SPLToken.sol
@@ -31,7 +31,7 @@ interface SPLToken {
 
     function findAccount(bytes32 salt) external pure returns(bytes32);
 
-    function exists(bytes32 account) external view returns(bool);
+    function isSystemAccount(bytes32 account) external view returns(bool);
     function getAccount(bytes32 account) external view returns(Account memory);
     function getMint(bytes32 account) external view returns(Mint memory);
 

--- a/evm_loader/solidity/SPLToken.sol
+++ b/evm_loader/solidity/SPLToken.sol
@@ -36,6 +36,9 @@ interface SPLToken {
     // Return spl_token account data. This function checks the account is owned by correct spl_token.
     // Return default not initialized spl_token account data if corresponded Solana account doesn't exist.
     function getAccount(bytes32 account) external view returns(Account memory);
+
+    // Return spl_token mint data. This function checks the mint is owned by correct spl_token.
+    // Return default not initialized spl_token mint data if corresponded Solana account doesn't exist.
     function getMint(bytes32 account) external view returns(Mint memory);
 
     function initializeMint(bytes32 salt, uint8 decimals) external returns(bytes32);

--- a/evm_loader/solidity/SPLToken.sol
+++ b/evm_loader/solidity/SPLToken.sol
@@ -32,6 +32,9 @@ interface SPLToken {
     function findAccount(bytes32 salt) external pure returns(bytes32);
 
     function isSystemAccount(bytes32 account) external view returns(bool);
+
+    // Return spl_token account data. This function checks the account is owned by correct spl_token.
+    // Return default not initialized spl_token account data if corresponded Solana account doesn't exist.
     function getAccount(bytes32 account) external view returns(Account memory);
     function getMint(bytes32 account) external view returns(Mint memory);
 

--- a/evm_loader/solidity/SPLToken.sol
+++ b/evm_loader/solidity/SPLToken.sol
@@ -43,8 +43,8 @@ interface SPLToken {
 
     function closeAccount(bytes32 account) external;
 
-    function mintTo(bytes32 account, uint64 amount) external;
-    function burn(bytes32 account, uint64 amount) external;
+    function mintTo(bytes32 mint, bytes32 account, uint64 amount) external;
+    function burn(bytes32 mint, bytes32 account, uint64 amount) external;
 
     function approve(bytes32 source, bytes32 target, uint64 amount) external;
     function revoke(bytes32 source) external;
@@ -55,6 +55,6 @@ interface SPLToken {
     // This method uses PDA[ACCOUNT_SEED_VERSION, b"AUTH", msg.sender, seed] to authorize transfer
     function transferWithSeed(bytes32 seed, bytes32 source, bytes32 target, uint64 amount) external;
 
-    function freeze(bytes32 account) external;
-    function thaw(bytes32 account) external;
+    function freeze(bytes32 mint, bytes32 account) external;
+    function thaw(bytes32 mint, bytes32 account) external;
 }

--- a/evm_loader/solidity/erc20_for_spl.sol
+++ b/evm_loader/solidity/erc20_for_spl.sol
@@ -167,7 +167,7 @@ contract ERC20ForSpl {
         bytes32 fromSolana = _solanaAccount(from);
 
         require(_splToken.getAccount(fromSolana).amount >= amount, "ERC20: burn amount exceeds balance");
-        _splToken.burn(fromSolana, uint64(amount));
+        _splToken.burn(tokenMint, fromSolana, uint64(amount));
 
         emit Transfer(from, address(0), amount);
     }
@@ -227,7 +227,7 @@ contract ERC20ForSplMintable is ERC20ForSpl {
             _splToken.initializeAccount(_salt(to), tokenMint);
         }
 
-        _splToken.mintTo(toSolana, uint64(amount));
+        _splToken.mintTo(tokenMint, toSolana, uint64(amount));
 
         emit Transfer(address(0), to, amount);
     }

--- a/evm_loader/solidity/erc20_for_spl.sol
+++ b/evm_loader/solidity/erc20_for_spl.sol
@@ -133,7 +133,7 @@ contract ERC20ForSpl {
     function claimTo(bytes32 from, address to, uint64 amount) public returns (bool) {
         bytes32 toSolana = _solanaAccount(to);
 
-        if (!_splToken.exists(toSolana)) {
+        if (_splToken.isSystemAccount(toSolana)) {
             _splToken.initializeAccount(_salt(to), tokenMint);
         }
 
@@ -182,7 +182,7 @@ contract ERC20ForSpl {
         require(amount <= type(uint64).max, "ERC20: transfer amount exceeds uint64 max");
         require(_splToken.getAccount(fromSolana).amount >= amount, "ERC20: transfer amount exceeds balance");
 
-        if (!_splToken.exists(toSolana)) {
+        if (_splToken.isSystemAccount(toSolana)) {
             _splToken.initializeAccount(_salt(to), tokenMint);
         }
 
@@ -223,7 +223,7 @@ contract ERC20ForSplMintable is ERC20ForSpl {
         require(totalSupply() + amount <= type(uint64).max, "ERC20: total mint amount exceeds uint64 max");
 
         bytes32 toSolana = _solanaAccount(to);
-        if (!_splToken.exists(toSolana)) {
+        if (_splToken.isSystemAccount(toSolana)) {
             _splToken.initializeAccount(_salt(to), tokenMint);
         }
 

--- a/evm_loader/solidity/erc721_for_metaplex.sol
+++ b/evm_loader/solidity/erc721_for_metaplex.sol
@@ -90,7 +90,7 @@ contract ERC721ForMetaplex is IERC165, IERC721, IERC721Metadata {
 
         bytes32 seed = keccak256(abi.encode(account.mint, msg.sender));
         bytes32 toSolana = _splToken.findAccount(seed);
-        if (!_splToken.exists(toSolana)) {
+        if (_splToken.isSystemAccount(toSolana)) {
             _splToken.initializeAccount(seed, account.mint);
         }
 
@@ -254,7 +254,7 @@ contract ERC721ForMetaplex is IERC165, IERC721, IERC721Metadata {
         bytes32 toSeed = keccak256(abi.encode(tokenId, to));
         bytes32 toSolana = _splToken.findAccount(toSeed);
 
-        if (!_splToken.exists(toSolana)) {
+        if (_splToken.isSystemAccount(toSolana)) {
             _splToken.initializeAccount(toSeed, bytes32(tokenId));
         }
 

--- a/evm_loader/solidity/erc721_for_metaplex.sol
+++ b/evm_loader/solidity/erc721_for_metaplex.sol
@@ -114,7 +114,7 @@ contract ERC721ForMetaplex is IERC165, IERC721, IERC721Metadata {
         bytes32 tokenSeed = keccak256(abi.encode(mintId, to));
         bytes32 account = _splToken.initializeAccount(tokenSeed, mintId);
 
-        _splToken.mintTo(account, 1);
+        _splToken.mintTo(mintId, account, 1);
 
         _metaplex.createMetadata(mintId, _name, _symbol, uri);
         _metaplex.createMasterEdition(mintId, 0);


### PR DESCRIPTION
SA-195,196,206 Verify arguments to metaplex precompile contract
SA-190 Use safer path to create accounts (transfer,assign,allocate)
SA-196 verify u64 and u8 data in spl_token precompile
SA-201 Rename exists -> isSystemAccount
SA-202 getAccount() & getMint() fail in case of invalid account
SA-192 Pass mint into mintTo,burn,freeze,thaw spl_token methods
SA-199 Fix callcode or delegatecall check in spl_token