### PR TITLE
NDEV-2438: Simplify Rpc trait usage

### DIFF
--- a/evm_loader/lib/src/commands/collect_treasury.rs
+++ b/evm_loader/lib/src/commands/collect_treasury.rs
@@ -26,7 +26,7 @@ pub async fn execute(
     rpc_client: &CloneRpcClient,
     signer: &dyn Signer,
 ) -> NeonResult<CollectTreasuryReturn> {
-    let neon_params = read_elf_parameters_from_account(config, &rpc_client.clone().into()).await?;
+    let neon_params = read_elf_parameters_from_account(config, rpc_client).await?;
 
     let pool_count: u32 = neon_params
         .get("NEON_TREASURY_POOL_COUNT")

--- a/evm_loader/lib/src/commands/get_balance.rs
+++ b/evm_loader/lib/src/commands/get_balance.rs
@@ -6,10 +6,9 @@ use solana_sdk::{account::Account, pubkey::Pubkey};
 
 use crate::{account_storage::account_info, rpc::Rpc, types::BalanceAddress, NeonResult};
 
-use crate::rpc::RpcEnum;
 use serde_with::{serde_as, DisplayFromStr};
 
-use super::get_config::ChainInfo;
+use super::get_config::{BuildConfigSimulator, ChainInfo};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum BalanceStatus {
@@ -92,7 +91,7 @@ fn is_legacy_chain_id(id: u64, chains: &[ChainInfo]) -> bool {
 }
 
 pub async fn execute(
-    rpc: &RpcEnum,
+    rpc: &(impl Rpc + BuildConfigSimulator),
     program_id: &Pubkey,
     address: &[BalanceAddress],
 ) -> NeonResult<Vec<GetBalanceResponse>> {

--- a/evm_loader/lib/src/commands/get_contract.rs
+++ b/evm_loader/lib/src/commands/get_contract.rs
@@ -7,10 +7,9 @@ use solana_sdk::{account::Account, pubkey::Pubkey};
 
 use crate::{account_storage::account_info, rpc::Rpc, NeonResult};
 
-use crate::rpc::RpcEnum;
 use serde_with::{hex::Hex, serde_as, DisplayFromStr};
 
-use super::get_config::ChainInfo;
+use super::get_config::{BuildConfigSimulator, ChainInfo};
 
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize)]
@@ -75,7 +74,7 @@ fn read_account(
 }
 
 pub async fn execute(
-    rpc: &RpcEnum,
+    rpc: &(impl Rpc + BuildConfigSimulator),
     program_id: &Pubkey,
     accounts: &[Address],
 ) -> NeonResult<Vec<GetContractResponse>> {

--- a/evm_loader/lib/src/commands/get_holder.rs
+++ b/evm_loader/lib/src/commands/get_holder.rs
@@ -12,7 +12,6 @@ use std::fmt::Display;
 
 use crate::{account_storage::account_info, rpc::Rpc, NeonResult};
 
-use crate::rpc::RpcEnum;
 use serde_with::{hex::Hex, serde_as, skip_serializing_none, DisplayFromStr};
 
 #[derive(Debug, Default, Serialize)]
@@ -141,7 +140,7 @@ pub fn read_holder(program_id: &Pubkey, info: AccountInfo) -> NeonResult<GetHold
 }
 
 pub async fn execute(
-    rpc: &RpcEnum,
+    rpc: &impl Rpc,
     program_id: &Pubkey,
     address: Pubkey,
 ) -> NeonResult<GetHolderResponse> {

--- a/evm_loader/lib/src/commands/get_neon_elf.rs
+++ b/evm_loader/lib/src/commands/get_neon_elf.rs
@@ -7,7 +7,7 @@ use solana_sdk::{
 };
 use std::{collections::HashMap, convert::TryFrom, fs::File, io::Read};
 
-use crate::rpc::{Rpc, RpcEnum};
+use crate::rpc::Rpc;
 use crate::{errors::NeonError, Config, NeonResult};
 
 pub type GetNeonElfReturn = HashMap<String, String>;
@@ -17,7 +17,7 @@ pub struct CachedElfParams {
 }
 
 impl CachedElfParams {
-    pub async fn new(config: &Config, rpc: &RpcEnum) -> Self {
+    pub async fn new(config: &Config, rpc: &impl Rpc) -> Self {
         Self {
             elf_params: read_elf_parameters_from_account(config, rpc)
                 .await
@@ -144,7 +144,7 @@ pub fn get_elf_parameter(data: &[u8], elf_parameter: &str) -> Result<String> {
 
 pub async fn read_elf_parameters_from_account(
     config: &Config,
-    rpc: &RpcEnum,
+    rpc: &impl Rpc,
 ) -> Result<GetNeonElfReturn, NeonError> {
     let (_, program_data) = read_program_data_from_account(config, rpc, &config.evm_loader).await?;
     Ok(read_elf_parameters(config, &program_data))
@@ -152,7 +152,7 @@ pub async fn read_elf_parameters_from_account(
 
 pub async fn read_program_data_from_account(
     config: &Config,
-    rpc: &RpcEnum,
+    rpc: &impl Rpc,
     evm_loader: &Pubkey,
 ) -> Result<(Option<Pubkey>, Vec<u8>), NeonError> {
     let account = rpc
@@ -224,14 +224,14 @@ fn read_program_params_from_file(
 
 async fn read_program_params_from_account(
     config: &Config,
-    rpc: &RpcEnum,
+    rpc: &impl Rpc,
 ) -> NeonResult<GetNeonElfReturn> {
     read_elf_parameters_from_account(config, rpc).await
 }
 
 pub async fn execute(
     config: &Config,
-    rpc: &RpcEnum,
+    rpc: &impl Rpc,
     program_location: Option<&str>,
 ) -> NeonResult<GetNeonElfReturn> {
     if let Some(program_location) = program_location {

--- a/evm_loader/lib/src/commands/get_storage_at.rs
+++ b/evm_loader/lib/src/commands/get_storage_at.rs
@@ -4,14 +4,15 @@ use solana_sdk::pubkey::Pubkey;
 
 use evm_loader::{account_storage::AccountStorage, types::Address};
 
-use crate::rpc::RpcEnum;
+use crate::commands::get_config::BuildConfigSimulator;
+use crate::rpc::Rpc;
 use crate::{account_storage::EmulatorAccountStorage, NeonResult};
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct GetStorageAtReturn(pub [u8; 32]);
 
 pub async fn execute(
-    rpc: &RpcEnum,
+    rpc: &(impl Rpc + BuildConfigSimulator),
     program_id: &Pubkey,
     address: Address,
     index: U256,

--- a/evm_loader/lib/src/commands/init_environment.rs
+++ b/evm_loader/lib/src/commands/init_environment.rs
@@ -129,9 +129,8 @@ pub async fn execute(
         &bpf_loader_upgradeable::id(),
     )
     .0;
-    let rpc_enum = client.clone().into();
     let (program_upgrade_authority, program_data) =
-        read_program_data_from_account(config, &rpc_enum, &config.evm_loader).await?;
+        read_program_data_from_account(config, client, &config.evm_loader).await?;
     let data = file.map_or(Ok(program_data), read_program_data)?;
     let program_parameters = Parameters::new(read_elf_parameters(config, &data));
 
@@ -204,7 +203,7 @@ pub async fn execute(
 
     //====================== Create 'Deposit' NEON-token balance ======================================================
     let (deposit_authority, _) = Pubkey::find_program_address(&[b"Deposit"], &config.evm_loader);
-    let chains = super::get_config::read_chains(&rpc_enum, config.evm_loader).await?;
+    let chains = super::get_config::read_chains(client, config.evm_loader).await?;
     for chain in chains {
         let pool = get_associated_token_address(&deposit_authority, &chain.token);
 

--- a/evm_loader/lib/src/rpc/mod.rs
+++ b/evm_loader/lib/src/rpc/mod.rs
@@ -5,6 +5,7 @@ pub use db_call_client::CallDbClient;
 pub use validator_client::CloneRpcClient;
 pub use validator_client::SolanaRpc;
 
+use crate::commands::get_config::{BuildConfigSimulator, ConfigSimulator};
 use crate::{NeonError, NeonResult};
 use async_trait::async_trait;
 use enum_dispatch::enum_dispatch;
@@ -34,7 +35,7 @@ pub trait Rpc {
     async fn get_slot(&self) -> ClientResult<Slot>;
 }
 
-#[enum_dispatch(Rpc)]
+#[enum_dispatch(BuildConfigSimulator, Rpc)]
 pub enum RpcEnum {
     CloneRpcClient,
     CallDbClient,

--- a/evm_loader/lib/src/syscall_stubs.rs
+++ b/evm_loader/lib/src/syscall_stubs.rs
@@ -1,7 +1,6 @@
 use log::info;
 use solana_sdk::{program_error::ProgramError, program_stubs::SyscallStubs, sysvar::rent::Rent};
 
-use crate::rpc::RpcEnum;
 use crate::{errors::NeonError, rpc::Rpc};
 
 pub struct DefaultStubs;
@@ -13,7 +12,7 @@ pub struct EmulatorStubs {
 }
 
 impl EmulatorStubs {
-    pub async fn new(rpc: &RpcEnum) -> Result<Box<EmulatorStubs>, NeonError> {
+    pub async fn new(rpc: &impl Rpc) -> Result<Box<EmulatorStubs>, NeonError> {
         let rent_pubkey = solana_sdk::sysvar::rent::id();
         let data = rpc
             .get_account(&rent_pubkey)
@@ -57,7 +56,7 @@ impl SyscallStubs for EmulatorStubs {
     }
 }
 
-pub async fn setup_emulator_syscall_stubs(rpc: &RpcEnum) -> Result<(), NeonError> {
+pub async fn setup_emulator_syscall_stubs(rpc: &impl Rpc) -> Result<(), NeonError> {
     let syscall_stubs = EmulatorStubs::new(rpc).await?;
     solana_sdk::program_stubs::set_syscall_stubs(syscall_stubs);
 


### PR DESCRIPTION
Addendum to #233.

- Simplified `Rpc` trait usage (removed the need to wrap Solana `RpcClient` in `RpcEnum` using `rpc_client.clone().into()`, since both `RpcClient` and `RpcEnum` implement `Rpc`, so `impl Rpc` parameters accept both)
- Extracted `BuildConfigSimulator` trait
- Converted `ConfigSimulator` functions to methods
- Renamed some local variables