### PR TITLE
Add 'write version' to EmulateRequestModel

### DIFF
--- a/evm_loader/api/src/api_context.rs
+++ b/evm_loader/api/src/api_context.rs
@@ -6,19 +6,21 @@ use std::sync::Arc;
 pub async fn build_rpc_client(
     state: &NeonApiState,
     slot: Option<u64>,
+    tx_index_in_block: Option<u64>,
 ) -> Result<Arc<dyn rpc::Rpc>, NeonError> {
     if let Some(slot) = slot {
-        return build_call_db_client(state, slot).await;
+        build_call_db_client(state, slot, tx_index_in_block).await
+    } else {
+        Ok(state.rpc_client.clone())
     }
-
-    Ok(state.rpc_client.clone())
 }
 
 pub async fn build_call_db_client(
     state: &NeonApiState,
     slot: u64,
+    tx_index_in_block: Option<u64>,
 ) -> Result<Arc<dyn rpc::Rpc>, NeonError> {
     Ok(Arc::new(
-        CallDbClient::new(state.tracer_db.clone(), slot).await?,
+        CallDbClient::new(state.tracer_db.clone(), slot, tx_index_in_block).await?,
     ))
 }

--- a/evm_loader/api/src/api_server/handlers/emulate.rs
+++ b/evm_loader/api/src/api_server/handlers/emulate.rs
@@ -19,7 +19,13 @@ pub async fn emulate(
 ) -> impl Responder {
     let tx = emulate_request.tx_params.into();
 
-    let rpc_client = match api_context::build_rpc_client(&state, emulate_request.slot).await {
+    let rpc_client = match api_context::build_rpc_client(
+        &state,
+        emulate_request.slot,
+        emulate_request.tx_index_in_block,
+    )
+    .await
+    {
         Ok(rpc_client) => rpc_client,
         Err(e) => return process_error(StatusCode::BAD_REQUEST, &e),
     };

--- a/evm_loader/api/src/api_server/handlers/get_ether_account_data.rs
+++ b/evm_loader/api/src/api_server/handlers/get_ether_account_data.rs
@@ -14,7 +14,7 @@ pub async fn get_ether_account_data(
     request_id: RequestId,
     Query(req_params): Query<GetEtherRequest>,
 ) -> impl Responder {
-    let rpc_client = match api_context::build_rpc_client(&state, req_params.slot).await {
+    let rpc_client = match api_context::build_rpc_client(&state, req_params.slot, None).await {
         Ok(rpc_client) => rpc_client,
         Err(e) => return process_error(StatusCode::BAD_REQUEST, &e),
     };

--- a/evm_loader/api/src/api_server/handlers/get_storage_at.rs
+++ b/evm_loader/api/src/api_server/handlers/get_storage_at.rs
@@ -17,7 +17,7 @@ pub async fn get_storage_at(
     request_id: RequestId,
     Query(req_params): Query<GetStorageAtRequest>,
 ) -> impl Responder {
-    let rpc_client = match api_context::build_rpc_client(&state, req_params.slot).await {
+    let rpc_client = match api_context::build_rpc_client(&state, req_params.slot, None).await {
         Ok(rpc_client) => rpc_client,
         Err(e) => return process_error(StatusCode::BAD_REQUEST, &e),
     };

--- a/evm_loader/api/src/api_server/handlers/trace.rs
+++ b/evm_loader/api/src/api_server/handlers/trace.rs
@@ -19,11 +19,16 @@ pub async fn trace(
 ) -> impl Responder {
     let tx = trace_request.emulate_request.tx_params.into();
 
-    let rpc_client =
-        match api_context::build_rpc_client(&state, trace_request.emulate_request.slot).await {
-            Ok(rpc_client) => rpc_client,
-            Err(e) => return process_error(StatusCode::BAD_REQUEST, &e),
-        };
+    let rpc_client = match api_context::build_rpc_client(
+        &state,
+        trace_request.emulate_request.slot,
+        trace_request.emulate_request.tx_index_in_block,
+    )
+    .await
+    {
+        Ok(rpc_client) => rpc_client,
+        Err(e) => return process_error(StatusCode::BAD_REQUEST, &e),
+    };
 
     let context = Context::new(&*rpc_client, &state.config);
 

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -59,6 +59,7 @@ async fn run<'a>(options: &'a ArgMatches<'a>) -> NeonCliResult {
             CallDbClient::new(
                 TracerDb::new(config.db_config.as_ref().expect("db-config not found")),
                 slot,
+                None,
             )
             .await?,
         )

--- a/evm_loader/lib/src/rpc/db_call_client.rs
+++ b/evm_loader/lib/src/rpc/db_call_client.rs
@@ -24,11 +24,16 @@ use std::any::Any;
 
 pub struct CallDbClient {
     tracer_db: TracerDb,
-    pub slot: u64,
+    slot: u64,
+    tx_index_in_block: Option<u64>,
 }
 
 impl CallDbClient {
-    pub async fn new(tracer_db: TracerDb, slot: u64) -> Result<Self, NeonError> {
+    pub async fn new(
+        tracer_db: TracerDb,
+        slot: u64,
+        tx_index_in_block: Option<u64>,
+    ) -> Result<Self, NeonError> {
         let earliest_rooted_slot = tracer_db
             .get_earliest_rooted_slot()
             .await
@@ -37,7 +42,11 @@ impl CallDbClient {
             return Err(NeonError::EarlySlot(slot, earliest_rooted_slot));
         }
 
-        Ok(Self { tracer_db, slot })
+        Ok(Self {
+            tracer_db,
+            slot,
+            tx_index_in_block,
+        })
     }
 }
 
@@ -60,7 +69,7 @@ impl Rpc for CallDbClient {
 
     async fn get_account(&self, key: &Pubkey) -> ClientResult<Account> {
         self.tracer_db
-            .get_account_at(key, self.slot)
+            .get_account_at(key, self.slot, self.tx_index_in_block)
             .await
             .map_err(|e| e!("load account error", key, e))?
             .ok_or_else(|| e!("account not found", key))
@@ -73,7 +82,7 @@ impl Rpc for CallDbClient {
     ) -> RpcResult<Option<Account>> {
         let account = self
             .tracer_db
-            .get_account_at(key, self.slot)
+            .get_account_at(key, self.slot, self.tx_index_in_block)
             .await
             .map_err(|e| e!("load account error", key, e))?;
 
@@ -95,7 +104,7 @@ impl Rpc for CallDbClient {
         for key in pubkeys {
             let account = self
                 .tracer_db
-                .get_account_at(key, self.slot)
+                .get_account_at(key, self.slot, self.tx_index_in_block)
                 .await
                 .map_err(|e| e!("load account error", key, e))?;
             result.push(account);

--- a/evm_loader/lib/src/types/request_models.rs
+++ b/evm_loader/lib/src/types/request_models.rs
@@ -102,6 +102,7 @@ pub struct EmulateRequestModel {
     #[serde(flatten)]
     pub emulation_params: EmulationParamsRequestModel,
     pub slot: Option<u64>,
+    pub tx_index_in_block: Option<u64>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Default)]

--- a/evm_loader/lib/src/types/tracer_ch_db.rs
+++ b/evm_loader/lib/src/types/tracer_ch_db.rs
@@ -221,8 +221,15 @@ impl ClickHouseDb {
     }
 
     #[allow(clippy::too_many_lines)]
-    pub async fn get_account_at(&self, pubkey: &Pubkey, slot: u64) -> ChResult<Option<Account>> {
-        info!("get_account_at {{ pubkey: {pubkey}, slot: {slot} }}");
+    pub async fn get_account_at(
+        &self,
+        pubkey: &Pubkey,
+        slot: u64,
+        tx_index_in_block: Option<u64>,
+    ) -> ChResult<Option<Account>> {
+        info!(
+            "get_account_at {{ pubkey: {pubkey}, slot: {slot}, tx index in block: {tx_index_in_block:?} }}"
+        );
         let (first, mut branch) = self.get_branch_slots(Some(slot)).await.map_err(|e| {
             println!("get_branch_slots error: {:?}", e);
             e
@@ -244,24 +251,35 @@ impl ClickHouseDb {
         let mut row = if branch.is_empty() {
             None
         } else {
-            let query = r#"
-                SELECT owner, lamports, executable, rent_epoch, data, txn_signature
-                FROM events.update_account_distributed
-                WHERE pubkey = ?
-                  AND slot IN ?
-                ORDER BY pubkey, slot DESC, write_version DESC
-                LIMIT 1
-            "#;
+            let query = if tx_index_in_block.is_some() {
+                r#"
+                    SELECT owner, lamports, executable, rent_epoch, data, txn_signature
+                    FROM events.update_account_distributed
+                    WHERE pubkey = ?
+                      AND write_version = ?
+                      AND slot IN ?
+                    ORDER BY slot DESC, write_version DESC
+                    LIMIT 1
+                "#
+            } else {
+                r#"
+                    SELECT owner, lamports, executable, rent_epoch, data, txn_signature
+                    FROM events.update_account_distributed
+                    WHERE pubkey = ?
+                      AND slot IN ?
+                    ORDER BY slot DESC, write_version DESC
+                    LIMIT 1
+                "#
+            };
 
             let time_start = Instant::now();
-            let row = Self::row_opt(
-                self.client
-                    .query(query)
-                    .bind(pubkey_str.clone())
-                    .bind(branch.as_slice())
-                    .fetch_one::<AccountRow>()
-                    .await,
-            )
+            let row = Self::row_opt({
+                let mut row = self.client.query(query).bind(pubkey_str.clone());
+                if let Some(tx_index_in_block) = tx_index_in_block {
+                    row = row.bind(tx_index_in_block);
+                }
+                row.bind(branch.as_slice()).fetch_one::<AccountRow>().await
+            })
             .map_err(|e| {
                 println!("get_account_at error: {e}");
                 ChError::Db(e)
@@ -470,7 +488,7 @@ impl ClickHouseDb {
 
         // If not found, get closest account state in one of previous slots
         if let Some(parent) = slot.parent {
-            self.get_account_at(pubkey, parent).await
+            self.get_account_at(pubkey, parent, None).await
         } else {
             Ok(None)
         }


### PR DESCRIPTION
The write version is needed to correctly trace transactions because we need the exact state of the accounts.

Related to https://github.com/neonlabsorg/tracer-api/pull/67.