### PR TITLE
NDEV-1881: Use non-blocking writer for logs

### DIFF
--- a/evm_loader/Cargo.lock
+++ b/evm_loader/Cargo.lock
@@ -2197,6 +2197,7 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -4800,6 +4801,17 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+dependencies = [
+ "crossbeam-channel",
+ "time 0.3.20",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/evm_loader/api/Cargo.toml
+++ b/evm_loader/api/Cargo.toml
@@ -15,6 +15,7 @@ ethnum = { version = "1", default_features = false, features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-appender = "0.2.2"
 axum = "0.6"
 tower = { version = "0.4", features = ["make"] }
 neon-lib = { path = "../lib" }

--- a/evm_loader/lib/src/config.rs
+++ b/evm_loader/lib/src/config.rs
@@ -26,7 +26,7 @@ pub struct Config {
 // }
 
 /// # Errors
-pub fn create_from_api_comnfig(api_config: &APIOptions) -> Result<Config, NeonError> {
+pub fn create_from_api_config(api_config: &APIOptions) -> Result<Config, NeonError> {
     let solana_cli_config: SolanaConfig =
         if let Some(path) = api_config.solana_cli_config_path.clone() {
             solana_cli_config::Config::load(path.as_str()).unwrap_or_default()


### PR DESCRIPTION
1. Add non-blocking writer for tracing_subscriber. A dedicated worker thread will be spawned to handle logging.
2. Writer configured to be non-lossy.
