### PR TITLE
NDEV-2252: Clean up tracer implementation

### DIFF
--- a/evm_loader/Cargo.lock
+++ b/evm_loader/Cargo.lock
@@ -3998,10 +3998,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
+ "indexmap 2.0.0",
  "itoa",
  "ryu",
  "serde",

--- a/evm_loader/api/Cargo.toml
+++ b/evm_loader/api/Cargo.toml
@@ -11,7 +11,7 @@ evm-loader = { path = "../program", default-features = false, features = ["log"]
 solana-sdk = "=1.16.15"
 solana-client = "=1.16.15"
 serde = "1.0.186"
-serde_json = "1.0.85"
+serde_json = { version = "1.0.107", features = ["preserve_order"] }
 ethnum = { version = "1.4", default-features = false, features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"

--- a/evm_loader/cli/Cargo.toml
+++ b/evm_loader/cli/Cargo.toml
@@ -14,7 +14,7 @@ solana-clap-utils = "=1.16.15"
 solana-cli-config = "=1.16.15"
 hex = "0.4.2"
 serde = "1.0.186"
-serde_json = "1.0.85"
+serde_json = { version = "1.0.107", features = ["preserve_order"] }
 log = "0.4.17"
 fern = "0.6"
 ethnum = { version = "1.4", default-features = false, features = ["serde"] }

--- a/evm_loader/lib/Cargo.toml
+++ b/evm_loader/lib/Cargo.toml
@@ -21,7 +21,7 @@ spl-associated-token-account = { version = "~1.1", default-features = false, fea
 bs58 = "0.4.0"
 hex = "0.4.2"
 serde = "1.0.186"
-serde_json = "1.0.105"
+serde_json = { version = "1.0.107", features = ["preserve_order"] }
 log = "0.4.17"
 rand = "0.8"
 ethnum = { version = "1.4", default-features = false, features = ["serde"] }

--- a/evm_loader/program/Cargo.toml
+++ b/evm_loader/program/Cargo.toml
@@ -51,7 +51,7 @@ borsh = "0.9"
 bincode = "1"
 serde_bytes = "0.11.12"
 serde = { version = "1.0.186", default-features = false, features = ["derive", "rc"] }
-serde_json = { version = "1.0.105", optional = true }
+serde_json = { version = "1.0.107", features = ["preserve_order"], optional = true }
 ethnum = { version = "1.4", default-features = false, features = ["serde"] }
 const_format = { version = "0.2.21" }
 cfg-if = { version = "1.0" }

--- a/evm_loader/program/src/evm/mod.rs
+++ b/evm_loader/program/src/evm/mod.rs
@@ -284,14 +284,8 @@ impl<B: Database> Machine<B> {
             call_data: trx.extract_call_data(),
             return_data: Buffer::empty(),
             return_range: 0..0,
-            stack: Stack::new(
-                #[cfg(not(target_os = "solana"))]
-                tracer.clone(),
-            ),
-            memory: Memory::new(
-                #[cfg(not(target_os = "solana"))]
-                tracer.clone(),
-            ),
+            stack: Stack::new(),
+            memory: Memory::new(),
             pc: 0_usize,
             is_static: false,
             reason: Reason::Call,
@@ -336,14 +330,8 @@ impl<B: Database> Machine<B> {
             gas_limit: trx.gas_limit(),
             return_data: Buffer::empty(),
             return_range: 0..0,
-            stack: Stack::new(
-                #[cfg(not(target_os = "solana"))]
-                tracer.clone(),
-            ),
-            memory: Memory::new(
-                #[cfg(not(target_os = "solana"))]
-                tracer.clone(),
-            ),
+            stack: Stack::new(),
+            memory: Memory::new(),
             pc: 0_usize,
             is_static: false,
             reason: Reason::Create,
@@ -449,14 +437,8 @@ impl<B: Database> Machine<B> {
             call_data,
             return_data: Buffer::empty(),
             return_range: 0..0,
-            stack: Stack::new(
-                #[cfg(not(target_os = "solana"))]
-                self.tracer.clone(),
-            ),
-            memory: Memory::new(
-                #[cfg(not(target_os = "solana"))]
-                self.tracer.clone(),
-            ),
+            stack: Stack::new(),
+            memory: Memory::new(),
             pc: 0_usize,
             is_static: self.is_static,
             reason,

--- a/evm_loader/program/src/evm/opcode.rs
+++ b/evm_loader/program/src/evm/opcode.rs
@@ -811,7 +811,6 @@ impl<B: Database> Machine<B> {
         let index = self.stack.pop_u256()?;
         let value = *self.stack.pop_array()?;
 
-        tracing_event!(self, super::tracing::Event::StorageSet { index, value });
         tracing_event!(self, super::tracing::Event::StorageAccess { index, value });
 
         backend.set_storage(self.context.contract, index, value)?;

--- a/evm_loader/program/src/evm/tracing/mod.rs
+++ b/evm_loader/program/src/evm/tracing/mod.rs
@@ -55,6 +55,7 @@ pub enum Event {
     },
 }
 
+/// See <https://github.com/ethereum/go-ethereum/blob/master/internal/ethapi/api.go#L993>
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BlockOverrides {
@@ -72,6 +73,7 @@ pub struct BlockOverrides {
     pub base_fee: Option<U256>, // NOT SUPPORTED BY Neon EVM
 }
 
+/// See <https://github.com/ethereum/go-ethereum/blob/master/internal/ethapi/api.go#L942>
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountOverride {
@@ -97,8 +99,10 @@ impl AccountOverride {
     }
 }
 
+/// See <https://github.com/ethereum/go-ethereum/blob/master/internal/ethapi/api.go#L951>
 pub type AccountOverrides = HashMap<Address, AccountOverride>;
 
+/// See <https://github.com/ethereum/go-ethereum/blob/master/eth/tracers/api.go#L151>
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[allow(clippy::module_name_repetitions, clippy::struct_excessive_bools)]
@@ -116,6 +120,7 @@ pub struct TraceConfig {
     pub tracer_config: Option<Value>,
 }
 
+/// See <https://github.com/ethereum/go-ethereum/blob/master/eth/tracers/api.go#L163>
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[allow(clippy::module_name_repetitions)]

--- a/evm_loader/program/src/evm/tracing/mod.rs
+++ b/evm_loader/program/src/evm/tracing/mod.rs
@@ -49,17 +49,6 @@ pub enum Event {
         gas_used: u64,
         return_data: Option<Vec<u8>>,
     },
-    StackPush {
-        value: [u8; 32],
-    },
-    MemorySet {
-        offset: usize,
-        data: Vec<u8>,
-    },
-    StorageSet {
-        index: U256,
-        value: [u8; 32],
-    },
     StorageAccess {
         index: U256,
         value: [u8; 32],

--- a/evm_loader/program/src/evm/tracing/mod.rs
+++ b/evm_loader/program/src/evm/tracing/mod.rs
@@ -124,7 +124,7 @@ pub struct TraceConfig {
     pub enable_return_data: bool,
     pub tracer: Option<String>,
     pub timeout: Option<String>,
-    pub tracer_config: Value,
+    pub tracer_config: Option<Value>,
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]

--- a/evm_loader/program/src/evm/tracing/tracers/struct_logger.rs
+++ b/evm_loader/program/src/evm/tracing/tracers/struct_logger.rs
@@ -12,13 +12,14 @@ use crate::types::hexbytes::HexBytes;
 /// `StructLoggerResult` groups all structured logs emitted by the EVM
 /// while replaying a transaction in debug mode as well as transaction
 /// execution status, the amount of gas used and the return value
+/// see <https://github.com/ethereum/go-ethereum/blob/master/eth/tracers/logger/logger.go#L404>
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct StructLoggerResult {
-    /// Is execution failed or not
-    pub failed: bool,
     /// Total used gas but include the refunded gas
     pub gas: u64,
+    /// Is execution failed or not
+    pub failed: bool,
     /// The data after execution or revert reason
     pub return_value: String,
     /// Logs emitted during execution
@@ -27,6 +28,7 @@ pub struct StructLoggerResult {
 
 /// `StructLog` stores a structured log emitted by the EVM while replaying a
 /// transaction in debug mode
+/// see <https://github.com/ethereum/go-ethereum/blob/master/eth/tracers/logger/logger.go#L413>
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct StructLog {
@@ -35,24 +37,34 @@ pub struct StructLog {
     /// Operation name
     op: &'static str,
     /// Amount of used gas
-    gas: Option<u64>,
+    gas: u64,
     /// Gas cost for this instruction.
     gas_cost: u64,
     /// Current depth
     depth: usize,
-    /// Snapshot of the current memory sate
     #[serde(skip_serializing_if = "Option::is_none")]
-    memory: Option<Vec<HexBytes>>, // U256 sized chunks
+    error: Option<String>,
     /// Snapshot of the current stack sate
     #[serde(skip_serializing_if = "Option::is_none")]
     stack: Option<Vec<U256>>,
-    /// Result of the step
+    #[serde(skip_serializing_if = "Option::is_none")]
     return_data: Option<HexBytes>,
+    /// Snapshot of the current memory sate
+    #[serde(skip_serializing_if = "Option::is_none")]
+    memory: Option<Vec<String>>, // chunks of 32 bytes
+    /// Result of the step
     /// Snapshot of the current storage
     #[serde(skip_serializing_if = "Option::is_none")]
-    storage: Option<BTreeMap<U256, U256>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    error: Option<String>,
+    storage: Option<BTreeMap<String, String>>,
+    /// Refund counter
+    #[serde(skip_serializing_if = "is_zero")]
+    refund: u64,
+}
+
+/// This is only used for serialize
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_zero(num: &u64) -> bool {
+    *num == 0
 }
 
 impl StructLog {
@@ -62,22 +74,22 @@ impl StructLog {
         pc: u64,
         gas_cost: u64,
         depth: usize,
-        memory: Option<Vec<HexBytes>>,
+        memory: Option<Vec<String>>,
         stack: Option<Vec<U256>>,
-        storage: Option<BTreeMap<U256, U256>>,
     ) -> Self {
         let op = OPNAMES[opcode as usize];
         Self {
             pc,
             op,
-            gas: None,
+            gas: 0,
             gas_cost,
             depth,
             memory,
             stack,
             return_data: None,
-            storage,
+            storage: None,
             error: None,
+            refund: 0,
         }
     }
 }
@@ -148,27 +160,13 @@ impl EventListener for StructLogger {
                     )
                 };
 
-                let memory = if !self.config.enable_memory || memory.is_empty() {
-                    None
+                let memory = if self.config.enable_memory {
+                    Some(memory.chunks(32).map(hex::encode).collect())
                 } else {
-                    Some(
-                        memory
-                            .chunks(32)
-                            .map(|slice| slice.to_vec().into())
-                            .collect(),
-                    )
+                    None
                 };
 
-                let storage = if self.config.disable_storage {
-                    None
-                } else {
-                    self.logs
-                        .last()
-                        .and_then(|log| log.storage.clone())
-                        .or(None)
-                };
-
-                let log = StructLog::new(opcode, pc as u64, 0, self.depth, memory, stack, storage);
+                let log = StructLog::new(opcode, pc as u64, 0, self.depth, memory, stack);
                 self.logs.push(log);
             }
             Event::EndStep {
@@ -179,12 +177,13 @@ impl EventListener for StructLogger {
                     .logs
                     .last_mut()
                     .expect("`EndStep` event before `BeginStep`");
-                last.gas = Some(gas_used);
+                last.gas = gas_used;
                 if !self.config.disable_storage {
                     if let Some((index, value)) = self.storage_access.take() {
-                        last.storage
-                            .get_or_insert_with(Default::default)
-                            .insert(index, value);
+                        last.storage.get_or_insert_with(Default::default).insert(
+                            hex::encode(index.to_be_bytes()),
+                            hex::encode(value.to_be_bytes()),
+                        );
                     };
                 }
                 if self.config.enable_return_data {
@@ -215,5 +214,86 @@ impl EventListener for StructLogger {
         };
 
         serde_json::to_value(result).expect("Conversion error")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serialize_struct_logger_result_all_fields() {
+        let struct_logger_result = StructLoggerResult {
+            gas: 20000,
+            failed: false,
+            return_value: "000000000000000000000000000000000000000000000000000000000000001b"
+                .to_string(),
+            struct_logs: vec![StructLog {
+                pc: 8,
+                op: "PUSH2",
+                gas: 0,
+                gas_cost: 0,
+                depth: 1,
+                stack: Some(vec![U256::from(0u8), U256::from(1u8)]),
+                memory: Some(vec![
+                    "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+                    "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+                    "0000000000000000000000000000000000000000000000000000000000000080".to_string(),
+                ]),
+                return_data: None,
+                storage: None,
+                refund: 0,
+                error: None,
+            }],
+        };
+        assert_eq!(serde_json::to_string(&struct_logger_result).unwrap(), "{\"gas\":20000,\"failed\":false,\"returnValue\":\"000000000000000000000000000000000000000000000000000000000000001b\",\"structLogs\":[{\"pc\":8,\"op\":\"PUSH2\",\"gas\":0,\"gasCost\":0,\"depth\":1,\"stack\":[\"0x0\",\"0x1\"],\"memory\":[\"0000000000000000000000000000000000000000000000000000000000000000\",\"0000000000000000000000000000000000000000000000000000000000000000\",\"0000000000000000000000000000000000000000000000000000000000000080\"]}]}");
+    }
+
+    #[test]
+    fn test_serialize_struct_logger_result_no_optional_fields() {
+        let struct_logger_result = StructLoggerResult {
+            gas: 20000,
+            failed: false,
+            return_value: "000000000000000000000000000000000000000000000000000000000000001b"
+                .to_string(),
+            struct_logs: vec![StructLog {
+                pc: 0,
+                op: "PUSH1",
+                gas: 0,
+                gas_cost: 0,
+                depth: 1,
+                stack: None,
+                memory: None,
+                return_data: None,
+                storage: None,
+                refund: 0,
+                error: None,
+            }],
+        };
+        assert_eq!(serde_json::to_string(&struct_logger_result).unwrap(), "{\"gas\":20000,\"failed\":false,\"returnValue\":\"000000000000000000000000000000000000000000000000000000000000001b\",\"structLogs\":[{\"pc\":0,\"op\":\"PUSH1\",\"gas\":0,\"gasCost\":0,\"depth\":1}]}");
+    }
+
+    #[test]
+    fn test_serialize_struct_logger_result_empty_stack_empty_memory() {
+        let struct_logger_result = StructLoggerResult {
+            gas: 20000,
+            failed: false,
+            return_value: "000000000000000000000000000000000000000000000000000000000000001b"
+                .to_string(),
+            struct_logs: vec![StructLog {
+                pc: 0,
+                op: "PUSH1",
+                gas: 0,
+                gas_cost: 0,
+                depth: 1,
+                stack: Some(vec![]),
+                memory: Some(vec![]),
+                return_data: None,
+                storage: None,
+                refund: 0,
+                error: None,
+            }],
+        };
+        assert_eq!(serde_json::to_string(&struct_logger_result).unwrap(), "{\"gas\":20000,\"failed\":false,\"returnValue\":\"000000000000000000000000000000000000000000000000000000000000001b\",\"structLogs\":[{\"pc\":0,\"op\":\"PUSH1\",\"gas\":0,\"gasCost\":0,\"depth\":1,\"stack\":[],\"memory\":[]}]}");
     }
 }

--- a/evm_loader/program/src/evm/tracing/tracers/struct_logger.rs
+++ b/evm_loader/program/src/evm/tracing/tracers/struct_logger.rs
@@ -190,10 +190,11 @@ impl EventListener for StructLogger {
                     last.return_data = return_data.map(Into::into);
                 }
             }
-            Event::StorageAccess { index, value } if !self.config.disable_storage => {
-                self.storage_access = Some((index, U256::from_be_bytes(value)));
+            Event::StorageAccess { index, value } => {
+                if !self.config.disable_storage {
+                    self.storage_access = Some((index, U256::from_be_bytes(value)));
+                }
             }
-            _ => (),
         };
     }
 


### PR DESCRIPTION
All changes in this PR have been tested by sending `debug_traceCall` to both Go Ethereum and Tracer API and comparing the returned JSON.

- Enabled `serde_json` `"preserve_order"` feature so `StructLog` field order is preserved in JSON response bodies for debug calls.
- Reordered some fields of `StructLog` and `StructLoggerResult` to match the order of fields returned by Go Ethereum debug methods.
- Storage is output only on `SLOAD` and `SSTORE` opcodes, in hex format without `0x` prefix. 
- Made field `tracerConfig` optional, as it is in Go Ethereum.
- Memory is output in hex format without `0x` prefix. Empty memory is serialized as an empty JSON array.
- Apart from used `gas`, `gas` and `gasCost` `StructLog` fields being always `0` on NeonEVM, `debug_traceCall` output is identical to Go Ethereum one for Storage contract.
- Removed unused `Event` enum variants.