### PR TITLE
NDEV-1925: Make trace_trx non-async

### DIFF
--- a/evm_loader/lib/src/commands/emulate.rs
+++ b/evm_loader/lib/src/commands/emulate.rs
@@ -145,7 +145,8 @@ pub(crate) fn emulate_transaction(
     step_limit: u64,
     storage: EmulatorAccountStorage,
 ) -> Result<(EmulationResult, EmulatorAccountStorage), NeonError> {
-    emulate_trx(tx_params, &storage, chain_id, step_limit).map(move |result| (result, storage))
+    let result = emulate_trx(tx_params, &storage, chain_id, step_limit)?;
+    Ok((result, storage))
 }
 
 pub(crate) fn emulate_trx<'a>(

--- a/evm_loader/lib/src/commands/emulate.rs
+++ b/evm_loader/lib/src/commands/emulate.rs
@@ -139,12 +139,12 @@ pub async fn execute(
     })
 }
 
-pub(crate) fn emulate_transaction<'a>(
+pub(crate) fn emulate_transaction(
     tx_params: TxParams,
     chain_id: u64,
     step_limit: u64,
-    storage: EmulatorAccountStorage<'a>,
-) -> Result<(EmulationResult, EmulatorAccountStorage<'a>), NeonError> {
+    storage: EmulatorAccountStorage,
+) -> Result<(EmulationResult, EmulatorAccountStorage), NeonError> {
     emulate_trx(tx_params, &storage, chain_id, step_limit).map(move |result| (result, storage))
 }
 

--- a/evm_loader/lib/src/commands/emulate.rs
+++ b/evm_loader/lib/src/commands/emulate.rs
@@ -124,7 +124,7 @@ pub async fn execute(
     .await?;
 
     let (emulation_result, storage) =
-        emulate_transaction(tx_params, chain_id, step_limit, storage).await?;
+        emulate_transaction(tx_params, chain_id, step_limit, storage)?;
     let accounts = block(storage.accounts.read()).values().cloned().collect();
     let solana_accounts = block(storage.solana_accounts.read())
         .values()
@@ -139,7 +139,7 @@ pub async fn execute(
     })
 }
 
-pub(crate) async fn emulate_transaction<'a>(
+pub(crate) fn emulate_transaction<'a>(
     tx_params: TxParams,
     chain_id: u64,
     step_limit: u64,

--- a/evm_loader/lib/src/commands/emulate.rs
+++ b/evm_loader/lib/src/commands/emulate.rs
@@ -123,8 +123,7 @@ pub async fn execute(
     )
     .await?;
 
-    let (emulation_result, storage) =
-        emulate_transaction(tx_params, chain_id, step_limit, storage)?;
+    let emulation_result = emulate_trx(tx_params, &storage, chain_id, step_limit)?;
     let accounts = block(storage.accounts.read()).values().cloned().collect();
     let solana_accounts = block(storage.solana_accounts.read())
         .values()
@@ -137,16 +136,6 @@ pub async fn execute(
         token_accounts: vec![],
         emulation_result,
     })
-}
-
-pub(crate) fn emulate_transaction(
-    tx_params: TxParams,
-    chain_id: u64,
-    step_limit: u64,
-    storage: EmulatorAccountStorage,
-) -> Result<(EmulationResult, EmulatorAccountStorage), NeonError> {
-    let result = emulate_trx(tx_params, &storage, chain_id, step_limit)?;
-    Ok((result, storage))
 }
 
 pub(crate) fn emulate_trx<'a>(

--- a/evm_loader/lib/src/commands/emulate.rs
+++ b/evm_loader/lib/src/commands/emulate.rs
@@ -139,7 +139,6 @@ pub async fn execute(
     })
 }
 
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn emulate_transaction<'a>(
     tx_params: TxParams,
     chain_id: u64,

