### PR TITLE
NDEV-2115: Replace default_features with default-features

### DIFF
--- a/evm_loader/api/Cargo.toml
+++ b/evm_loader/api/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 
 [dependencies]
 clap = "2.33.3"
-evm-loader = { path = "../program", default_features = false, features = ["log"] }
+evm-loader = { path = "../program", default-features = false, features = ["log"] }
 solana-sdk = "=1.14.20"
 serde = "1.0.186"
 serde_json = "1.0.85"
-ethnum = { version = "1", default_features = false, features = ["serde"] }
+ethnum = { version = "1", default-features = false, features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/evm_loader/cli/Cargo.toml
+++ b/evm_loader/cli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 clap = "2.33.3"
-evm-loader = { path = "../program", default_features = false, features = ["log"] }
+evm-loader = { path = "../program", default-features = false, features = ["log"] }
 solana-sdk = "=1.14.20"
 solana-client = "=1.14.20"
 solana-clap-utils = "=1.14.20"
@@ -17,6 +17,6 @@ serde = "1.0.186"
 serde_json = "1.0.85"
 log = "0.4.17"
 fern = "0.6"
-ethnum = { version = "1", default_features = false, features = ["serde"] }
+ethnum = { version = "1", default-features = false, features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
 neon-lib = { path = "../lib" }

--- a/evm_loader/lib/Cargo.toml
+++ b/evm_loader/lib/Cargo.toml
@@ -8,22 +8,22 @@ edition = "2021"
 [dependencies]
 thiserror = "1.0"
 bincode = "1.3.1"
-evm-loader = { path = "../program", default_features = false, features = ["log", "tracing"] }
+evm-loader = { path = "../program", default-features = false, features = ["log", "tracing"] }
 solana-sdk = "=1.14.20"
 solana-client = "=1.14.20"
 solana-clap-utils = "=1.14.20"
 solana-cli-config = "=1.14.20"
 solana-cli = "=1.14.20"
 solana-transaction-status = "=1.14.20"
-spl-token = { version = "~3.5", default_features = false, features = ["no-entrypoint"] }
-spl-associated-token-account = { version = "~1.1", default_features = false, features = ["no-entrypoint"] }
+spl-token = { version = "~3.5", default-features = false, features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "~1.1", default-features = false, features = ["no-entrypoint"] }
 bs58 = "0.4.0"
 hex = "0.4.2"
 serde = "1.0.186"
 serde_json = "1.0.105"
 log = "0.4.17"
 rand = "0.8"
-ethnum = { version = "1", default_features = false, features = ["serde"] }
+ethnum = { version = "1", default-features = false, features = ["serde"] }
 goblin = { version = "0.6.0" }
 scroll = "0.11.0"
 tokio = { version = "1", features = ["full"] }

--- a/evm_loader/program/Cargo.toml
+++ b/evm_loader/program/Cargo.toml
@@ -37,12 +37,12 @@ default = ["custom-heap"]
 tracing = ["serde_json"]
 
 [dependencies]
-linked_list_allocator = { version = "0.10", default_features = false }
+linked_list_allocator = { version = "0.10", default-features = false }
 evm-loader-macro = { path = "../program-macro" }
-solana-program = { version = "=1.14.20", default_features = false }
-spl-token = { version = "~3.5", default_features = false, features = ["no-entrypoint"] }
-spl-associated-token-account = { version = "~1.1", default_features = false, features = ["no-entrypoint"] }
-mpl-token-metadata = { version = "1.12", default_features = false, features = ["no-entrypoint"] }
+solana-program = { version = "=1.14.20", default-features = false }
+spl-token = { version = "~3.5", default-features = false, features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "~1.1", default-features = false, features = ["no-entrypoint"] }
+mpl-token-metadata = { version = "1.12", default-features = false, features = ["no-entrypoint"] }
 thiserror = "1.0"
 arrayref = "0.3.6"
 hex = "0.4.2"
@@ -54,7 +54,7 @@ bincode = "1"
 serde_bytes = "0.11.12"
 serde = { version = "1.0.186", default-features = false, features = ["derive", "rc"] }
 serde_json = { version = "1.0.105", optional = true }
-ethnum = { version = "1", default_features = false, features = ["serde"] }
+ethnum = { version = "1", default-features = false, features = ["serde"] }
 const_format = { version = "0.2.21" }
 cfg-if = { version = "1.0" }
 log = { version = "0.4", default-features = false, optional = true }


### PR DESCRIPTION
Fixed typo in `default_features = false`.

The correct spelling is [`default-features = false`](https://doc.rust-lang.org/cargo/reference/features.html#the-default-feature).