### PR TITLE
[v1.4.x] Add batch request for get-ether-account-data

### DIFF
--- a/evm_loader/api/src/main.rs
+++ b/evm_loader/api/src/main.rs
@@ -23,6 +23,7 @@ use std::{env, net::SocketAddr, str::FromStr};
 
 use crate::api_server::handlers::build_info::build_info_route;
 use crate::api_server::handlers::emulate::emulate;
+use crate::api_server::handlers::get_ether_account_data::get_batch_ether_account_data;
 use crate::api_server::handlers::get_ether_account_data::get_ether_account_data;
 use crate::api_server::handlers::get_storage_at::get_storage_at;
 use crate::api_server::handlers::trace::trace;
@@ -70,6 +71,7 @@ async fn main() -> NeonApiResult<()> {
                 .service(build_info_route)
                 .service(emulate)
                 .service(get_ether_account_data)
+                .service(get_batch_ether_account_data)
                 .service(get_storage_at)
                 .service(trace)
                 .wrap(RequestIdentifier::with_uuid()),

--- a/evm_loader/lib/src/commands/get_ether_account_data.rs
+++ b/evm_loader/lib/src/commands/get_ether_account_data.rs
@@ -1,6 +1,7 @@
+use ethnum::U256;
 use evm_loader::{account::EthereumAccount, types::Address};
 use serde::{Deserialize, Serialize};
-use solana_sdk::pubkey::Pubkey;
+use solana_sdk::{account::Account, pubkey::Pubkey};
 use std::fmt::{Display, Formatter};
 
 use crate::{
@@ -21,6 +22,54 @@ pub struct GetEtherAccountDataReturn {
     pub generation: u32,
     pub code_size: u32,
     pub code: String,
+}
+
+impl GetEtherAccountDataReturn {
+    pub fn new(
+        program_id: &Pubkey,
+        address: Address,
+        pubkey: Pubkey,
+        account: Option<Account>,
+    ) -> Self {
+        let Some(mut account) = account else {
+            return Self::empty(address, pubkey);
+        };
+
+        let info = account_info(&pubkey, &mut account);
+        let Ok(account_data) = EthereumAccount::from_account(program_id, &info) else {
+            return Self::empty(address, pubkey);
+        };
+
+        let contract_code = account_data
+            .contract_data()
+            .map_or_else(Vec::new, |c| c.code().to_vec());
+
+        GetEtherAccountDataReturn {
+            solana_address: pubkey.to_string(),
+            address,
+            bump_seed: account_data.bump_seed,
+            trx_count: account_data.trx_count,
+            rw_blocked: account_data.rw_blocked,
+            balance: account_data.balance.to_string(),
+            generation: account_data.generation,
+            code_size: account_data.code_size,
+            code: hex::encode(contract_code),
+        }
+    }
+
+    pub fn empty(address: Address, pubkey: Pubkey) -> Self {
+        Self {
+            solana_address: pubkey.to_string(),
+            address,
+            bump_seed: 0,
+            trx_count: 0,
+            rw_blocked: false,
+            balance: U256::ZERO.to_string(),
+            generation: 0,
+            code_size: 0,
+            code: String::new(),
+        }
+    }
 }
 
 impl Display for GetEtherAccountDataReturn {
@@ -67,4 +116,26 @@ pub async fn execute(
         }
         (solana_address, None) => Err(NeonError::AccountNotFound(solana_address)),
     }
+}
+
+pub async fn execute_batch(
+    rpc_client: &dyn Rpc,
+    evm_loader: &Pubkey,
+    addresses: &[Address],
+) -> NeonResult<Vec<GetEtherAccountDataReturn>> {
+    let pubkeys: Vec<Pubkey> = addresses
+        .iter()
+        .map(|a| a.find_solana_address(evm_loader).0)
+        .collect();
+
+    let accounts = rpc_client.get_multiple_accounts(&pubkeys).await?;
+
+    Ok(addresses
+        .iter()
+        .zip(pubkeys)
+        .zip(accounts)
+        .map(|((address, pubkey), account)| {
+            GetEtherAccountDataReturn::new(evm_loader, *address, pubkey, account)
+        })
+        .collect())
 }

--- a/evm_loader/lib/src/types/request_models.rs
+++ b/evm_loader/lib/src/types/request_models.rs
@@ -16,6 +16,12 @@ pub struct GetEtherRequest {
 }
 
 #[derive(Deserialize, Serialize, Debug, Default)]
+pub struct GetEtherBatchRequest {
+    pub ether: Vec<Address>,
+    pub slot: Option<u64>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Default)]
 pub struct GetStorageAtRequest {
     pub contract_id: Address,
     pub index: U256,


### PR DESCRIPTION
This should significantly reduce the number of requests to Solana node from proxy through the API.
For `develop` branch the same feature will be implemented as part of the Multiple Tokens epic.