### PR TITLE
NDEV-2155: Use neon-evm-1 runners

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build-neon-evm:
-    runs-on: build-runner
+    runs-on: neon-evm-1
     steps:
       - uses: actions/checkout@v3
         with:
@@ -66,7 +66,7 @@ jobs:
           --is_draft=${{github.event.pull_request.draft}} \
           --labels='${{ toJson(github.event.pull_request.labels.*.name) }}'
   finalize-image:
-    runs-on: build-runner
+    runs-on: neon-evm-1
     needs:
       - trigger-proxy-tests
       - run-neon-evm-tests


### PR DESCRIPTION
Use `neon-evm-1`-labeled runners instead of `build-runner`-labeled runner.

There is only one `build-runner` machine and 11 `neon-evm-1` machines https://github.com/neonlabsorg/neon-evm/actions/runners?tab=self-hosted. This change should make running concurrent CI builds faster.