### PR TITLE
NDEV-2176: Change the ordering of data in neon_revision

### DIFF
--- a/evm_loader/lib/src/types/tracer_ch_db.rs
+++ b/evm_loader/lib/src/types/tracer_ch_db.rs
@@ -569,9 +569,8 @@ impl ClickHouseDb {
         let query = r#"SELECT data
         FROM events.update_account_distributed
         WHERE
-            pubkey = ?
+            pubkey = ? AND slot <= ?
         ORDER BY
-            abs(? - slot) ASC,
             pubkey ASC,
             slot ASC,
             write_version ASC


### PR DESCRIPTION
We must consistently provide the lower neon_revision version. Therefore, if we possess neon_revision for slots 1000 and 2000, and a query requests slot 1700, we should give the neon_revision version associated with the 1000 slot.