### PR TITLE
NDEV-2160: Improve account data printing

### DIFF
--- a/evm_loader/lib/src/types/tracer_ch_db.rs
+++ b/evm_loader/lib/src/types/tracer_ch_db.rs
@@ -13,6 +13,7 @@ use std::{
         Ordering::{Equal, Greater, Less},
     },
     convert::TryFrom,
+    fmt,
     sync::Arc,
     time::Instant,
 };
@@ -71,14 +72,41 @@ impl SlotParent {
     }
 }
 
-#[derive(Debug, Row, serde::Deserialize, Clone)]
+#[derive(Row, serde::Deserialize, Clone)]
 pub struct AccountRow {
-    owner: Vec<u8>,
-    lamports: u64,
-    executable: bool,
-    rent_epoch: u64,
-    data: Vec<u8>,
-    txn_signature: Vec<Option<u8>>,
+    pub owner: Vec<u8>,
+    pub lamports: u64,
+    pub executable: bool,
+    pub rent_epoch: u64,
+    pub data: Vec<u8>,
+    pub txn_signature: Vec<Option<u8>>,
+}
+
+impl fmt::Display for AccountRow {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "AccountRow {{\n    owner: {},\n    lamports: {},\n    executable: {},\n    rent_epoch: {},\n}}",
+            bs58::encode(&self.owner).into_string(),
+            self.lamports,
+            self.executable,
+            self.rent_epoch,
+        )
+    }
+}
+
+impl fmt::Debug for AccountRow {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Account")
+            .field(
+                "owner",
+                &format!("{}", bs58::encode(&self.owner).into_string()),
+            )
+            .field("lamports", &self.lamports)
+            .field("executable", &self.executable)
+            .field("rent_epoch", &self.rent_epoch)
+            .finish()
+    }
 }
 
 impl TryInto<Account> for AccountRow {


### PR DESCRIPTION
The data field clogs the logs with a huge amount of unnecessary information, I suggest not printing it at all.
At the same time, the owner field should be printed in base58 format rather than as an array.