### PR TITLE
NDEV-2366: Update Solana dependencies to 1.16.18

### DIFF
--- a/.github/workflows/deploy.py
+++ b/.github/workflows/deploy.py
@@ -31,8 +31,8 @@ DOCKER_USER = os.environ.get("DHUBU")
 DOCKER_PASSWORD = os.environ.get("DHUBP")
 IMAGE_NAME = os.environ.get("IMAGE_NAME")
 RUN_LINK_REPO = os.environ.get("RUN_LINK_REPO")
-SOLANA_NODE_VERSION = 'v1.16.17'
-SOLANA_BPF_VERSION = 'v1.16.17'
+SOLANA_NODE_VERSION = 'v1.16.18'
+SOLANA_BPF_VERSION = 'v1.16.18'
 
 VERSION_BRANCH_TEMPLATE = r"[vt]{1}\d{1,2}\.\d{1,2}\.x.*"
 docker_client = docker.APIClient()

--- a/evm_loader/Cargo.lock
+++ b/evm_loader/Cargo.lock
@@ -4266,9 +4266,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121e55656c2094950f374247e1303dd09517f1ed49c91bf60bf114760b286eb4"
+checksum = "83da6908b4865a9680c4fcb5e77d319467fdc5ab96a6ccc8361e7110ebcd206e"
 dependencies = [
  "Inflector",
  "base64 0.21.4",
@@ -4291,9 +4291,9 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ccb31f7f14d5876acd9ec38f5bf6097bfb4b350141d81c7ff2bf684db3ca815"
+checksum = "9102429e980b8e58f05e39a2aceb799fc1fd7b81e440bc70322854e0debb21dc"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -4312,9 +4312,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6302bcae9ca7cddffc5af54c9407abbbb14b94539300aca01d879a3f23379f42"
+checksum = "009b84c1ac3f6b9cb53a8f133c43efeaa4a6e8e46f9ddfa616f9d1f04c551a76"
 dependencies = [
  "bincode",
  "byteorder",
@@ -4331,9 +4331,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a8150d4ff694d9587496a5976d33e6ebdb16cc61c6338bdfe3b2fc2c7c4986"
+checksum = "fe15843171a435eed014e7180f62c0d5e7e8178f7eaf4da0077ea21354506e2a"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -4349,9 +4349,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b209b925e75e6080f019ed44d134ec9d687eede1156641e1723e808f2a62dec"
+checksum = "15d042a7d26b5c0152dbb2ab3dbbbf62ea13e238e3344fcd7d3790a4f6abd04f"
 dependencies = [
  "bincode",
  "bs58",
@@ -4400,9 +4400,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6017eea88d739fae5f6f4f3f2779a68ad16cadf2f714baccad9714400cf93460"
+checksum = "6430afcc4444bd3b7b16b9314f0ae533344d0cd9bbbd160fb47cb45f9689a801"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -4416,9 +4416,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e049558c43fc0c9e8faf5d6aba3d4c56d0491c139f55427be4a9c5f26aec6a78"
+checksum = "88e1902f40e61a873317c3f296e56333bb52258ca717813990eac1ae8ba8670c"
 dependencies = [
  "Inflector",
  "base64 0.21.4",
@@ -4443,9 +4443,9 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35d7582847ab4d60652ff640ca574647789461c1630e8c7580ff770738c3d7f4"
+checksum = "38917c4655a42881fd2998c5c7626fa4cee9f95d5877592b347b213782782145"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4476,9 +4476,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94dc0f4463daf1c6155f20eac948ea4ced705e5f5520546aef4e11e746a6d95d"
+checksum = "b8c2804d121a6d87f4b0cb861dc26e677e76953f4888a43292e34c5e6c5f2852"
 dependencies = [
  "bincode",
  "chrono",
@@ -4490,9 +4490,9 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758587d44e05a4abdf82b9514d1c8b7d35637ad65f7af7c3e3e02417aaae3c9e"
+checksum = "2fe0460a6005bb2d9ee1d4bce9379ff50c1b438f6f1c8dc867d8b74141f68349"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4511,9 +4511,9 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0b7dfac6dd9a1cd3829fc230ed348f4972934800d754db73e2b434c16dafafd"
+checksum = "e7bfbf4c31ec25ef12ca89a93ad10e23909249a6bf91f2ad7ca9ce3d510019bb"
 dependencies = [
  "bincode",
  "byteorder",
@@ -4535,9 +4535,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266bf0311bb403d31206aa2904b8741f57c7f5e27580b6810ad5e22fc7c3282"
+checksum = "8a63aebf4beac713a1949216ae180355c044df9cc3db9a58ca153bb10bb5843b"
 dependencies = [
  "ahash 0.8.3",
  "blake3",
@@ -4568,9 +4568,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfe18c5155015dcb494c6de84a03b725fcf90ec2006a047769018b94c2cf0de"
+checksum = "bced1b3c0421605312fd7eae7ceb6850d3b1d2e939da349c928e6d46a945c829"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.32",
@@ -4580,9 +4580,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f76fe25c2d06dcf621befd1e8d5655143e8a059c7e20fcb71736bc80ed779d6"
+checksum = "c95311f23906f0fa4a6d995f3c39593db18e4d943e4d3fbf082a510d0881d7af"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -4591,9 +4591,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db165b8a7f5d840abef011c78a18ffe63cad9192d676b07d94f469b6b5dc6cf6"
+checksum = "944244553c62855c57d05ac049140762f1e095188a0e5b973b859947ac1d00bf"
 dependencies = [
  "log",
  "solana-sdk",
@@ -4601,9 +4601,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa01731bb3952904962d49a1ea1205db54e93f3a56f4006d32e02a7c85d60546"
+checksum = "f02b2244ee93fd282f057146ce779987a96cdeba5615d43dc0b6347b96134772"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -4615,9 +4615,9 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7ab67329dcebe4a40673fd0da27373282b1359ec7945e0fb81a9c594bcd057"
+checksum = "f1dad26635fb41e948f56e1b896eab10e84cc62e00c59109a428a95c78fd6560"
 dependencies = [
  "bincode",
  "clap 3.2.23",
@@ -4637,9 +4637,9 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f900c1015844087cd4f10ba9d2d26a9859f2f5ca07427865cc74942595abc0a7"
+checksum = "b03a0782c2b62c476c3fafd4e002ad8d91a2e36ca952df8e965d81dbf1dc158d"
 dependencies = [
  "ahash 0.8.3",
  "bincode",
@@ -4664,9 +4664,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb16998986492de307eef503ce47e84503d35baa92dc60832b22476948b1c16"
+checksum = "e1f5c12cb15108734adae20be5e922c2db09d9623099541dcc61790703c6271c"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -4719,9 +4719,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "036d6ecf67a3a7c6dc74d4f7fa6ab321e7ce8feccb7c9dff8384a41d0a12345b"
+checksum = "eb7d1b8df43a93c410456be7d41c0dca9e2c460530a075243a98f556391d2bf9"
 dependencies = [
  "base64 0.21.4",
  "bincode",
@@ -4747,9 +4747,9 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e318f46bedb39374e98f299266a155b2c81c9d920f3c90f761261267c275c1"
+checksum = "3b06d8521ac6edf8e8080cb5411f3b831a400341274036528a6364d52f2a97a4"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -4772,9 +4772,9 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61db18a804642f8eb37369e903774a85d7949a55bd204ec090ebe0742fd2fe32"
+checksum = "4cba7522b79c889136f99aef825f874be07e94afef561b85a13e9ea3c012d778"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -4800,9 +4800,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805377478f2d413f6cfcba6924c81ac4988ac0f96cdb045a8a9d81c430e6622a"
+checksum = "dd2081d1ed74301999e73e437c25c17dca82038e5472e104caf34b2657b3ba4a"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -4810,9 +4810,9 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1148dcd76f76ad0399c1d9abf05cb32a0e545c5bee47ebe6d3b3e800c7fa7c"
+checksum = "0a08a9c833b21fe9ec6ab74ea271de236cf7fd2602f34283752bba9c25d62304"
 dependencies = [
  "console",
  "dialoguer",
@@ -4830,9 +4830,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc51a85c6ff03bb4a3e1fde1e36dcb553b990f2b3e66aed941a31a6a7c20fa33"
+checksum = "1301ef82a9e87afb28bfccab1b3ebf8f10d6d2ee42c5b1d793ab989d70f83e27"
 dependencies = [
  "async-trait",
  "base64 0.21.4",
@@ -4856,9 +4856,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6756a1f89f509154644a958869c7cc6c70cc622f44faddf9b94612d8d2d8eed5"
+checksum = "9ffdfe666315851d1a5c3d426a688dccfd2af19b46667140ea59b9ddf3988038"
 dependencies = [
  "base64 0.21.4",
  "bs58",
@@ -4878,9 +4878,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850e8db607525a36d330f073703e78e908a54ac66aa323a44cfc12c14c16699"
+checksum = "d45f9be345ea2d29eb2c43d4b9a4c5181513f0af3e366be8b5e478ef451177be"
 dependencies = [
  "clap 2.34.0",
  "solana-clap-utils",
@@ -4891,9 +4891,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4106cda3d10833ba957dbd25fb841b50aeca7480ccf8f54859294716f54bcd4b"
+checksum = "051b93dc7737a7fb530c1e74f135a652bb69f5554c8804b2ebf55d6fb6a30f26"
 dependencies = [
  "assert_matches",
  "base64 0.21.4",
@@ -4944,9 +4944,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e560806a3859717eb2220b26e2cd68bb757b63affa3e79c3f1d8d853b5ee78f"
+checksum = "a1fae2d1f62d655f88280a39711db401973d1bbe54fec9f795be80b9d76837ae"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.66",
@@ -4957,9 +4957,9 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f142cbb497d257e70253c158a4c34037e310d24a055fae7dbc5c396b7611aa"
+checksum = "f9cf11ed42da5fd14f4fd197d325951d2d7890aab8e25a7782f8b7540918d3a1"
 dependencies = [
  "async-channel",
  "bytes",
@@ -4990,9 +4990,9 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0e41ce715b34749d2c0d3181dd910d2b99fa2142a0aaf3cd44926cb02edd60d"
+checksum = "bffbc01cdc316ff88398afbcd3befa78919049362bfe1a8a5794c942ce34bd96"
 dependencies = [
  "bincode",
  "log",
@@ -5005,9 +5005,9 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ec99361a39e17a2bffe2a59b97b3d20ddef323f9166929783ce49f340c200d"
+checksum = "8209c111aff1fcf3028a8ee39c7c2171012fda5b31a72b2427d2c2d989dc6d3c"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5030,9 +5030,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "236dd4e43b8a7402bce250228e04c0c68d9493a3e19c71b377ccc7c4390fd969"
+checksum = "bdad82a1e22d7c3fc1e009eeec4e8841697f6cce1902b7a1d5b73baf2bcca2e5"
 dependencies = [
  "Inflector",
  "base64 0.21.4",
@@ -5056,9 +5056,9 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b438036719e5c1201aba2336a5dc1caa8c8eefafd7110b7a3818ae199b54da"
+checksum = "a48721c6347353071589e3fbade33079e7ebade6087bb5b10edc788ad41b1ae2"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -5071,9 +5071,9 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62847d7ef409e3b410f65e726bf7816d8f8d0330918e78537e940bdf1ca061ae"
+checksum = "de7e99eb16bdc91861829bf0a6e361dd87ab898673b3708ebacf4ba27ca4d242"
 dependencies = [
  "log",
  "rustc_version",
@@ -5087,9 +5087,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0c3e5ee7bd03b249c6b80eead5620af62bc7ef1af8ea4f499b8054b00e9c7d"
+checksum = "22b1a3a2d9807a4141f0a550fdb3fa61a4aac4b4e7ea31694739509a43b9fa23"
 dependencies = [
  "bincode",
  "log",
@@ -5109,9 +5109,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.16.17"
+version = "1.16.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278c08e13bc04b6940997602909052524a375154b00cf0bfa934359a3bb7e6f0"
+checksum = "ad3cc2b931a39510b1c90dc876a93ae315b9712a8338296e4b60519d09e57be9"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.21.4",

--- a/evm_loader/api/Cargo.toml
+++ b/evm_loader/api/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 [dependencies]
 clap = "2.33.3"
 evm-loader = { path = "../program", default-features = false, features = ["log"] }
-solana-sdk = "=1.16.17"
-solana-client = "=1.16.17"
+solana-sdk = "=1.16.18"
+solana-client = "=1.16.18"
 serde = "1.0.186"
 serde_json = { version = "1.0.107", features = ["preserve_order"] }
 ethnum = { version = "1.4", default-features = false, features = ["serde"] }

--- a/evm_loader/cli/Cargo.toml
+++ b/evm_loader/cli/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2021"
 [dependencies]
 clap = "2.33.3"
 evm-loader = { path = "../program", default-features = false, features = ["log"] }
-solana-sdk = "=1.16.17"
-solana-client = "=1.16.17"
-solana-clap-utils = "=1.16.17"
-solana-cli-config = "=1.16.17"
+solana-sdk = "=1.16.18"
+solana-client = "=1.16.18"
+solana-clap-utils = "=1.16.18"
+solana-cli-config = "=1.16.18"
 hex = "0.4.2"
 serde = "1.0.186"
 serde_json = { version = "1.0.107", features = ["preserve_order"] }

--- a/evm_loader/lib/Cargo.toml
+++ b/evm_loader/lib/Cargo.toml
@@ -10,12 +10,12 @@ thiserror = "1.0"
 anyhow = "1.0"
 bincode = "1.3.1"
 evm-loader = { path = "../program", default-features = false, features = ["log", "async-trait", "serde_json"] }
-solana-sdk = "=1.16.17"
-solana-client = "=1.16.17"
-solana-clap-utils = "=1.16.17"
-solana-cli-config = "=1.16.17"
-solana-cli = "=1.16.17"
-solana-transaction-status = "=1.16.17"
+solana-sdk = "=1.16.18"
+solana-client = "=1.16.18"
+solana-clap-utils = "=1.16.18"
+solana-cli-config = "=1.16.18"
+solana-cli = "=1.16.18"
+solana-transaction-status = "=1.16.18"
 spl-token = { version = "~3.5", default-features = false, features = ["no-entrypoint"] }
 spl-associated-token-account = { version = "~1.1", default-features = false, features = ["no-entrypoint"] }
 bs58 = "0.4.0"

--- a/evm_loader/program/Cargo.toml
+++ b/evm_loader/program/Cargo.toml
@@ -37,7 +37,7 @@ default = ["custom-heap"]
 [dependencies]
 linked_list_allocator = { version = "0.10", default-features = false }
 evm-loader-macro = { path = "../program-macro" }
-solana-program = { version = "=1.16.17", default-features = false }
+solana-program = { version = "=1.16.18", default-features = false }
 spl-token = { version = "~3.5", default-features = false, features = ["no-entrypoint"] }
 spl-associated-token-account = { version = "~1.1", default-features = false, features = ["no-entrypoint"] }
 mpl-token-metadata = { version = "1.13.2", default-features = false, features = ["no-entrypoint"] }


### PR DESCRIPTION
Solana 1.16.18 was released 3 weeks ago, we should update all our repositories.
Pretty soon, this version will be the minimum mandatory version.