### PR TITLE
NDEV-2183: Remove the semicolon in query_is_startup

### DIFF
--- a/evm_loader/lib/src/types/tracer_ch_db.rs
+++ b/evm_loader/lib/src/types/tracer_ch_db.rs
@@ -552,7 +552,7 @@ impl ClickHouseDb {
           SELECT MAX(slot)
           FROM events.update_account_distributed
         )
-        LIMIT 1;
+        LIMIT 1
         "#;
 
         let is_startup = Self::row_opt(


### PR DESCRIPTION
Multi statement is not supported by clickhouse-rs. I forgot to remove ; in the SQL statement