### PR TITLE
Fix JSON deserialization (serde_json) for the Action type

### DIFF
--- a/evm_loader/Cargo.lock
+++ b/evm_loader/Cargo.lock
@@ -1222,6 +1222,7 @@ dependencies = [
  "rlp",
  "serde",
  "serde_bytes",
+ "serde_json",
  "solana-program",
  "spl-associated-token-account",
  "spl-token",

--- a/evm_loader/program/Cargo.toml
+++ b/evm_loader/program/Cargo.toml
@@ -59,6 +59,9 @@ cfg-if = { version = "1.0" }
 log = { version = "0.4", default-features = false, optional = true }
 environmental = { version = "1", default-features = false, optional = true}
 
+[dev-dependencies]
+serde_json = "1"
+
 [lib]
 crate-type = ["cdylib", "lib"]
 

--- a/evm_loader/program/src/executor/action.rs
+++ b/evm_loader/program/src/executor/action.rs
@@ -17,19 +17,18 @@ pub enum Action {
     NeonTransfer {
         source: Address,
         target: Address,
-        #[serde(with = "ethnum::serde::bytes::le")]
+        #[serde(with = "serde_u256")]
         value: U256,
     },
     NeonWithdraw {
         source: Address,
-        #[serde(with = "ethnum::serde::bytes::le")]
+        #[serde(with = "serde_u256")]
         value: U256,
     },
     EvmSetStorage {
         address: Address,
-        #[serde(with = "ethnum::serde::bytes::le")]
+        #[serde(with = "serde_u256")]
         index: U256,
-        #[serde(with = "serde_bytes_32")]
         value: [u8; 32],
     },
     EvmIncrementNonce {
@@ -44,37 +43,92 @@ pub enum Action {
     },
 }
 
-mod serde_bytes_32 {
-    pub fn serialize<S>(value: &[u8; 32], serializer: S) -> Result<S::Ok, S::Error>
+mod serde_u256 {
+    use ethnum::U256;
+    use serde::{
+        de::{self, SeqAccess, Visitor},
+        Deserializer, Serializer,
+    };
+
+    pub fn serialize<S>(value: &U256, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::ser::Serializer,
+        S: Serializer,
     {
-        serializer.serialize_bytes(value)
+        serializer.serialize_bytes(&value.to_le_bytes())
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<[u8; 32], D::Error>
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<U256, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
-        struct BytesVisitor;
+        deserializer.deserialize_bytes(U256Visitor {})
+    }
 
-        impl<'de> serde::de::Visitor<'de> for BytesVisitor {
-            type Value = [u8; 32];
+    struct U256Visitor {}
 
-            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                f.write_str("[u8; 32]")
-            }
+    impl<'de> Visitor<'de> for U256Visitor {
+        type Value = U256;
 
-            fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                value
-                    .try_into()
-                    .map_err(|_| serde::de::Error::invalid_length(value.len(), &self))
-            }
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.write_str("32 bytes in little endian")
         }
 
-        deserializer.deserialize_bytes(BytesVisitor)
+        fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            let bytes = v
+                .try_into()
+                .map_err(|_| E::invalid_length(v.len(), &self))?;
+            Ok(U256::from_le_bytes(bytes))
+        }
+
+        fn visit_seq<S>(self, mut seq: S) -> Result<Self::Value, S::Error>
+        where
+            S: SeqAccess<'de>,
+        {
+            let mut bytes = Vec::with_capacity(32);
+            while let Some(b) = seq.next_element()? {
+                bytes.push(b);
+            }
+            Ok(U256::from_le_bytes(
+                bytes
+                    .try_into()
+                    .map_err(|_| de::Error::custom("Invalid U256 value"))?,
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_bincode() {
+        let action = Action::EvmSetStorage {
+            address: Default::default(),
+            index: U256::from_le_bytes([
+                255, 46, 185, 41, 144, 201, 3, 36, 227, 18, 148, 147, 106, 131, 110, 6, 229, 235,
+                44, 154, 71, 124, 159, 144, 47, 119, 77, 5, 154, 49, 23, 54,
+            ]),
+            value: Default::default(),
+        };
+        let serialized = bincode::serialize(&action).unwrap();
+        let _deserialized: Action = bincode::deserialize(&serialized).unwrap();
+    }
+
+    #[test]
+    fn roundtrip_json() {
+        let action = Action::EvmSetStorage {
+            address: Default::default(),
+            index: U256::from_le_bytes([
+                255, 46, 185, 41, 144, 201, 3, 36, 227, 18, 148, 147, 106, 131, 110, 6, 229, 235,
+                44, 154, 71, 124, 159, 144, 47, 119, 77, 5, 154, 49, 23, 54,
+            ]),
+            value: Default::default(),
+        };
+        let serialized = serde_json::to_string(&action).unwrap();
+        let _deserialized: Action = serde_json::from_str(&serialized).unwrap();
     }
 }

--- a/evm_loader/program/src/external_programs/spl_associated_token.rs
+++ b/evm_loader/program/src/external_programs/spl_associated_token.rs
@@ -41,7 +41,7 @@ pub fn emulate(
     };
 
     {
-        let mut funder = accounts.get_mut(funder_key).unwrap();
+        let funder = accounts.get_mut(funder_key).unwrap();
         if funder.lamports < required_lamports {
             return Err!(ProgramError::InsufficientFunds; "Insufficient operator lamports");
         }
@@ -50,7 +50,7 @@ pub fn emulate(
     }
 
     {
-        let mut associated_token_account = accounts.get_mut(associated_token_account_key).unwrap();
+        let associated_token_account = accounts.get_mut(associated_token_account_key).unwrap();
         if !solana_program::system_program::check_id(&associated_token_account.owner) {
             return Err!(ProgramError::InvalidInstructionData; "Account {} is not system owned", associated_token_account_key);
         }

--- a/evm_loader/program/src/external_programs/system.rs
+++ b/evm_loader/program/src/external_programs/system.rs
@@ -24,7 +24,7 @@ pub fn emulate(
             let account_key = &meta[1].pubkey;
 
             {
-                let mut funder = accounts.get_mut(funder_key).unwrap();
+                let funder = accounts.get_mut(funder_key).unwrap();
                 if funder.lamports < lamports {
                     return Err!(ProgramError::InsufficientFunds; "Insufficient operator lamports");
                 }
@@ -33,7 +33,7 @@ pub fn emulate(
             }
 
             {
-                let mut account = accounts.get_mut(account_key).unwrap();
+                let account = accounts.get_mut(account_key).unwrap();
                 if (account.lamports > 0)
                     || !account.data.is_empty()
                     || !system_program::check_id(&account.owner)
@@ -48,7 +48,7 @@ pub fn emulate(
         }
         SystemInstruction::Assign { owner } => {
             let account_key = &meta[0].pubkey;
-            let mut account = accounts.get_mut(account_key).unwrap();
+            let account = accounts.get_mut(account_key).unwrap();
 
             if !system_program::check_id(&account.owner) {
                 return Err!(ProgramError::InvalidInstructionData; "Assign Account: account already in use");
@@ -61,7 +61,7 @@ pub fn emulate(
             let to_key = &meta[1].pubkey;
 
             {
-                let mut from = accounts.get_mut(from_key).unwrap();
+                let from = accounts.get_mut(from_key).unwrap();
                 if !from.data.is_empty() {
                     return Err!(ProgramError::InvalidArgument; "Transfer: `from` must not carry data");
                 }
@@ -78,7 +78,7 @@ pub fn emulate(
             }
 
             {
-                let mut to = accounts.get_mut(to_key).unwrap();
+                let to = accounts.get_mut(to_key).unwrap();
                 to.lamports += lamports;
             }
         }


### PR DESCRIPTION
The current deserialization implementation uses the `#[serde(with = "ethnum::serde::bytes::le")]` attribute and it didn't work for JSON (`serde_json`) because the `visit_seq` function is required for that format and the library only provides the `visit_bytes` method. This pull request introduces a custom implementation that mirrors the behavior for binary formats, so serialization to `bincode` shouldn't be affected, but it adds the missing method, so JSON works too.

To be clear: the new implementation is almost identical to the one provided by the `ethnum` crate. The [serialization is the same](https://github.com/nlordell/ethnum-rs/blob/main/src/serde.rs#L364) and one method used for the [deserialization](https://github.com/nlordell/ethnum-rs/blob/main/src/serde.rs#L398) has been added to the visitor. I have checked manually and `visit_bytes` is called during bincode deserialization and `visit_seq` is only used for the JSON format.