### PR TITLE
NDEV-2374: Fixes for tracer-api multiple tokens support

### DIFF
--- a/evm_loader/api/src/api_server/handlers/emulate.rs
+++ b/evm_loader/api/src/api_server/handlers/emulate.rs
@@ -1,19 +1,22 @@
 use actix_request_identifier::RequestId;
 use actix_web::{http::StatusCode, post, web::Json, Responder};
 use std::convert::Into;
+use tracing::info;
 
 use crate::api_server::handlers::process_error;
 use crate::{commands::emulate as EmulateCommand, types::EmulateApiRequest, NeonApiState};
 
 use super::process_result;
 
-#[tracing::instrument(skip(state, request_id), fields(id = request_id.as_str()))]
+#[tracing::instrument(skip_all, fields(id = request_id.as_str()))]
 #[post("/emulate")]
 pub async fn emulate(
     state: NeonApiState,
     request_id: RequestId,
     Json(emulate_request): Json<EmulateApiRequest>,
 ) -> impl Responder {
+    info!("emulate_request={:?}", emulate_request);
+
     let slot = emulate_request.slot;
     let index = emulate_request.tx_index_in_block;
 

--- a/evm_loader/api/src/api_server/handlers/get_balance.rs
+++ b/evm_loader/api/src/api_server/handlers/get_balance.rs
@@ -5,23 +5,26 @@ use actix_request_identifier::RequestId;
 use actix_web::web::Json;
 use actix_web::{http::StatusCode, post, Responder};
 use std::convert::Into;
+use tracing::log::info;
 
 use super::process_result;
 
-#[tracing::instrument(skip(state, request_id), fields(id = request_id.as_str()))]
+#[tracing::instrument(skip_all, fields(id = request_id.as_str()))]
 #[post("/balance")]
 pub async fn get_balance(
     state: NeonApiState,
     request_id: RequestId,
-    Json(req_params): Json<GetBalanceRequest>,
+    Json(get_balance_request): Json<GetBalanceRequest>,
 ) -> impl Responder {
-    let rpc = match state.build_rpc(req_params.slot, None).await {
+    info!("get_balance_request={:?}", get_balance_request);
+
+    let rpc = match state.build_rpc(get_balance_request.slot, None).await {
         Ok(rpc) => rpc,
         Err(e) => return process_error(StatusCode::BAD_REQUEST, &e),
     };
 
     process_result(
-        &GetBalanceCommand::execute(&rpc, &state.config.evm_loader, &req_params.account)
+        &GetBalanceCommand::execute(&rpc, &state.config.evm_loader, &get_balance_request.account)
             .await
             .map_err(Into::into),
     )

--- a/evm_loader/api/src/api_server/handlers/get_config.rs
+++ b/evm_loader/api/src/api_server/handlers/get_config.rs
@@ -9,7 +9,7 @@ use crate::commands::get_config as GetConfigCommand;
 
 use super::process_result;
 
-#[tracing::instrument(skip(state, request_id), fields(id = request_id.as_str()))]
+#[tracing::instrument(skip_all, fields(id = request_id.as_str()))]
 #[routes]
 #[post("/config")]
 #[get("/config")]

--- a/evm_loader/api/src/api_server/handlers/get_contract.rs
+++ b/evm_loader/api/src/api_server/handlers/get_contract.rs
@@ -6,24 +6,31 @@ use actix_web::post;
 use actix_web::web::Json;
 use actix_web::{http::StatusCode, Responder};
 use std::convert::Into;
+use tracing::info;
 
 use super::process_result;
 
-#[tracing::instrument(skip(state, request_id), fields(id = request_id.as_str()))]
+#[tracing::instrument(skip_all, fields(id = request_id.as_str()))]
 #[post("/contract")]
 pub async fn get_contract(
     state: NeonApiState,
     request_id: RequestId,
-    Json(req_params): Json<GetContractRequest>,
+    Json(get_contract_request): Json<GetContractRequest>,
 ) -> impl Responder {
-    let rpc = match state.build_rpc(req_params.slot, None).await {
+    info!("get_contract_request={:?}", get_contract_request);
+
+    let rpc = match state.build_rpc(get_contract_request.slot, None).await {
         Ok(rpc) => rpc,
         Err(e) => return process_error(StatusCode::BAD_REQUEST, &e),
     };
 
     process_result(
-        &GetContractCommand::execute(&rpc, &state.config.evm_loader, &req_params.contract)
-            .await
-            .map_err(Into::into),
+        &GetContractCommand::execute(
+            &rpc,
+            &state.config.evm_loader,
+            &get_contract_request.contract,
+        )
+        .await
+        .map_err(Into::into),
     )
 }

--- a/evm_loader/api/src/api_server/handlers/get_holder.rs
+++ b/evm_loader/api/src/api_server/handlers/get_holder.rs
@@ -6,23 +6,26 @@ use actix_web::post;
 use actix_web::web::Json;
 use actix_web::{http::StatusCode, Responder};
 use std::convert::Into;
+use tracing::info;
 
 use super::process_result;
 
-#[tracing::instrument(skip(state, request_id), fields(id = request_id.as_str()))]
+#[tracing::instrument(skip_all, fields(id = request_id.as_str()))]
 #[post("/holder")]
 pub async fn get_holder_account_data(
     state: NeonApiState,
     request_id: RequestId,
-    Json(req_params): Json<GetHolderRequest>,
+    Json(get_holder_request): Json<GetHolderRequest>,
 ) -> impl Responder {
-    let rpc = match state.build_rpc(req_params.slot, None).await {
+    info!("get_holder_request={:?}", get_holder_request);
+
+    let rpc = match state.build_rpc(get_holder_request.slot, None).await {
         Ok(rpc) => rpc,
         Err(e) => return process_error(StatusCode::BAD_REQUEST, &e),
     };
 
     process_result(
-        &GetHolderCommand::execute(&rpc, &state.config.evm_loader, req_params.pubkey)
+        &GetHolderCommand::execute(&rpc, &state.config.evm_loader, get_holder_request.pubkey)
             .await
             .map_err(Into::into),
     )

--- a/evm_loader/api/src/api_server/handlers/trace.rs
+++ b/evm_loader/api/src/api_server/handlers/trace.rs
@@ -1,6 +1,7 @@
 use actix_request_identifier::RequestId;
 use actix_web::{http::StatusCode, post, web::Json, Responder};
 use std::convert::Into;
+use tracing::info;
 
 use crate::api_server::handlers::process_error;
 use crate::commands::trace::trace_transaction;
@@ -8,13 +9,15 @@ use crate::{types::EmulateApiRequest, NeonApiState};
 
 use super::process_result;
 
-#[tracing::instrument(skip(state, request_id), fields(id = request_id.as_str()))]
+#[tracing::instrument(skip_all, fields(id = request_id.as_str()))]
 #[post("/trace")]
 pub async fn trace(
     state: NeonApiState,
     request_id: RequestId,
     Json(trace_request): Json<EmulateApiRequest>,
 ) -> impl Responder {
+    info!("trace_request={:?}", trace_request);
+
     let slot = trace_request.slot;
     let index = trace_request.tx_index_in_block;
 

--- a/evm_loader/api/src/api_server/state.rs
+++ b/evm_loader/api/src/api_server/state.rs
@@ -12,7 +12,7 @@ pub struct State {
 impl State {
     pub fn new(config: Config) -> Self {
         Self {
-            tracer_db: TracerDb::new(&config),
+            tracer_db: TracerDb::new(config.db_config.as_ref().expect("db-config not found")),
             rpc_client: config.build_clone_solana_rpc_client(),
             config,
         }

--- a/evm_loader/api/src/main.rs
+++ b/evm_loader/api/src/main.rs
@@ -30,6 +30,7 @@ use crate::api_server::handlers::trace::trace;
 use crate::build_info::get_build_info;
 pub use config::Config;
 use tracing::info;
+use tracing_subscriber::EnvFilter;
 
 type NeonApiResult<T> = Result<T, NeonApiError>;
 type NeonApiState = Data<api_server::state::State>;
@@ -43,7 +44,10 @@ async fn main() -> NeonApiResult<()> {
         .lossy(false)
         .finish(std::io::stdout());
 
-    tracing_subscriber::fmt().with_writer(non_blocking).init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_writer(non_blocking)
+        .init();
 
     info!("{}", get_build_info());
 

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -162,7 +162,14 @@ async fn build_rpc(options: &ArgMatches<'_>, config: &Config) -> Result<RpcEnum,
         .map(|slot_str| slot_str.parse().expect("slot parse error"));
 
     Ok(if let Some(slot) = slot {
-        RpcEnum::CallDbClient(CallDbClient::new(TracerDb::new(config), slot, None).await?)
+        RpcEnum::CallDbClient(
+            CallDbClient::new(
+                TracerDb::new(config.db_config.as_ref().expect("db-config not found")),
+                slot,
+                None,
+            )
+            .await?,
+        )
     } else {
         RpcEnum::CloneRpcClient(config.build_clone_solana_rpc_client())
     })

--- a/evm_loader/lib/src/tracing/tracers/struct_logger.rs
+++ b/evm_loader/lib/src/tracing/tracers/struct_logger.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use ethnum::U256;
 use evm_loader::evm::ExitStatus;
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde_json::Value;
 
 use crate::tracing::TraceConfig;
 use evm_loader::evm::opcode_table::OPNAMES;
@@ -206,17 +206,15 @@ impl EventListener for StructLogger {
 
     fn into_traces(self: Box<Self>) -> Value {
         let exit_status = self.exit_status.expect("Emulation is not completed");
-        json!({
-            "struct_logs": self.logs,
-            "failed": exit_status
+        let result = StructLoggerResult {
+            gas: 0,
+            failed: !exit_status
                 .is_succeed()
                 .expect("Emulation is not completed"),
-            "return_value": hex::encode(
-                exit_status
-                    .into_result()
-                    .unwrap_or_default(),
-            )
-        })
+            return_value: hex::encode(exit_status.into_result().unwrap_or_default()),
+            struct_logs: self.logs,
+        };
+        serde_json::to_value(result).expect("serialization should not fail")
     }
 }
 

--- a/evm_loader/lib/src/types/tracer_ch_db.rs
+++ b/evm_loader/lib/src/types/tracer_ch_db.rs
@@ -1,11 +1,11 @@
 use crate::{
     commands::get_neon_elf::get_elf_parameter,
     types::tracer_ch_common::{AccountRow, ChError, RevisionRow, SlotParent, ROOT_BLOCK_DELAY},
-    Config,
 };
 
 use super::tracer_ch_common::{ChResult, EthSyncStatus, EthSyncing, RevisionMap, SlotParentRooted};
 
+use crate::types::ChDbConfig;
 use clickhouse::Client;
 use log::{debug, error, info};
 use rand::Rng;
@@ -28,9 +28,7 @@ pub struct ClickHouseDb {
 }
 
 impl ClickHouseDb {
-    pub fn new(config: &Config) -> Self {
-        let config = config.db_config.as_ref().expect("db-config not found");
-
+    pub fn new(config: &ChDbConfig) -> Self {
         let url_id = rand::thread_rng().gen_range(0..config.clickhouse_url.len());
         let url = config.clickhouse_url.get(url_id).unwrap();
 


### PR DESCRIPTION
Fixes for https://github.com/neonlabsorg/tracer-api/pull/88:
- Use `StructLoggerResult` struct with proper camelCase serialization of fields.
- Enabled `RUST_LOG` env var log filtering mechanism in order to remove verbose logging introduced by `solana-program-test` usage.
- Reduced tracing spans to only include the request id, in order to remove the duplicated request fields on each trace log event.