### PR TITLE
NDEV-2007: Add rust-toolchain.toml with Rust Dockerfile version

### DIFF
--- a/evm_loader/program/src/executor/action.rs
+++ b/evm_loader/program/src/executor/action.rs
@@ -156,7 +156,7 @@ mod tests {
     #[test]
     fn roundtrip_bincode() {
         let action = Action::EvmSetStorage {
-            address: Default::default(),
+            address: Address::default(),
             index: U256::from_le_bytes([
                 255, 46, 185, 41, 144, 201, 3, 36, 227, 18, 148, 147, 106, 131, 110, 6, 229, 235,
                 44, 154, 71, 124, 159, 144, 47, 119, 77, 5, 154, 49, 23, 54,
@@ -170,7 +170,7 @@ mod tests {
     #[test]
     fn roundtrip_json() {
         let action = Action::EvmSetStorage {
-            address: Default::default(),
+            address: Address::default(),
             index: U256::from_le_bytes([
                 255, 46, 185, 41, 144, 201, 3, 36, 227, 18, 148, 147, 106, 131, 110, 6, 229, 235,
                 44, 154, 71, 124, 159, 144, 47, 119, 77, 5, 154, 49, 23, 54,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.64.0"


### PR DESCRIPTION
[CI build](https://github.com/neonlabsorg/neon-evm/blob/develop/.github/workflows/pipeline.yml#L31) uses [Rust 1.64.0](https://github.com/neonlabsorg/neon-evm/blob/develop/Dockerfile#L3).

I added [`rust-toolchain.toml`](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) file in order to use the same CI Rust version locally too.