--- a/evm_loader/lib/src/commands/emulate.rs
+++ b/evm_loader/lib/src/commands/emulate.rs
@@ -108,6 +108,8 @@ pub async fn execute(
     solana_accounts: &[Pubkey],
     trace_call_config: TraceCallConfig,
 ) -> NeonResult<EmulationResultWithAccounts> {
+    setup_syscall_stubs(rpc_client).await?;
+
     let (emulation_result, storage) = emulate_transaction(
         rpc_client,
         evm_loader,
@@ -148,8 +150,6 @@ pub(crate) async fn emulate_transaction<'a>(
     solana_accounts: &[Pubkey],
     trace_call_config: TraceCallConfig,
 ) -> Result<(EmulationResult, EmulatorAccountStorage<'a>), NeonError> {
-    setup_syscall_stubs(rpc_client).await?;
-
     let storage = EmulatorAccountStorage::with_accounts(
         rpc_client,
         evm_loader,

--- a/evm_loader/lib/src/commands/emulate.rs
+++ b/evm_loader/lib/src/commands/emulate.rs
@@ -163,12 +163,10 @@ pub(crate) async fn emulate_transaction<'a>(
     )
     .await?;
 
-    emulate_trx(tx_params, &storage, chain_id, step_limit)
-        .await
-        .map(move |result| (result, storage))
+    emulate_trx(tx_params, &storage, chain_id, step_limit).map(move |result| (result, storage))
 }
 
-pub(crate) async fn emulate_trx<'a>(
+pub(crate) fn emulate_trx<'a>(
     tx_params: TxParams,
     storage: &'a EmulatorAccountStorage<'a>,
     chain_id: u64,

--- a/evm_loader/lib/src/commands/trace.rs
+++ b/evm_loader/lib/src/commands/trace.rs
@@ -29,7 +29,7 @@ pub async fn trace_transaction(
 ) -> Result<TracedCall, NeonError> {
     let mut tracer = Tracer::new(trace_call_config.trace_config.enable_return_data);
 
-    let (emulation_result, _storage) = evm_loader::evm::tracing::using(&mut tracer, || async {
+    let (emulation_result, _storage) = evm_loader::evm::tracing::using(&mut tracer, || {
         emulate_transaction(
             rpc_client,
             evm_loader,
@@ -42,7 +42,6 @@ pub async fn trace_transaction(
             solana_accounts,
             trace_call_config,
         )
-        .await
     })
     .await?;
 
@@ -114,8 +113,7 @@ async fn trace_trx<'a>(
 
     let emulation_result = evm_loader::evm::tracing::using(&mut tracer, || {
         emulate_trx(tx_params, storage, chain_id, steps)
-    })
-    .await?;
+    })?;
 
     let (vm_trace, full_trace_data) = tracer.into_traces();
 

--- a/evm_loader/lib/src/commands/trace.rs
+++ b/evm_loader/lib/src/commands/trace.rs
@@ -98,14 +98,14 @@ pub async fn trace_block(
 
     let mut results = vec![];
     for tx_params in transactions {
-        let result = trace_trx(tx_params, &storage, chain_id, steps, trace_config).await?;
+        let result = trace_trx(tx_params, &storage, chain_id, steps, trace_config)?;
         results.push(result);
     }
 
     Ok(TraceBlockReturn(results))
 }
 
-async fn trace_trx<'a>(
+fn trace_trx<'a>(
     tx_params: TxParams,
     storage: &'a EmulatorAccountStorage<'a>,
     chain_id: u64,

--- a/evm_loader/lib/src/commands/trace.rs
+++ b/evm_loader/lib/src/commands/trace.rs
@@ -42,21 +42,13 @@ pub async fn trace_transaction(
     )
     .await?;
 
-    let mut tracer = Tracer::new(trace_call_config.trace_config.enable_return_data);
-
-    let emulation_result = evm_loader::evm::tracing::using(&mut tracer, || {
-        emulate_trx(tx, &storage, chain_id, steps)
-    })?;
-
-    let (vm_trace, full_trace_data) = tracer.into_traces();
-
-    Ok(TracedCall {
-        vm_trace,
-        full_trace_data,
-        used_gas: emulation_result.used_gas,
-        result: emulation_result.result,
-        exit_status: emulation_result.exit_status,
-    })
+    trace_trx(
+        tx,
+        &storage,
+        chain_id,
+        steps,
+        &trace_call_config.trace_config,
+    )
 }
 
 #[derive(Serialize, Deserialize)]

--- a/evm_loader/lib/src/commands/trace.rs
+++ b/evm_loader/lib/src/commands/trace.rs
@@ -45,7 +45,7 @@ pub async fn trace_transaction(
         )
         .await?;
 
-        emulate_transaction(tx, chain_id, steps, storage).await
+        emulate_transaction(tx, chain_id, steps, storage)
     })
     .await?;
 

