### PR TITLE
NDEV-1881: Temporary increase worker_threads to 512

### DIFF
--- a/evm_loader/Cargo.lock
+++ b/evm_loader/Cargo.lock
@@ -3411,11 +3411,10 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.12"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1b6471d7496b051e03f1958802a73f88b947866f5146f329e47e36554f4e55"
+checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
 dependencies = [
- "itoa",
  "serde",
 ]
 

--- a/evm_loader/api/src/main.rs
+++ b/evm_loader/api/src/main.rs
@@ -26,7 +26,7 @@ use tokio::signal::{self};
 type NeonApiResult<T> = Result<T, NeonApiError>;
 type NeonApiState = Arc<api_server::state::State>;
 
-#[tokio::main]
+#[tokio::main(flavor = "multi_thread", worker_threads = 512)]
 async fn main() -> NeonApiResult<()> {
     let options = api_options::parse();
 


### PR DESCRIPTION
The main challenge for us is to increase the throughput capacity of our service.
We can't do it properly when we have a bunch of nested blocking calls, the main problem is the function block_in_place which will block the current thread. 
```Rust
pub fn block<Fu>(f: Fu) -> Fu::Output
where
    Fu: std::future::Future,
{
    match tokio::runtime::Handle::try_current() {
        Ok(handle) => block_in_place(|| handle.block_on(f)),
        Err(_) => RT.block_on(f),
    }
}
```

When we have a lot of parallel calls to this function, which also contains many inner calls to the block function (account_storage, emulate, etc.), we slow down the work of the whole executor, as in fact all threads are busy executing blocking functions.

Taking into account that the 'Buffer' type containing raw pointers (*const u8) and other types that do not implement Send prevent us from using spawn_blocking, we have no other way for now but to temporarily increase the number of runtime threads.

We need to test the current branch using our performance tests and make sure we are getting more throughput.