### PR TITLE
Update the 'ethnum' crate version and remove the serialization workaround

### DIFF
--- a/evm_loader/Cargo.lock
+++ b/evm_loader/Cargo.lock
@@ -1183,9 +1183,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0198b9d0078e0f30dedc7acbb21c974e838fc8fae3ee170128658a98cb2c1c04"
+checksum = "6c8ff382b2fa527fb7fb06eeebfc5bbb3f17e3cc6b9d70b006c41daa8824adac"
 dependencies = [
  "serde",
 ]

--- a/evm_loader/api/Cargo.toml
+++ b/evm_loader/api/Cargo.toml
@@ -11,7 +11,7 @@ evm-loader = { path = "../program", default-features = false, features = ["log"]
 solana-sdk = "=1.14.20"
 serde = "1.0.186"
 serde_json = "1.0.85"
-ethnum = { version = "1", default-features = false, features = ["serde"] }
+ethnum = { version = "1.4", default-features = false, features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/evm_loader/cli/Cargo.toml
+++ b/evm_loader/cli/Cargo.toml
@@ -17,6 +17,6 @@ serde = "1.0.186"
 serde_json = "1.0.85"
 log = "0.4.17"
 fern = "0.6"
-ethnum = { version = "1", default-features = false, features = ["serde"] }
+ethnum = { version = "1.4", default-features = false, features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
 neon-lib = { path = "../lib" }

--- a/evm_loader/lib/Cargo.toml
+++ b/evm_loader/lib/Cargo.toml
@@ -24,7 +24,7 @@ serde = "1.0.186"
 serde_json = "1.0.105"
 log = "0.4.17"
 rand = "0.8"
-ethnum = { version = "1", default-features = false, features = ["serde"] }
+ethnum = { version = "1.4", default-features = false, features = ["serde"] }
 goblin = { version = "0.6.0" }
 scroll = "0.11.0"
 tokio = { version = "1", features = ["full"] }

--- a/evm_loader/program/Cargo.toml
+++ b/evm_loader/program/Cargo.toml
@@ -54,7 +54,7 @@ bincode = "1"
 serde_bytes = "0.11.12"
 serde = { version = "1.0.186", default-features = false, features = ["derive", "rc"] }
 serde_json = { version = "1.0.105", optional = true }
-ethnum = { version = "1", default-features = false, features = ["serde"] }
+ethnum = { version = "1.4", default-features = false, features = ["serde"] }
 const_format = { version = "0.2.21" }
 cfg-if = { version = "1.0" }
 log = { version = "0.4", default-features = false, optional = true }

--- a/evm_loader/program/src/executor/action.rs
+++ b/evm_loader/program/src/executor/action.rs
@@ -17,17 +17,17 @@ pub enum Action {
     NeonTransfer {
         source: Address,
         target: Address,
-        #[serde(with = "serde_u256")]
+        #[serde(with = "ethnum::serde::bytes::le")]
         value: U256,
     },
     NeonWithdraw {
         source: Address,
-        #[serde(with = "serde_u256")]
+        #[serde(with = "ethnum::serde::bytes::le")]
         value: U256,
     },
     EvmSetStorage {
         address: Address,
-        #[serde(with = "serde_u256")]
+        #[serde(with = "ethnum::serde::bytes::le")]
         index: U256,
         #[serde(with = "serde_bytes_32")]
         value: [u8; 32],
@@ -89,63 +89,6 @@ mod serde_bytes_32 {
         }
 
         deserializer.deserialize_bytes(BytesVisitor)
-    }
-}
-
-mod serde_u256 {
-    use ethnum::U256;
-    use serde::{
-        de::{self, SeqAccess, Visitor},
-        Deserializer, Serializer,
-    };
-
-    pub fn serialize<S>(value: &U256, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_bytes(&value.to_le_bytes())
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<U256, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_bytes(U256Visitor {})
-    }
-
-    struct U256Visitor {}
-
-    impl<'de> Visitor<'de> for U256Visitor {
-        type Value = U256;
-
-        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-            f.write_str("32 bytes in little endian")
-        }
-
-        fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-        where
-            E: de::Error,
-        {
-            let bytes = v
-                .try_into()
-                .map_err(|_| E::invalid_length(v.len(), &self))?;
-            Ok(U256::from_le_bytes(bytes))
-        }
-
-        fn visit_seq<S>(self, mut seq: S) -> Result<Self::Value, S::Error>
-        where
-            S: SeqAccess<'de>,
-        {
-            let mut bytes = Vec::with_capacity(32);
-            while let Some(b) = seq.next_element()? {
-                bytes.push(b);
-            }
-            Ok(U256::from_le_bytes(
-                bytes
-                    .try_into()
-                    .map_err(|_| de::Error::custom("Invalid U256 value"))?,
-            ))
-        }
     }
 }
 


### PR DESCRIPTION
The `1.4` update of the `ethnum` includes a fix for the workaround introduced in https://github.com/neonlabsorg/neon-evm/pull/129, so it can be removed now.