--- a/evm_loader/lib/src/commands/trace.rs
+++ b/evm_loader/lib/src/commands/trace.rs
@@ -32,19 +32,20 @@ pub async fn trace_transaction(
     let (emulation_result, _storage) = evm_loader::evm::tracing::using(&mut tracer, || async {
         setup_syscall_stubs(rpc_client).await?;
 
-        emulate_transaction(
+        let storage = EmulatorAccountStorage::with_accounts(
             rpc_client,
             evm_loader,
-            tx,
             token,
             chain_id,
-            steps,
             commitment,
             accounts,
             solana_accounts,
-            trace_call_config,
+            &trace_call_config.block_overrides,
+            trace_call_config.state_overrides,
         )
-        .await
+        .await?;
+
+        emulate_transaction(tx, chain_id, steps, storage).await
     })
     .await?;
 

--- a/evm_loader/lib/src/commands/trace.rs
+++ b/evm_loader/lib/src/commands/trace.rs
@@ -1,4 +1,3 @@
-use crate::commands::emulate::EmulationResult;
 use crate::{
     account_storage::EmulatorAccountStorage,
     commands::emulate::{emulate_trx, setup_syscall_stubs},
@@ -45,9 +44,8 @@ pub async fn trace_transaction(
 
     let mut tracer = Tracer::new(trace_call_config.trace_config.enable_return_data);
 
-    let (emulation_result, _storage) = evm_loader::evm::tracing::using(&mut tracer, || {
-        let emulation_result = emulate_trx(tx, &storage, chain_id, steps)?;
-        Ok::<(EmulationResult, EmulatorAccountStorage<'_>), NeonError>((emulation_result, storage))
+    let emulation_result = evm_loader::evm::tracing::using(&mut tracer, || {
+        emulate_trx(tx, &storage, chain_id, steps)
     })?;
 
     let (vm_trace, full_trace_data) = tracer.into_traces();

--- a/evm_loader/lib/src/commands/trace.rs
+++ b/evm_loader/lib/src/commands/trace.rs
@@ -1,6 +1,6 @@
 use crate::{
     account_storage::EmulatorAccountStorage,
-    commands::emulate::{emulate_transaction, emulate_trx, setup_syscall_stubs},
+    commands::emulate::{emulate_trx, setup_syscall_stubs},
     errors::NeonError,
     event_listener::tracer::Tracer,
     rpc::Rpc,
@@ -45,7 +45,8 @@ pub async fn trace_transaction(
         )
         .await?;
 
-        emulate_transaction(tx, chain_id, steps, storage)
+        let emulation_result = emulate_trx(tx, &storage, chain_id, steps)?;
+        Ok((emulation_result, storage))
     })
     .await?;
 

--- a/evm_loader/lib/src/commands/trace.rs
+++ b/evm_loader/lib/src/commands/trace.rs
@@ -29,7 +29,9 @@ pub async fn trace_transaction(
 ) -> Result<TracedCall, NeonError> {
     let mut tracer = Tracer::new(trace_call_config.trace_config.enable_return_data);
 
-    let (emulation_result, _storage) = evm_loader::evm::tracing::using(&mut tracer, || {
+    let (emulation_result, _storage) = evm_loader::evm::tracing::using(&mut tracer, || async {
+        setup_syscall_stubs(rpc_client).await?;
+
         emulate_transaction(
             rpc_client,
             evm_loader,
@@ -42,6 +44,7 @@ pub async fn trace_transaction(
             solana_accounts,
             trace_call_config,
         )
+        .await
     })
     .await?;
 


### PR DESCRIPTION
`trace_trx` function does not need to be async.