### PR TITLE
NDEV-2222: Add build-info to neon-cli and neon-api

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,6 @@ Dockerfile
 Dockerfile.*
 .*.swp
 
-.git
 .github
 .gitignore
 .gitmodules

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ ENV PATH=/root/.local/share/solana/install/active_release/bin:/usr/local/cargo/b
 
 # Build evm_loader
 FROM builder AS evm-loader-builder
-COPY ./evm_loader/ /opt/evm_loader/
-WORKDIR /opt/evm_loader
+COPY . /opt/neon-evm/
+WORKDIR /opt/neon-evm/evm_loader
 ARG REVISION
 ENV NEON_REVISION=${REVISION}
 RUN cargo fmt --check && \
@@ -73,10 +73,10 @@ RUN /opt/solana/bin/solana program dump metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518
 COPY evm_loader/solana-run-neon.sh \
      /opt/solana/bin/
 
-COPY --from=evm-loader-builder /opt/evm_loader/target/deploy/evm_loader*.so /opt/
-COPY --from=evm-loader-builder /opt/evm_loader/target/deploy/evm_loader-dump.txt /opt/
-COPY --from=evm-loader-builder /opt/evm_loader/target/release/neon-cli /opt/
-COPY --from=evm-loader-builder /opt/evm_loader/target/release/neon-api /opt/
+COPY --from=evm-loader-builder /opt/neon-evm/evm_loader/target/deploy/evm_loader*.so /opt/
+COPY --from=evm-loader-builder /opt/neon-evm/evm_loader/target/deploy/evm_loader-dump.txt /opt/
+COPY --from=evm-loader-builder /opt/neon-evm/evm_loader/target/release/neon-cli /opt/
+COPY --from=evm-loader-builder /opt/neon-evm/evm_loader/target/release/neon-api /opt/
 COPY --from=solana /usr/bin/spl-token /opt/spl-token
 COPY --from=contracts /opt/ /opt/solidity/
 COPY --from=contracts /usr/bin/solc /usr/bin/solc

