### PR TITLE
NDEV-1925: Remove environmental, rewrite code

### DIFF
--- a/evm_loader/Cargo.lock
+++ b/evm_loader/Cargo.lock
@@ -622,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "clickhouse"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c29e58dfff0518f6a6306b89c78397aa98ae7efbd452be871948b0f750573eb5"
+checksum = "33816ee1fea4f60d97abfeb773b9b566ae85f8bfa891758d00a1fb1e5a606591"
 dependencies = [
  "bstr",
  "bytes",
@@ -1174,12 +1174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "environmental"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
-
-[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,7 +1218,6 @@ dependencies = [
  "borsh",
  "cfg-if",
  "const_format",
- "environmental",
  "ethnum",
  "evm-loader-macro",
  "hex",

--- a/evm_loader/api/src/main.rs
+++ b/evm_loader/api/src/main.rs
@@ -6,12 +6,12 @@ mod api_server;
 
 use api_server::handlers::NeonApiError;
 use axum::Router;
+pub use evm_loader::evm::event_listener;
 pub use neon_lib::account_storage;
 pub use neon_lib::commands;
 pub use neon_lib::config;
 pub use neon_lib::context;
 pub use neon_lib::errors;
-pub use neon_lib::event_listener;
 pub use neon_lib::rpc;
 pub use neon_lib::syscall_stubs;
 pub use neon_lib::types;

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -7,9 +7,9 @@ mod context;
 mod logs;
 mod program_options;
 
+pub use evm_loader::evm::event_listener;
 pub use neon_lib::account_storage;
 pub use neon_lib::errors;
-pub use neon_lib::event_listener;
 pub use neon_lib::rpc;
 pub use neon_lib::syscall_stubs;
 pub use neon_lib::types;

--- a/evm_loader/lib/Cargo.toml
+++ b/evm_loader/lib/Cargo.toml
@@ -29,7 +29,7 @@ tokio = { version = "1", features = ["full"] }
 postgres = { version = "0.19", features = ["with-chrono-0_4", "array-impls"] }
 tokio-postgres = {version="0.7", features=["with-uuid-0_8"]}
 lazy_static = "1.4"
-clickhouse = "0.11.2"
+clickhouse = "0.11.5"
 tracing = "0.1"
 async-trait = "0.1.68"
 axum = "0.6"

--- a/evm_loader/lib/src/commands/trace.rs
+++ b/evm_loader/lib/src/commands/trace.rs
@@ -1,6 +1,5 @@
 use crate::{commands::emulate, context::Context, types::TxParams, Config, NeonResult};
 use evm_loader::evm::event_listener::trace::TracedCall;
-use evm_loader::evm::event_listener::tracer::Tracer;
 use evm_loader::types::Address;
 use solana_sdk::pubkey::Pubkey;
 
@@ -17,9 +16,7 @@ pub async fn execute(
     accounts: &[Address],
     solana_accounts: &[Pubkey],
 ) -> NeonResult<TraceReturn> {
-    let tracer = Tracer::new();
-
-    emulate::execute(
+    let result = emulate::execute(
         config,
         context,
         tx,
@@ -31,11 +28,9 @@ pub async fn execute(
     )
     .await?;
 
-    let (vm_trace, full_trace_data) = tracer.into_traces();
-
     let trace = TracedCall {
-        vm_trace,
-        full_trace_data,
+        vm_trace: result.vm_trace,
+        full_trace_data: result.full_trace_data,
         used_gas: 0,
     };
 

--- a/evm_loader/lib/src/commands/trace.rs
+++ b/evm_loader/lib/src/commands/trace.rs
@@ -1,10 +1,6 @@
-use crate::{
-    commands::emulate,
-    context::Context,
-    event_listener::tracer::Tracer,
-    types::{trace::TracedCall, TxParams},
-    Config, NeonResult,
-};
+use crate::{commands::emulate, context::Context, types::TxParams, Config, NeonResult};
+use evm_loader::evm::event_listener::trace::TracedCall;
+use evm_loader::evm::event_listener::tracer::Tracer;
 use evm_loader::types::Address;
 use solana_sdk::pubkey::Pubkey;
 
@@ -21,21 +17,18 @@ pub async fn execute(
     accounts: &[Address],
     solana_accounts: &[Pubkey],
 ) -> NeonResult<TraceReturn> {
-    let mut tracer = Tracer::new();
+    let tracer = Tracer::new();
 
-    evm_loader::evm::tracing::using(&mut tracer, || async {
-        emulate::execute(
-            config,
-            context,
-            tx,
-            token,
-            chain,
-            steps,
-            accounts,
-            solana_accounts,
-        )
-        .await
-    })
+    emulate::execute(
+        config,
+        context,
+        tx,
+        token,
+        chain,
+        steps,
+        accounts,
+        solana_accounts,
+    )
     .await?;
 
     let (vm_trace, full_trace_data) = tracer.into_traces();

--- a/evm_loader/lib/src/lib.rs
+++ b/evm_loader/lib/src/lib.rs
@@ -3,7 +3,6 @@ pub mod commands;
 pub mod config;
 pub mod context;
 pub mod errors;
-pub mod event_listener;
 pub mod rpc;
 pub mod syscall_stubs;
 pub mod types;

--- a/evm_loader/lib/src/types/mod.rs
+++ b/evm_loader/lib/src/types/mod.rs
@@ -1,7 +1,6 @@
 mod indexer_db;
 pub mod request_models;
 #[allow(clippy::all)]
-pub mod trace;
 mod tracer_ch_db;
 
 pub use indexer_db::IndexerDb;
@@ -19,8 +18,6 @@ use {
     thiserror::Error,
     tokio_postgres::{connect, Client},
 };
-
-type Bytes = Vec<u8>;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 pub struct ChDbConfig {

--- a/evm_loader/program/Cargo.toml
+++ b/evm_loader/program/Cargo.toml
@@ -34,7 +34,7 @@ no-entrypoint = []
 test-bpf = []
 custom-heap = []
 default = ["custom-heap"]
-tracing = ["environmental"]
+tracing = []
 
 [dependencies]
 linked_list_allocator = { version = "0.10", default_features = false }
@@ -57,7 +57,6 @@ ethnum = { version = "1", default_features = false, features = [ "serde" ] }
 const_format = { version = "0.2.21" }
 cfg-if = { version = "1.0" }
 log = { version = "0.4", default-features = false, optional = true }
-environmental = { version = "1", default-features = false, optional = true}
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/evm_loader/program/src/evm/event_listener/listener_tracer.rs
+++ b/evm_loader/program/src/evm/event_listener/listener_tracer.rs
@@ -1,5 +1,4 @@
-use super::tracer::Tracer;
-use crate::types::trace::FullTraceData;
+use super::{trace::FullTraceData, tracer::Tracer};
 
 pub trait ListenerTracer {
     fn begin_step(&mut self, stack: Vec<[u8; 32]>, memory: Vec<u8>);

--- a/evm_loader/program/src/evm/event_listener/listener_vm_tracer.rs
+++ b/evm_loader/program/src/evm/event_listener/listener_vm_tracer.rs
@@ -1,7 +1,10 @@
-use super::vm_tracer::VmTracer;
-use crate::types::trace::{MemoryDiff, StorageDiff, VMTracer};
+use crate::evm::{Context, ExitStatus};
+
+use super::{
+    trace::{MemoryDiff, StorageDiff, VMTracer},
+    vm_tracer::VmTracer,
+};
 use ethnum::U256;
-use evm_loader::evm::{Context, ExitStatus};
 
 pub trait ListenerVmTracer {
     fn begin_vm(&mut self, context: Context, code: Vec<u8>);

--- a/evm_loader/program/src/evm/event_listener/mod.rs
+++ b/evm_loader/program/src/evm/event_listener/mod.rs
@@ -1,10 +1,14 @@
+use self::listener_vm_tracer::ListenerVmTracer;
+
+use super::tracing::{Event, EventListener};
+
 mod listener_tracer;
 mod listener_vm_tracer;
+pub mod trace;
 pub mod tracer;
 mod vm_tracer;
 
-use evm_loader::evm::tracing::{Event, EventListener};
-use {listener_tracer::ListenerTracer, listener_vm_tracer::ListenerVmTracer, tracer::Tracer};
+use {listener_tracer::ListenerTracer, tracer::Tracer};
 
 impl EventListener for Tracer {
     fn event(&mut self, event: Event) {

--- a/evm_loader/program/src/evm/event_listener/trace.rs
+++ b/evm_loader/program/src/evm/event_listener/trace.rs
@@ -194,6 +194,10 @@ impl VMTracer for ExecutiveVMTracer {
     fn drain(mut self) -> Option<VMTrace> {
         self.data.subs.pop()
     }
+
+    fn copy_vm_trace(&self) -> Option<VMTrace> {
+        self.data.subs.clone().pop()
+    }
 }
 
 // ethcore/src/trace/mod.rs
@@ -222,6 +226,10 @@ pub trait VMTracer: Send {
 
     /// Consumes self and returns the VM trace.
     fn drain(self) -> Option<Self::Output>;
+
+    /// Copy the VM trace.
+    /// This is used to get the VM trace without consuming the tracer.
+    fn copy_vm_trace(&self) -> Option<Self::Output>;
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]

--- a/evm_loader/program/src/evm/event_listener/trace.rs
+++ b/evm_loader/program/src/evm/event_listener/trace.rs
@@ -1,12 +1,8 @@
-use {crate::types::Bytes, ethnum::U256, std::collections::HashMap};
+use {ethnum::U256, std::collections::HashMap};
 
-#[derive(
-    serde::Serialize,
-    serde::Deserialize,
-    Debug,
-    Clone,
-    PartialEq, /*, RlpEncodable, RlpDecodable */
-)]
+type Bytes = Vec<u8>;
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 /// A diff of some chunk of memory.
 pub struct MemoryDiff {
     /// Offset into memory the change begins.
@@ -20,8 +16,10 @@ pub struct MemoryDiff {
     serde::Deserialize,
     Debug,
     Clone,
-    PartialEq, /*, RlpEncodable, RlpDecodable */
+    PartialEq,
+    Eq, /*, RlpEncodable, RlpDecodable */
 )]
+
 /// A diff of some storage value.
 pub struct StorageDiff {
     /// Which key in storage is changed.
@@ -35,7 +33,8 @@ pub struct StorageDiff {
     serde::Deserialize,
     Debug,
     Clone,
-    PartialEq, /*, RlpEncodable, RlpDecodable */
+    PartialEq,
+    Eq, /*, RlpEncodable, RlpDecodable */
 )]
 /// A record of an executed VM operation.
 pub struct VMExecutedOperation {
@@ -55,6 +54,7 @@ pub struct VMExecutedOperation {
     Debug,
     Clone,
     PartialEq,
+    Eq,
     Default, /*, RlpEncodable, RlpDecodable */
 )]
 /// A record of the execution of a single VM operation.
@@ -114,6 +114,7 @@ pub struct ExecutiveVMTracer {
 
 impl ExecutiveVMTracer {
     /// Create a new top-level instance.
+    #[must_use]
     pub fn toplevel() -> Self {
         ExecutiveVMTracer {
             data: VMTrace {

--- a/evm_loader/program/src/evm/event_listener/tracer.rs
+++ b/evm_loader/program/src/evm/event_listener/tracer.rs
@@ -29,4 +29,10 @@ impl Tracer {
         let vm = self.vm.tracer.drain();
         (vm, self.data)
     }
+
+    #[must_use]
+    pub fn copy_traces(&self) -> (Option<VMTrace>, Vec<FullTraceData>) {
+        let vm = self.vm.tracer.copy_vm_trace();
+        (vm, self.data.clone())
+    }
 }

--- a/evm_loader/program/src/evm/event_listener/tracer.rs
+++ b/evm_loader/program/src/evm/event_listener/tracer.rs
@@ -1,5 +1,7 @@
-use super::vm_tracer::VmTracer;
-use crate::types::trace::{FullTraceData, VMTrace, VMTracer};
+use super::{
+    trace::{FullTraceData, VMTrace, VMTracer},
+    vm_tracer::VmTracer,
+};
 
 pub struct Tracer {
     pub vm: VmTracer,
@@ -13,6 +15,7 @@ impl Default for Tracer {
 }
 
 impl Tracer {
+    #[must_use]
     pub fn new() -> Self {
         Tracer {
             vm: VmTracer::init(),
@@ -20,6 +23,8 @@ impl Tracer {
         }
     }
 
+    #[allow(dead_code)]
+    #[must_use]
     pub fn into_traces(self) -> (Option<VMTrace>, Vec<FullTraceData>) {
         let vm = self.vm.tracer.drain();
         (vm, self.data)

--- a/evm_loader/program/src/evm/event_listener/vm_tracer.rs
+++ b/evm_loader/program/src/evm/event_listener/vm_tracer.rs
@@ -1,5 +1,6 @@
-use crate::types::trace::{ExecutiveVMTracer, MemoryDiff, StorageDiff};
 use ethnum::U256;
+
+use super::trace::{ExecutiveVMTracer, MemoryDiff, StorageDiff};
 
 #[derive(Debug, Default, Clone)]
 pub struct StepDiff {

--- a/evm_loader/program/src/evm/mod.rs
+++ b/evm_loader/program/src/evm/mod.rs
@@ -331,6 +331,12 @@ impl<B: Database> Machine<B> {
                 }
             };
 
+            // Need to check Tracing state-machine.
+            // precompiled contracts  raises error
+            //  the reason: opcode_call() derive new instance of tracer, calls BeginVM
+            // and returns Action::Continue for precompiled contract (keccak256).
+            // So, the for derived tracer instance the EndStep is called.
+            // BeginStep was not called, error raises.
             #[cfg(feature = "tracing")]
             if opcode_result != Action::Noop {
                 self.tracer

--- a/evm_loader/program/src/evm/mod.rs
+++ b/evm_loader/program/src/evm/mod.rs
@@ -36,7 +36,10 @@ mod utils;
 use self::{database::Database, memory::Memory, stack::Stack};
 
 #[cfg(feature = "tracing")]
-use crate::evm::event_listener::tracer::Tracer;
+use {
+    event_listener::trace::{FullTraceData, VMTrace},
+    event_listener::tracer::Tracer,
+};
 
 pub use buffer::Buffer;
 pub use precompile::is_precompile_address;
@@ -352,6 +355,12 @@ impl<B: Database> Machine<B> {
         });
 
         Ok((status, step))
+    }
+
+    #[cfg(feature = "tracing")]
+    #[must_use]
+    pub fn get_trace_data(&self) -> (Option<VMTrace>, Vec<FullTraceData>) {
+        self.tracer.as_ref().borrow().copy_traces()
     }
 
     fn fork(

--- a/evm_loader/program/src/evm/mod.rs
+++ b/evm_loader/program/src/evm/mod.rs
@@ -374,6 +374,13 @@ impl<B: Database> Machine<B> {
         #[cfg(feature = "tracing")]
         let tracer = Rc::new(RefCell::new(Tracer::new()));
 
+        #[cfg(feature = "tracing")]
+        {
+            tracer.borrow_mut().event(Event::BeginVM {
+                context,
+                code: execution_code.to_vec(),
+            });
+        }
         let stack;
         let memory;
 

--- a/evm_loader/program/src/evm/opcode.rs
+++ b/evm_loader/program/src/evm/opcode.rs
@@ -988,14 +988,6 @@ impl<B: Database> Machine<B> {
             code_address: None,
         };
 
-        #[cfg(feature = "tracing")]
-        {
-            self.tracer.borrow_mut().event(Event::BeginVM {
-                context,
-                code: init_code.to_vec(),
-            });
-        }
-
         self.fork(Reason::Create, context, init_code, Buffer::empty(), None);
         backend.snapshot();
 
@@ -1038,14 +1030,6 @@ impl<B: Database> Machine<B> {
             code_address: Some(address),
         };
 
-        #[cfg(feature = "tracing")]
-        {
-            self.tracer.borrow_mut().event(Event::BeginVM {
-                context,
-                code: code.to_vec(),
-            });
-        }
-
         self.fork(Reason::Call, context, code, call_data, Some(gas_limit));
         backend.snapshot();
 
@@ -1087,14 +1071,6 @@ impl<B: Database> Machine<B> {
             code_address: Some(address),
         };
 
-        #[cfg(feature = "tracing")]
-        {
-            self.tracer.borrow_mut().event(Event::BeginVM {
-                context,
-                code: code.to_vec(),
-            });
-        }
-
         self.fork(Reason::Call, context, code, call_data, Some(gas_limit));
         backend.snapshot();
 
@@ -1128,14 +1104,6 @@ impl<B: Database> Machine<B> {
             ..self.context
         };
 
-        #[cfg(feature = "tracing")]
-        {
-            self.tracer.borrow_mut().event(Event::BeginVM {
-                context,
-                code: code.to_vec(),
-            });
-        }
-
         self.fork(Reason::Call, context, code, call_data, Some(gas_limit));
         backend.snapshot();
 
@@ -1166,14 +1134,6 @@ impl<B: Database> Machine<B> {
             value: U256::ZERO,
             code_address: Some(address),
         };
-
-        #[cfg(feature = "tracing")]
-        {
-            self.tracer.borrow_mut().event(Event::BeginVM {
-                context,
-                code: code.to_vec(),
-            });
-        }
 
         self.fork(Reason::Call, context, code, call_data, Some(gas_limit));
         self.is_static = true;

--- a/evm_loader/program/src/evm/tracing.rs
+++ b/evm_loader/program/src/evm/tracing.rs
@@ -1,8 +1,6 @@
 use super::{Context, ExitStatus};
 use ethnum::U256;
 
-environmental::environmental!(listener: dyn EventListener + 'static);
-
 pub trait EventListener {
     fn event(&mut self, event: Event);
 }
@@ -41,15 +39,4 @@ pub enum Event {
         index: U256,
         value: [u8; 32],
     },
-}
-
-pub fn with<F: FnOnce(&mut (dyn EventListener + 'static))>(f: F) {
-    listener::with(f);
-}
-
-pub fn using<R, F: FnOnce() -> R>(
-    new: &mut (dyn EventListener + 'static + Send + Sync),
-    f: F,
-) -> R {
-    listener::using(new, f)
 }


### PR DESCRIPTION
1. Fully functional tracing feature (it did not work properly before)
2. The environmental crate has been removed.
3. Current changes allow EVM to be used in asynchronous/synchronous multithreaded code, current version in develop branch crashes, because crate environmental creates a global reference to a variable, which is unsafe.