--- a/evm_loader/Cargo.lock
+++ b/evm_loader/Cargo.lock
@@ -642,6 +642,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-info"
+version = "0.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b301350c1c448e35b896f32b68c49c8ecd969a71978fbafc4ebd09ec3f4eee2"
+dependencies = [
+ "build-info-common",
+ "build-info-proc",
+ "once_cell",
+]
+
+[[package]]
+name = "build-info-build"
+version = "0.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b314717755dd6a06fc11ad3f7909ba4c0ae2ab516f5cb0404fe924c71bfc7d0"
+dependencies = [
+ "anyhow",
+ "base64 0.21.4",
+ "bincode",
+ "build-info-common",
+ "cargo_metadata",
+ "chrono",
+ "git2",
+ "glob",
+ "once_cell",
+ "pretty_assertions",
+ "rustc_version",
+ "serde_json",
+ "xz2",
+]
+
+[[package]]
+name = "build-info-common"
+version = "0.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e040d36472d40ec9424c36a7b54be589072e605596b6f20b0c56c5230b460cc"
+dependencies = [
+ "chrono",
+ "derive_more",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "build-info-proc"
+version = "0.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd5f241ddd417436c48d35da9869480891449ddd1ae3fd483bbcfbae741a422"
+dependencies = [
+ "anyhow",
+ "base64 0.21.4",
+ "bincode",
+ "build-info-common",
+ "chrono",
+ "num-bigint 0.4.3",
+ "num-traits",
+ "proc-macro-error",
+ "proc-macro2 1.0.66",
+ "quote 1.0.32",
+ "serde_json",
+ "syn 2.0.28",
+ "xz2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,12 +755,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "caps"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190baaad529bcfbde9e1a19022c42781bdb6ff9de25721abdb8fd98c0807730b"
 dependencies = [
  "libc",
+ "thiserror",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
  "thiserror",
 ]
 
@@ -927,6 +1024,12 @@ name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -1203,6 +1306,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2 1.0.66",
+ "quote 1.0.32",
+ "rustc_version",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,6 +1329,12 @@ dependencies = [
  "tempfile",
  "zeroize",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -1672,6 +1794,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b989d6a7ca95a362cf2cfc5ad688b3a467be1f87e480b8dad07fee8c79b0044"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "goblin"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,6 +2261,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.15.2+1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a80df2e11fb4a61f4ba2ab42dbe7f74468da143f1a75c74e11dee7c813f694fa"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libsecp256k1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2165,6 +2318,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
 dependencies = [
  "libsecp256k1-core",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2225,6 +2390,17 @@ checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2422,6 +2598,8 @@ name = "neon-api"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "build-info",
+ "build-info-build",
  "clap 2.34.0",
  "ethnum",
  "evm-loader",
@@ -2446,6 +2624,8 @@ dependencies = [
 name = "neon-cli"
 version = "1.5.0-dev"
 dependencies = [
+ "build-info",
+ "build-info-build",
  "clap 2.34.0",
  "ethnum",
  "evm-loader",
@@ -2471,6 +2651,8 @@ dependencies = [
  "axum",
  "bincode",
  "bs58",
+ "build-info",
+ "build-info-build",
  "clickhouse",
  "ethnum",
  "evm-loader",
@@ -2931,6 +3113,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2947,6 +3139,30 @@ checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2 1.0.66",
+ "quote 1.0.32",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2 1.0.66",
+ "quote 1.0.32",
+ "version_check",
 ]
 
 [[package]]
@@ -3576,6 +3792,9 @@ name = "semver"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -5813,6 +6032,21 @@ dependencies = [
  "thiserror",
  "time 0.3.20",
 ]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yasna"

--- a/evm_loader/api/Cargo.toml
+++ b/evm_loader/api/Cargo.toml
@@ -25,3 +25,7 @@ http = "0.2.9"
 hyper = "0.14.27"
 tower-http = { version = "0.4.4", features = ["trace"] }
 hex = "0.4.2"
+build-info = { version = "0.0.31", features = ["serde"] }
+
+[build-dependencies]
+build-info-build = "0.0.31"

--- a/evm_loader/api/build.rs
+++ b/evm_loader/api/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    build_info_build::build_script();
+}

--- a/evm_loader/api/src/api_server/handlers/build_info.rs
+++ b/evm_loader/api/src/api_server/handlers/build_info.rs
@@ -1,0 +1,8 @@
+use crate::build_info::get_build_info;
+use axum::{http::StatusCode, Json};
+use neon_lib::build_info_common::SlimBuildInfo;
+
+#[tracing::instrument(ret)]
+pub async fn build_info() -> (StatusCode, Json<SlimBuildInfo>) {
+    (StatusCode::OK, Json(get_build_info()))
+}

--- a/evm_loader/api/src/api_server/handlers/mod.rs
+++ b/evm_loader/api/src/api_server/handlers/mod.rs
@@ -16,6 +16,7 @@ use std::net::AddrParseError;
 use std::str::FromStr;
 use tracing::error;
 
+pub mod build_info;
 pub mod emulate;
 pub mod get_ether_account_data;
 pub mod get_storage_at;

--- a/evm_loader/api/src/api_server/routes.rs
+++ b/evm_loader/api/src/api_server/routes.rs
@@ -7,7 +7,7 @@ use tower::ServiceBuilder;
 // use evm_loader::types::Address;
 use crate::{
     api_server::handlers::{
-        emulate::emulate, get_ether_account_data::get_ether_account_data,
+        build_info::build_info, emulate::emulate, get_ether_account_data::get_ether_account_data,
         get_storage_at::get_storage_at, trace::trace,
     },
     NeonApiState,
@@ -19,6 +19,7 @@ pub fn register() -> Router<NeonApiState> {
             .route("/emulate", post(emulate)) // Obsolete
             .route("/get-storage-at", get(get_storage_at))
             .route("/get-ether-account-data", get(get_ether_account_data))
-            .route("/trace", post(trace)),
+            .route("/trace", post(trace))
+            .route("/build-info", get(build_info)),
     )
 }

--- a/evm_loader/api/src/build_info.rs
+++ b/evm_loader/api/src/build_info.rs
@@ -1,0 +1,7 @@
+use neon_lib::build_info_common::SlimBuildInfo;
+
+build_info::build_info!(fn build_info);
+
+pub fn get_build_info() -> SlimBuildInfo {
+    build_info().into()
+}

--- a/evm_loader/api/src/main.rs
+++ b/evm_loader/api/src/main.rs
@@ -4,6 +4,8 @@
 mod api_context;
 mod api_options;
 mod api_server;
+#[allow(clippy::module_name_repetitions)]
+mod build_info;
 
 use api_server::handlers::NeonApiError;
 use axum::Router;
@@ -20,6 +22,7 @@ use tracing_appender::non_blocking::NonBlockingBuilder;
 use std::sync::Arc;
 use std::{env, net::SocketAddr, str::FromStr};
 
+use crate::build_info::get_build_info;
 pub use config::Config;
 pub use context::Context;
 use http::Request;
@@ -27,7 +30,7 @@ use hyper::Body;
 use tokio::signal::{self};
 use tower_http::trace::TraceLayer;
 use tower_request_id::{RequestId, RequestIdLayer};
-use tracing::info_span;
+use tracing::{info, info_span};
 
 type NeonApiResult<T> = Result<T, NeonApiError>;
 type NeonApiState = Arc<api_server::state::State>;
@@ -45,6 +48,8 @@ async fn main() -> NeonApiResult<()> {
         .with_thread_ids(true)
         .with_writer(non_blocking)
         .init();
+
+    info!("{}", get_build_info());
 
     let api_config = config::load_api_config_from_enviroment();
 

--- a/evm_loader/cli/Cargo.toml
+++ b/evm_loader/cli/Cargo.toml
@@ -20,3 +20,7 @@ fern = "0.6"
 ethnum = { version = "1.4", default-features = false, features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
 neon-lib = { path = "../lib" }
+build-info = { version = "0.0.31", features = ["serde"] }
+
+[build-dependencies]
+build-info-build = "0.0.31"

--- a/evm_loader/cli/build.rs
+++ b/evm_loader/cli/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    build_info_build::build_script();
+}

--- a/evm_loader/cli/src/build_info.rs
+++ b/evm_loader/cli/src/build_info.rs
@@ -1,0 +1,7 @@
+use neon_lib::build_info_common::SlimBuildInfo;
+
+build_info::build_info!(fn build_info);
+
+pub fn get_build_info() -> SlimBuildInfo {
+    build_info().into()
+}

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -1,6 +1,8 @@
 #![deny(warnings)]
 #![deny(clippy::all, clippy::pedantic)]
 
+#[allow(clippy::module_name_repetitions)]
+mod build_info;
 mod config;
 mod logs;
 mod program_options;
@@ -22,6 +24,7 @@ use std::io::Read;
 
 use ethnum::U256;
 use evm_loader::evm::tracing::TraceCallConfig;
+use log::debug;
 use serde_json::json;
 use solana_clap_utils::input_parsers::{pubkey_of, value_of, values_of};
 use solana_client::nonblocking::rpc_client::RpcClient;
@@ -30,6 +33,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tokio::time::Instant;
 
+use crate::build_info::get_build_info;
 use crate::{
     errors::NeonError,
     types::{TransactionParams, TxParams},
@@ -82,6 +86,8 @@ async fn main() {
         let message = std::format!("Panic: {info}");
         print_result(&Err(NeonError::Panic(message)));
     }));
+
+    debug!("{}", get_build_info());
 
     let result = run(&options).await;
 

--- a/evm_loader/lib/Cargo.toml
+++ b/evm_loader/lib/Cargo.toml
@@ -33,3 +33,7 @@ clickhouse = "0.11.5"
 tracing = "0.1"
 async-trait = "0.1.68"
 axum = "0.6"
+build-info = "0.0.31"
+
+[build-dependencies]
+build-info-build = "0.0.31"

--- a/evm_loader/lib/build.rs
+++ b/evm_loader/lib/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    build_info_build::build_script();
+}

--- a/evm_loader/lib/src/build_info.rs
+++ b/evm_loader/lib/src/build_info.rs
@@ -1,0 +1,7 @@
+use crate::build_info_common::SlimBuildInfo;
+
+build_info::build_info!(fn build_info);
+
+pub fn get_build_info() -> SlimBuildInfo {
+    build_info().into()
+}

--- a/evm_loader/lib/src/build_info_common.rs
+++ b/evm_loader/lib/src/build_info_common.rs
@@ -5,7 +5,7 @@ use build_info::{BuildInfo, OptimizationLevel};
 use serde::Serialize;
 use std::fmt::{Display, Formatter};
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct SlimBuildInfo {
     timestamp: DateTime<Utc>,
     profile: String,
@@ -15,18 +15,18 @@ pub struct SlimBuildInfo {
     version_control: GitInfo,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 struct CrateInfo {
     name: String,
     version: Version,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 struct CompilerInfo {
     version: Version,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 struct GitInfo {
     commit_id: String,
     dirty: bool,

--- a/evm_loader/lib/src/build_info_common.rs
+++ b/evm_loader/lib/src/build_info_common.rs
@@ -1,0 +1,76 @@
+use build_info::chrono::{DateTime, Utc};
+use build_info::semver::Version;
+use build_info::VersionControl::Git;
+use build_info::{BuildInfo, OptimizationLevel};
+use serde::Serialize;
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, Serialize)]
+pub struct SlimBuildInfo {
+    timestamp: DateTime<Utc>,
+    profile: String,
+    optimization_level: OptimizationLevel,
+    crate_info: CrateInfo,
+    compiler: CompilerInfo,
+    version_control: GitInfo,
+}
+
+#[derive(Debug, Serialize)]
+struct CrateInfo {
+    name: String,
+    version: Version,
+}
+
+#[derive(Debug, Serialize)]
+struct CompilerInfo {
+    version: Version,
+}
+
+#[derive(Debug, Serialize)]
+struct GitInfo {
+    commit_id: String,
+    dirty: bool,
+    branch: Option<String>,
+    tags: Vec<String>,
+}
+
+impl From<&BuildInfo> for SlimBuildInfo {
+    fn from(build_info: &BuildInfo) -> Self {
+        let build_info = build_info.clone();
+
+        let crate_info = build_info.crate_info;
+
+        let Git(git_info) = build_info
+            .version_control
+            .expect("Project should be built inside version control");
+
+        SlimBuildInfo {
+            timestamp: build_info.timestamp,
+            profile: build_info.profile,
+            optimization_level: build_info.optimization_level,
+            crate_info: CrateInfo {
+                name: crate_info.name,
+                version: crate_info.version,
+            },
+            compiler: CompilerInfo {
+                version: build_info.compiler.version,
+            },
+            version_control: GitInfo {
+                commit_id: git_info.commit_id,
+                dirty: git_info.dirty,
+                branch: git_info.branch,
+                tags: git_info.tags,
+            },
+        }
+    }
+}
+
+impl Display for SlimBuildInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "BuildInfo={}",
+            serde_json::to_string(&self).expect("Serialization should not fail")
+        )
+    }
+}

--- a/evm_loader/lib/src/commands/init_environment.rs
+++ b/evm_loader/lib/src/commands/init_environment.rs
@@ -139,14 +139,16 @@ pub async fn execute(
     let program_parameters = Parameters::new(read_elf_parameters(config, &data));
 
     let neon_revision = program_parameters.get::<String>("NEON_REVISION")?;
-    if neon_revision != env!("NEON_REVISION") {
+    let build_neon_revision =
+        build_info::format!("{}", $.version_control.unwrap().git().unwrap().commit_id);
+    if neon_revision != build_neon_revision {
         if force {
             warn!("NeonEVM revision doesn't match CLI revision. This check has been disabled with `--force` flag");
         } else {
             error!("NeonEVM revision doesn't match CLI revision. Use appropriate neon-cli version or add `--force` flag");
             return Err(EnvironmentError::RevisionMismatch(
                 neon_revision,
-                env!("NEON_REVISION").to_string(),
+                build_neon_revision.to_string(),
             )
             .into());
         }

--- a/evm_loader/lib/src/lib.rs
+++ b/evm_loader/lib/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod account_storage;
+pub mod build_info;
+pub mod build_info_common;
 pub mod commands;
 pub mod config;
 pub mod context;


### PR DESCRIPTION
Added `/api/build_info` endpoint with build info information extracted from [build-info](https://docs.rs/build-info/latest/build_info/) crate.

The API returns a slimmed-down version of build info data from [BuildInfo](https://docs.rs/build-info/latest/build_info/struct.BuildInfo.html) struct.

Example request:
```bash
curl --location 'http://0.0.0.0:8080/api/build-info'
```

Example response:
```json
{
    "timestamp": "2023-09-25T09:24:12.642987Z",
    "profile": "debug",
    "optimization_level": "O0",
    "crate_info": {
        "name": "neon-api",
        "version": "0.1.0"
    },
    "compiler": {
        "version": "1.69.0"
    },
    "version_control": {
        "commit_id": "b644f3a5aaab9e1c929c3bfe3c884dc24c615753",
        "dirty": false,
        "branch": "NDEV-2222",
        "tags": []
    }
}
```