### PR TITLE
NDEV-2441: Remove type parameter duplication in precompile_extension module

### DIFF
--- a/evm_loader/program/src/executor/precompile_extension/metaplex.rs
+++ b/evm_loader/program/src/executor/precompile_extension/metaplex.rs
@@ -58,7 +58,7 @@ pub async fn metaplex<B: AccountStorage>(
             let symbol = read_string(input, 64, 256)?;
             let uri = read_string(input, 96, 1024)?;
 
-            create_metadata(context, state, mint, name, symbol, uri)
+            state.create_metadata(context, mint, name, symbol, uri)
         }
         [0x4a, 0xe8, 0xb6, 0x6b] => {
             // "createMasterEdition(bytes32,uint64)"
@@ -69,32 +69,32 @@ pub async fn metaplex<B: AccountStorage>(
             let mint = read_pubkey(input)?;
             let max_supply = read_u64(&input[32..])?;
 
-            create_master_edition(context, state, mint, Some(max_supply))
+            state.create_master_edition(context, mint, Some(max_supply))
         }
         [0xf7, 0xb6, 0x37, 0xbb] => {
             // "isInitialized(bytes32)"
             let mint = read_pubkey(input)?;
-            is_initialized(context, state, mint).await
+            state.is_initialized(context, mint).await
         }
         [0x23, 0x5b, 0x2b, 0x94] => {
             // "isNFT(bytes32)"
             let mint = read_pubkey(input)?;
-            is_nft(context, state, mint).await
+            state.is_nft(context, mint).await
         }
         [0x9e, 0xd1, 0x9d, 0xdb] => {
             // "uri(bytes32)"
             let mint = read_pubkey(input)?;
-            uri(context, state, mint).await
+            state.uri(context, mint).await
         }
         [0x69, 0x1f, 0x34, 0x31] => {
             // "name(bytes32)"
             let mint = read_pubkey(input)?;
-            token_name(context, state, mint).await
+            state.token_name(context, mint).await
         }
         [0x6b, 0xaa, 0x03, 0x30] => {
             // "symbol(bytes32)"
             let mint = read_pubkey(input)?;
-            symbol(context, state, mint).await
+            state.symbol(context, mint).await
         }
         _ => Err(Error::UnknownPrecompileMethodSelector(*address, selector)),
     }
@@ -143,184 +143,174 @@ fn read_string(input: &[u8], offset_position: usize, max_length: usize) -> Resul
     String::from_utf8(data).map_err(|_| Error::Custom("Invalid utf8 string".to_string()))
 }
 
-fn create_metadata<B: AccountStorage>(
-    context: &crate::evm::Context,
-    state: &mut ExecutorState<B>,
-    mint: Pubkey,
-    name: String,
-    symbol: String,
-    uri: String,
-) -> Result<Vec<u8>> {
-    let signer = context.caller;
-    let (signer_pubkey, bump_seed) = state.backend.contract_pubkey(signer);
+impl<B: AccountStorage> ExecutorState<'_, B> {
+    fn create_metadata(
+        &mut self,
+        context: &crate::evm::Context,
+        mint: Pubkey,
+        name: String,
+        symbol: String,
+        uri: String,
+    ) -> Result<Vec<u8>> {
+        let signer = context.caller;
+        let (signer_pubkey, bump_seed) = self.backend.contract_pubkey(signer);
 
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        signer.as_bytes().to_vec(),
-        vec![bump_seed],
-    ];
+        let seeds = vec![
+            vec![ACCOUNT_SEED_VERSION],
+            signer.as_bytes().to_vec(),
+            vec![bump_seed],
+        ];
 
-    let (metadata_pubkey, _) = mpl_token_metadata::pda::find_metadata_account(&mint);
+        let (metadata_pubkey, _) = mpl_token_metadata::pda::find_metadata_account(&mint);
 
-    let instruction = mpl_token_metadata::instruction::create_metadata_accounts_v3(
-        mpl_token_metadata::ID,
-        metadata_pubkey,
-        mint,
-        signer_pubkey,
-        state.backend.operator(),
-        signer_pubkey,
-        name,
-        symbol,
-        uri,
-        Some(vec![
-            Creator {
-                address: *state.backend.program_id(),
-                verified: false,
-                share: 0,
-            },
-            Creator {
-                address: signer_pubkey,
-                verified: true,
-                share: 100,
-            },
-        ]),
-        0,     // Seller Fee
-        true,  // Update Authority == Mint Authority
-        false, // Is Mutable
-        None,  // Collection
-        None,  // Uses
-        None,  // Collection Details
-    );
+        let instruction = mpl_token_metadata::instruction::create_metadata_accounts_v3(
+            mpl_token_metadata::ID,
+            metadata_pubkey,
+            mint,
+            signer_pubkey,
+            self.backend.operator(),
+            signer_pubkey,
+            name,
+            symbol,
+            uri,
+            Some(vec![
+                Creator {
+                    address: *self.backend.program_id(),
+                    verified: false,
+                    share: 0,
+                },
+                Creator {
+                    address: signer_pubkey,
+                    verified: true,
+                    share: 100,
+                },
+            ]),
+            0,     // Seller Fee
+            true,  // Update Authority == Mint Authority
+            false, // Is Mutable
+            None,  // Collection
+            None,  // Uses
+            None,  // Collection Details
+        );
 
-    let rent = Rent::get()?;
-    let fee = rent.minimum_balance(MAX_METADATA_LEN) + CREATE_FEE;
+        let rent = Rent::get()?;
+        let fee = rent.minimum_balance(MAX_METADATA_LEN) + CREATE_FEE;
 
-    state.queue_external_instruction(instruction, seeds, fee);
+        self.queue_external_instruction(instruction, seeds, fee);
 
-    Ok(metadata_pubkey.to_bytes().to_vec())
-}
+        Ok(metadata_pubkey.to_bytes().to_vec())
+    }
 
-fn create_master_edition<B: AccountStorage>(
-    context: &crate::evm::Context,
-    state: &mut ExecutorState<B>,
-    mint: Pubkey,
-    max_supply: Option<u64>,
-) -> Result<Vec<u8>> {
-    let signer = context.caller;
-    let (signer_pubkey, bump_seed) = state.backend.contract_pubkey(signer);
+    fn create_master_edition(
+        &mut self,
+        context: &crate::evm::Context,
+        mint: Pubkey,
+        max_supply: Option<u64>,
+    ) -> Result<Vec<u8>> {
+        let signer = context.caller;
+        let (signer_pubkey, bump_seed) = self.backend.contract_pubkey(signer);
 
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        signer.as_bytes().to_vec(),
-        vec![bump_seed],
-    ];
+        let seeds = vec![
+            vec![ACCOUNT_SEED_VERSION],
+            signer.as_bytes().to_vec(),
+            vec![bump_seed],
+        ];
 
-    let (metadata_pubkey, _) = mpl_token_metadata::pda::find_metadata_account(&mint);
-    let (edition_pubkey, _) = mpl_token_metadata::pda::find_master_edition_account(&mint);
+        let (metadata_pubkey, _) = mpl_token_metadata::pda::find_metadata_account(&mint);
+        let (edition_pubkey, _) = mpl_token_metadata::pda::find_master_edition_account(&mint);
 
-    let instruction = mpl_token_metadata::instruction::create_master_edition_v3(
-        mpl_token_metadata::ID,
-        edition_pubkey,
-        mint,
-        signer_pubkey,
-        signer_pubkey,
-        metadata_pubkey,
-        state.backend.operator(),
-        max_supply,
-    );
+        let instruction = mpl_token_metadata::instruction::create_master_edition_v3(
+            mpl_token_metadata::ID,
+            edition_pubkey,
+            mint,
+            signer_pubkey,
+            signer_pubkey,
+            metadata_pubkey,
+            self.backend.operator(),
+            max_supply,
+        );
 
-    let rent = Rent::get()?;
-    let fee = rent.minimum_balance(MAX_MASTER_EDITION_LEN) + CREATE_FEE;
+        let rent = Rent::get()?;
+        let fee = rent.minimum_balance(MAX_MASTER_EDITION_LEN) + CREATE_FEE;
 
-    state.queue_external_instruction(instruction, seeds, fee);
+        self.queue_external_instruction(instruction, seeds, fee);
 
-    Ok(edition_pubkey.to_bytes().to_vec())
-}
+        Ok(edition_pubkey.to_bytes().to_vec())
+    }
 
-#[maybe_async]
-async fn is_initialized<B: AccountStorage>(
-    context: &crate::evm::Context,
-    state: &mut ExecutorState<'_, B>,
-    mint: Pubkey,
-) -> Result<Vec<u8>> {
-    let is_initialized = metadata(context, state, mint)
-        .await?
-        .map_or_else(|| false, |_| true);
+    #[maybe_async]
+    async fn is_initialized(
+        &mut self,
+        context: &crate::evm::Context,
+        mint: Pubkey,
+    ) -> Result<Vec<u8>> {
+        let is_initialized = self
+            .metadata(context, mint)
+            .await?
+            .map_or_else(|| false, |_| true);
 
-    Ok(to_solidity_bool(is_initialized))
-}
+        Ok(to_solidity_bool(is_initialized))
+    }
 
-#[maybe_async]
-async fn is_nft<B: AccountStorage>(
-    context: &crate::evm::Context,
-    state: &mut ExecutorState<'_, B>,
-    mint: Pubkey,
-) -> Result<Vec<u8>> {
-    let is_nft = metadata(context, state, mint).await?.map_or_else(
-        || false,
-        |m| m.token_standard == Some(TokenStandard::NonFungible),
-    );
+    #[maybe_async]
+    async fn is_nft(&mut self, context: &crate::evm::Context, mint: Pubkey) -> Result<Vec<u8>> {
+        let is_nft = self.metadata(context, mint).await?.map_or_else(
+            || false,
+            |m| m.token_standard == Some(TokenStandard::NonFungible),
+        );
 
-    Ok(to_solidity_bool(is_nft))
-}
+        Ok(to_solidity_bool(is_nft))
+    }
 
-#[maybe_async]
-async fn uri<B: AccountStorage>(
-    context: &crate::evm::Context,
-    state: &mut ExecutorState<'_, B>,
-    mint: Pubkey,
-) -> Result<Vec<u8>> {
-    let uri = metadata(context, state, mint)
-        .await?
-        .map_or_else(String::new, |m| m.data.uri);
+    #[maybe_async]
+    async fn uri(&mut self, context: &crate::evm::Context, mint: Pubkey) -> Result<Vec<u8>> {
+        let uri = self
+            .metadata(context, mint)
+            .await?
+            .map_or_else(String::new, |m| m.data.uri);
 
-    Ok(to_solidity_string(uri.trim_end_matches('\0')))
-}
+        Ok(to_solidity_string(uri.trim_end_matches('\0')))
+    }
 
-#[maybe_async]
-async fn token_name<B: AccountStorage>(
-    context: &crate::evm::Context,
-    state: &mut ExecutorState<'_, B>,
-    mint: Pubkey,
-) -> Result<Vec<u8>> {
-    let token_name = metadata(context, state, mint)
-        .await?
-        .map_or_else(String::new, |m| m.data.name);
+    #[maybe_async]
+    async fn token_name(&mut self, context: &crate::evm::Context, mint: Pubkey) -> Result<Vec<u8>> {
+        let token_name = self
+            .metadata(context, mint)
+            .await?
+            .map_or_else(String::new, |m| m.data.name);
 
-    Ok(to_solidity_string(token_name.trim_end_matches('\0')))
-}
+        Ok(to_solidity_string(token_name.trim_end_matches('\0')))
+    }
 
-#[maybe_async]
-async fn symbol<B: AccountStorage>(
-    context: &crate::evm::Context,
-    state: &mut ExecutorState<'_, B>,
-    mint: Pubkey,
-) -> Result<Vec<u8>> {
-    let symbol = metadata(context, state, mint)
-        .await?
-        .map_or_else(String::new, |m| m.data.symbol);
+    #[maybe_async]
+    async fn symbol(&mut self, context: &crate::evm::Context, mint: Pubkey) -> Result<Vec<u8>> {
+        let symbol = self
+            .metadata(context, mint)
+            .await?
+            .map_or_else(String::new, |m| m.data.symbol);
 
-    Ok(to_solidity_string(symbol.trim_end_matches('\0')))
-}
+        Ok(to_solidity_string(symbol.trim_end_matches('\0')))
+    }
 
-#[maybe_async]
-async fn metadata<B: AccountStorage>(
-    _context: &crate::evm::Context,
-    state: &mut ExecutorState<'_, B>,
-    mint: Pubkey,
-) -> Result<Option<Metadata>> {
-    let (metadata_pubkey, _) = mpl_token_metadata::pda::find_metadata_account(&mint);
-    let metadata_account = state.external_account(metadata_pubkey).await?;
+    #[maybe_async]
+    async fn metadata(
+        &mut self,
+        _context: &crate::evm::Context,
+        mint: Pubkey,
+    ) -> Result<Option<Metadata>> {
+        let (metadata_pubkey, _) = mpl_token_metadata::pda::find_metadata_account(&mint);
+        let metadata_account = self.external_account(metadata_pubkey).await?;
 
-    let result = {
-        if mpl_token_metadata::check_id(&metadata_account.owner) {
-            let metadata = Metadata::safe_deserialize(&metadata_account.data);
-            metadata.ok()
-        } else {
-            None
-        }
-    };
-    Ok(result)
+        let result = {
+            if mpl_token_metadata::check_id(&metadata_account.owner) {
+                let metadata = Metadata::safe_deserialize(&metadata_account.data);
+                metadata.ok()
+            } else {
+                None
+            }
+        };
+        Ok(result)
+    }
 }
 
 fn to_solidity_bool(v: bool) -> Vec<u8> {

--- a/evm_loader/program/src/executor/precompile_extension/mod.rs
+++ b/evm_loader/program/src/executor/precompile_extension/mod.rs
@@ -45,7 +45,7 @@ impl<B: AccountStorage> ExecutorState<'_, B> {
     ) -> Option<Result<Vec<u8>>> {
         match *address {
             Self::SYSTEM_ACCOUNT_QUERY => {
-                Some(query_account::query_account(self, address, input, context, is_static).await)
+                Some(self.query_account(address, input, context, is_static).await)
             }
             Self::SYSTEM_ACCOUNT_NEON_TOKEN => {
                 Some(self.neon_token(address, input, context, is_static).await)

--- a/evm_loader/program/src/executor/precompile_extension/mod.rs
+++ b/evm_loader/program/src/executor/precompile_extension/mod.rs
@@ -8,7 +8,7 @@ mod neon_token;
 mod query_account;
 mod spl_token;
 
-impl<'a, B: AccountStorage> ExecutorState<'a, B> {
+impl<B: AccountStorage> ExecutorState<'_, B> {
     #[deprecated]
     const _SYSTEM_ACCOUNT_ERC20_WRAPPER: Address = Address([
         0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01,
@@ -54,7 +54,7 @@ impl<'a, B: AccountStorage> ExecutorState<'a, B> {
                 Some(spl_token::spl_token(self, address, input, context, is_static).await)
             }
             Self::SYSTEM_ACCOUNT_METAPLEX => {
-                Some(metaplex::metaplex(self, address, input, context, is_static).await)
+                Some(self.metaplex(address, input, context, is_static).await)
             }
             _ => None,
         }

--- a/evm_loader/program/src/executor/precompile_extension/mod.rs
+++ b/evm_loader/program/src/executor/precompile_extension/mod.rs
@@ -48,7 +48,7 @@ impl<B: AccountStorage> ExecutorState<'_, B> {
                 Some(query_account::query_account(self, address, input, context, is_static).await)
             }
             Self::SYSTEM_ACCOUNT_NEON_TOKEN => {
-                Some(neon_token::neon_token(self, address, input, context, is_static).await)
+                Some(self.neon_token(address, input, context, is_static).await)
             }
             Self::SYSTEM_ACCOUNT_SPL_TOKEN => {
                 Some(spl_token::spl_token(self, address, input, context, is_static).await)

--- a/evm_loader/program/src/executor/precompile_extension/mod.rs
+++ b/evm_loader/program/src/executor/precompile_extension/mod.rs
@@ -51,7 +51,7 @@ impl<B: AccountStorage> ExecutorState<'_, B> {
                 Some(self.neon_token(address, input, context, is_static).await)
             }
             Self::SYSTEM_ACCOUNT_SPL_TOKEN => {
-                Some(spl_token::spl_token(self, address, input, context, is_static).await)
+                Some(self.spl_token(address, input, context, is_static).await)
             }
             Self::SYSTEM_ACCOUNT_METAPLEX => {
                 Some(self.metaplex(address, input, context, is_static).await)

--- a/evm_loader/program/src/executor/precompile_extension/neon_token.rs
+++ b/evm_loader/program/src/executor/precompile_extension/neon_token.rs
@@ -22,124 +22,126 @@ use crate::{
 //--------------------------------------------------
 const NEON_TOKEN_METHOD_WITHDRAW_ID: &[u8; 4] = &[0x8e, 0x19, 0x89, 0x9e];
 
-#[maybe_async]
-pub async fn neon_token<B: AccountStorage>(
-    state: &mut ExecutorState<'_, B>,
-    address: &Address,
-    input: &[u8],
-    context: &crate::evm::Context,
-    is_static: bool,
-) -> Result<Vec<u8>> {
-    debug_print!("neon_token({})", hex::encode(input));
+impl<B: AccountStorage> ExecutorState<'_, B> {
+    #[maybe_async]
+    pub async fn neon_token(
+        &mut self,
+        address: &Address,
+        input: &[u8],
+        context: &crate::evm::Context,
+        is_static: bool,
+    ) -> Result<Vec<u8>> {
+        debug_print!("neon_token({})", hex::encode(input));
 
-    if &context.contract != address {
-        return Err(Error::Custom(
-            "Withdraw: callcode or delegatecall is not allowed".to_string(),
-        ));
-    }
-
-    let (method_id, rest) = input.split_at(4);
-    let method_id: &[u8; 4] = method_id.try_into().unwrap_or(&[0_u8; 4]);
-
-    if method_id == NEON_TOKEN_METHOD_WITHDRAW_ID {
-        if is_static {
-            return Err(Error::StaticModeViolation(*address));
+        if &context.contract != address {
+            return Err(Error::Custom(
+                "Withdraw: callcode or delegatecall is not allowed".to_string(),
+            ));
         }
 
-        let source = context.contract;
-        let chain_id = context.contract_chain_id;
-        let value = context.value;
-        // owner of the associated token account
-        let destination = array_ref![rest, 0, 32];
-        let destination = Pubkey::new_from_array(*destination);
+        let (method_id, rest) = input.split_at(4);
+        let method_id: &[u8; 4] = method_id.try_into().unwrap_or(&[0_u8; 4]);
 
-        withdraw(state, source, chain_id, destination, value).await?;
+        if method_id == NEON_TOKEN_METHOD_WITHDRAW_ID {
+            if is_static {
+                return Err(Error::StaticModeViolation(*address));
+            }
 
-        let mut output = vec![0_u8; 32];
-        output[31] = 1; // return true
+            let source = context.contract;
+            let chain_id = context.contract_chain_id;
+            let value = context.value;
+            // owner of the associated token account
+            let destination = array_ref![rest, 0, 32];
+            let destination = Pubkey::new_from_array(*destination);
 
-        return Ok(output);
-    };
+            self.withdraw(source, chain_id, destination, value).await?;
 
-    debug_print!("neon_token UNKNOWN");
-    Err(Error::UnknownPrecompileMethodSelector(*address, *method_id))
-}
+            let mut output = vec![0_u8; 32];
+            output[31] = 1; // return true
 
-#[maybe_async]
-async fn withdraw<B: AccountStorage>(
-    state: &mut ExecutorState<'_, B>,
-    source: Address,
-    chain_id: u64,
-    target: Pubkey,
-    value: U256,
-) -> Result<()> {
-    if value == 0 {
-        return Err(Error::Custom("Neon Withdraw: value == 0".to_string()));
+            return Ok(output);
+        };
+
+        debug_print!("neon_token UNKNOWN");
+        Err(Error::UnknownPrecompileMethodSelector(*address, *method_id))
     }
 
-    let mint_address = state.backend.chain_id_to_token(chain_id);
+    #[maybe_async]
+    async fn withdraw(
+        &mut self,
+        source: Address,
+        chain_id: u64,
+        target: Pubkey,
+        value: U256,
+    ) -> Result<()> {
+        if value == 0 {
+            return Err(Error::Custom("Neon Withdraw: value == 0".to_string()));
+        }
 
-    let mut mint_account = state.external_account(mint_address).await?;
-    let mint_data = {
-        let info = mint_account.into_account_info();
-        token::Mint::from_account(&info)?.into_data()
-    };
+        let mint_address = self.backend.chain_id_to_token(chain_id);
 
-    assert!(mint_data.decimals < 18);
+        let mut mint_account = self.external_account(mint_address).await?;
+        let mint_data = {
+            let info = mint_account.into_account_info();
+            token::Mint::from_account(&info)?.into_data()
+        };
 
-    let additional_decimals: u32 = (18 - mint_data.decimals).into();
-    let min_amount: u128 = u128::pow(10, additional_decimals);
+        assert!(mint_data.decimals < 18);
 
-    let spl_amount = value / min_amount;
-    let remainder = value % min_amount;
+        let additional_decimals: u32 = (18 - mint_data.decimals).into();
+        let min_amount: u128 = u128::pow(10, additional_decimals);
 
-    if spl_amount > U256::from(u64::MAX) {
-        return Err(Error::Custom(
-            "Neon Withdraw: value exceeds u64::max".to_string(),
-        ));
-    }
+        let spl_amount = value / min_amount;
+        let remainder = value % min_amount;
 
-    if remainder != 0 {
-        return Err(Error::Custom(std::format!(
-            "Neon Withdraw: value must be divisible by 10^{additional_decimals}"
-        )));
-    }
+        if spl_amount > U256::from(u64::MAX) {
+            return Err(Error::Custom(
+                "Neon Withdraw: value exceeds u64::max".to_string(),
+            ));
+        }
 
-    let target_token = get_associated_token_address(&target, &mint_address);
-    let account = state.external_account(target_token).await?;
-    if !spl_token::check_id(&account.owner) {
-        use spl_associated_token_account::instruction::create_associated_token_account;
+        if remainder != 0 {
+            return Err(Error::Custom(std::format!(
+                "Neon Withdraw: value must be divisible by 10^{additional_decimals}"
+            )));
+        }
 
-        let create_associated = create_associated_token_account(
-            &state.backend.operator(),
-            &target,
-            &mint_address,
+        let target_token = get_associated_token_address(&target, &mint_address);
+        let account = self.external_account(target_token).await?;
+        if !spl_token::check_id(&account.owner) {
+            use spl_associated_token_account::instruction::create_associated_token_account;
+
+            let create_associated = create_associated_token_account(
+                &self.backend.operator(),
+                &target,
+                &mint_address,
+                &spl_token::ID,
+            );
+
+            let rent = Rent::get()?;
+            let fee = rent.minimum_balance(spl_token::state::Account::LEN);
+            self.queue_external_instruction(create_associated, vec![], fee);
+        }
+
+        let (authority, bump_seed) =
+            Pubkey::find_program_address(&[b"Deposit"], self.backend.program_id());
+        let pool = get_associated_token_address(&authority, &mint_address);
+
+        let transfer = spl_token::instruction::transfer_checked(
             &spl_token::ID,
-        );
+            &pool,
+            &mint_address,
+            &target_token,
+            &authority,
+            &[],
+            spl_amount.as_u64(),
+            mint_data.decimals,
+        )?;
+        let transfer_seeds = vec![b"Deposit".to_vec(), vec![bump_seed]];
+        self.queue_external_instruction(transfer, transfer_seeds, 0);
 
-        let rent = Rent::get()?;
-        let fee = rent.minimum_balance(spl_token::state::Account::LEN);
-        state.queue_external_instruction(create_associated, vec![], fee);
+        self.burn(source, chain_id, value);
+
+        Ok(())
     }
-
-    let (authority, bump_seed) =
-        Pubkey::find_program_address(&[b"Deposit"], state.backend.program_id());
-    let pool = get_associated_token_address(&authority, &mint_address);
-
-    let transfer = spl_token::instruction::transfer_checked(
-        &spl_token::ID,
-        &pool,
-        &mint_address,
-        &target_token,
-        &authority,
-        &[],
-        spl_amount.as_u64(),
-        mint_data.decimals,
-    )?;
-    let transfer_seeds = vec![b"Deposit".to_vec(), vec![bump_seed]];
-    state.queue_external_instruction(transfer, transfer_seeds, 0);
-
-    state.burn(source, chain_id, value);
-
-    Ok(())
 }

--- a/evm_loader/program/src/executor/precompile_extension/query_account.rs
+++ b/evm_loader/program/src/executor/precompile_extension/query_account.rs
@@ -31,208 +31,191 @@ use crate::{
 // "a9dbaf25": "length(bytes32)",
 // "7dd6c1a0": "data(bytes32,uint64,uint64)",
 
-#[maybe_async]
-pub async fn query_account<B: AccountStorage>(
-    state: &mut ExecutorState<'_, B>,
-    address: &Address,
-    input: &[u8],
-    context: &crate::evm::Context,
-    _is_static: bool,
-) -> Result<Vec<u8>> {
-    debug_print!("query_account({})", hex::encode(input));
+impl<B: AccountStorage> ExecutorState<'_, B> {
+    #[maybe_async]
+    pub async fn query_account(
+        &mut self,
+        address: &Address,
+        input: &[u8],
+        context: &crate::evm::Context,
+        _is_static: bool,
+    ) -> Result<Vec<u8>> {
+        debug_print!("query_account({})", hex::encode(input));
 
-    if context.value != 0 {
-        return Err(Error::Custom("Query Account: value != 0".to_string()));
+        if context.value != 0 {
+            return Err(Error::Custom("Query Account: value != 0".to_string()));
+        }
+
+        let (method_id, rest) = input.split_at(4);
+        let method_id: [u8; 4] = method_id.try_into()?;
+
+        let (account_address, rest) = rest.split_at(32);
+        let account_address = Pubkey::try_from(account_address)?;
+
+        match method_id {
+            [0x2b, 0x3c, 0x83, 0x22] => {
+                // cache(uint256,uint64,uint64)
+                // deprecated
+                Ok(Vec::new())
+            }
+            [0xa1, 0x23, 0xc3, 0x3e] | [0x02, 0x57, 0x1b, 0xe3] => {
+                debug_print!("query_account.owner({})", &account_address);
+                self.account_owner(&account_address).await
+            }
+            [0xaa, 0x8b, 0x99, 0xd2] | [0xa9, 0xdb, 0xaf, 0x25] => {
+                debug_print!("query_account.length({})", &account_address);
+                self.account_data_length(&account_address).await
+            }
+            [0x74, 0x8f, 0x2d, 0x8a] | [0x62, 0x73, 0x44, 0x8f] => {
+                debug_print!("query_account.lamports({})", &account_address);
+                self.account_lamports(&account_address).await
+            }
+            [0xc2, 0x19, 0xa7, 0x85] | [0xe6, 0xbe, 0xf4, 0x88] => {
+                debug_print!("query_account.executable({})", &account_address);
+                self.account_is_executable(&account_address).await
+            }
+            [0xc4, 0xd3, 0x69, 0xb5] | [0x8b, 0xb9, 0xe6, 0xf4] => {
+                debug_print!("query_account.rent_epoch({})", &account_address);
+                self.account_rent_epoch(&account_address).await
+            }
+            [0x43, 0xca, 0x51, 0x61] | [0x7d, 0xd6, 0xc1, 0xa0] => {
+                let arguments = array_ref![rest, 0, 64];
+                let (offset, length) = array_refs!(arguments, 32, 32);
+                let offset = U256::from_be_bytes(*offset).try_into()?;
+                let length = U256::from_be_bytes(*length).try_into()?;
+                debug_print!(
+                    "query_account.data({}, {}, {})",
+                    account_address,
+                    offset,
+                    length
+                );
+                self.account_data(&account_address, offset, length).await
+            }
+            [0xb6, 0x4a, 0x09, 0x7e] => {
+                debug_print!("query_account.info({})", &account_address);
+                self.account_info(&account_address).await
+            }
+            _ => {
+                debug_print!("query_account UNKNOWN {:?}", method_id);
+                Err(Error::UnknownPrecompileMethodSelector(*address, method_id))
+            }
+        }
     }
 
-    let (method_id, rest) = input.split_at(4);
-    let method_id: [u8; 4] = method_id.try_into()?;
+    #[allow(clippy::unnecessary_wraps)]
+    #[maybe_async]
+    async fn account_owner(&mut self, address: &Pubkey) -> Result<Vec<u8>> {
+        let owner = self
+            .backend
+            .map_solana_account(address, |info| info.owner.to_bytes())
+            .await;
 
-    let (account_address, rest) = rest.split_at(32);
-    let account_address = Pubkey::try_from(account_address)?;
-
-    match method_id {
-        [0x2b, 0x3c, 0x83, 0x22] => {
-            // cache(uint256,uint64,uint64)
-            // deprecated
-            Ok(Vec::new())
-        }
-        [0xa1, 0x23, 0xc3, 0x3e] | [0x02, 0x57, 0x1b, 0xe3] => {
-            debug_print!("query_account.owner({})", &account_address);
-            account_owner(state, &account_address).await
-        }
-        [0xaa, 0x8b, 0x99, 0xd2] | [0xa9, 0xdb, 0xaf, 0x25] => {
-            debug_print!("query_account.length({})", &account_address);
-            account_data_length(state, &account_address).await
-        }
-        [0x74, 0x8f, 0x2d, 0x8a] | [0x62, 0x73, 0x44, 0x8f] => {
-            debug_print!("query_account.lamports({})", &account_address);
-            account_lamports(state, &account_address).await
-        }
-        [0xc2, 0x19, 0xa7, 0x85] | [0xe6, 0xbe, 0xf4, 0x88] => {
-            debug_print!("query_account.executable({})", &account_address);
-            account_is_executable(state, &account_address).await
-        }
-        [0xc4, 0xd3, 0x69, 0xb5] | [0x8b, 0xb9, 0xe6, 0xf4] => {
-            debug_print!("query_account.rent_epoch({})", &account_address);
-            account_rent_epoch(state, &account_address).await
-        }
-        [0x43, 0xca, 0x51, 0x61] | [0x7d, 0xd6, 0xc1, 0xa0] => {
-            let arguments = array_ref![rest, 0, 64];
-            let (offset, length) = array_refs!(arguments, 32, 32);
-            let offset = U256::from_be_bytes(*offset).try_into()?;
-            let length = U256::from_be_bytes(*length).try_into()?;
-            debug_print!(
-                "query_account.data({}, {}, {})",
-                account_address,
-                offset,
-                length
-            );
-            account_data(state, &account_address, offset, length).await
-        }
-        [0xb6, 0x4a, 0x09, 0x7e] => {
-            debug_print!("query_account.info({})", &account_address);
-            account_info(state, &account_address).await
-        }
-        _ => {
-            debug_print!("query_account UNKNOWN {:?}", method_id);
-            Err(Error::UnknownPrecompileMethodSelector(*address, method_id))
-        }
-    }
-}
-
-#[allow(clippy::unnecessary_wraps)]
-#[maybe_async]
-async fn account_owner<B: AccountStorage>(
-    state: &mut ExecutorState<'_, B>,
-    address: &Pubkey,
-) -> Result<Vec<u8>> {
-    let owner = state
-        .backend
-        .map_solana_account(address, |info| info.owner.to_bytes())
-        .await;
-
-    Ok(owner.to_vec())
-}
-
-#[allow(clippy::unnecessary_wraps)]
-#[maybe_async]
-async fn account_lamports<B: AccountStorage>(
-    state: &mut ExecutorState<'_, B>,
-    address: &Pubkey,
-) -> Result<Vec<u8>> {
-    let lamports: U256 = state
-        .backend
-        .map_solana_account(address, |info| **info.lamports.borrow())
-        .await
-        .into();
-
-    let bytes = lamports.to_be_bytes().to_vec();
-
-    Ok(bytes)
-}
-
-#[allow(clippy::unnecessary_wraps)]
-#[maybe_async]
-async fn account_rent_epoch<B: AccountStorage>(
-    state: &mut ExecutorState<'_, B>,
-    address: &Pubkey,
-) -> Result<Vec<u8>> {
-    let epoch: U256 = state
-        .backend
-        .map_solana_account(address, |info| info.rent_epoch)
-        .await
-        .into();
-
-    let bytes = epoch.to_be_bytes().to_vec();
-
-    Ok(bytes)
-}
-
-#[allow(clippy::unnecessary_wraps)]
-#[maybe_async]
-async fn account_is_executable<B: AccountStorage>(
-    state: &mut ExecutorState<'_, B>,
-    address: &Pubkey,
-) -> Result<Vec<u8>> {
-    let executable: U256 = state
-        .backend
-        .map_solana_account(address, |info| info.executable)
-        .await
-        .into();
-
-    let bytes = executable.to_be_bytes().to_vec();
-
-    Ok(bytes)
-}
-
-#[allow(clippy::unnecessary_wraps)]
-#[maybe_async]
-async fn account_data_length<B: AccountStorage>(
-    state: &mut ExecutorState<'_, B>,
-    address: &Pubkey,
-) -> Result<Vec<u8>> {
-    let length: U256 = state
-        .backend
-        .map_solana_account(address, |info| info.data.borrow().len())
-        .await
-        .try_into()?;
-
-    let bytes = length.to_be_bytes().to_vec();
-
-    Ok(bytes)
-}
-
-#[allow(clippy::unnecessary_wraps)]
-#[maybe_async]
-async fn account_data<B: AccountStorage>(
-    state: &mut ExecutorState<'_, B>,
-    address: &Pubkey,
-    offset: usize,
-    length: usize,
-) -> Result<Vec<u8>> {
-    if length == 0 {
-        return Err(Error::Custom(
-            "Query Account: data() - length == 0".to_string(),
-        ));
+        Ok(owner.to_vec())
     }
 
-    state
-        .backend
-        .map_solana_account(address, |info| {
-            info.data
-                .borrow()
-                .get(offset..offset + length)
-                .map(<[u8]>::to_vec)
-        })
-        .await
-        .ok_or_else(|| Error::Custom("Query Account: data() - out of bounds".to_string()))
-}
+    #[allow(clippy::unnecessary_wraps)]
+    #[maybe_async]
+    async fn account_lamports(&mut self, address: &Pubkey) -> Result<Vec<u8>> {
+        let lamports: U256 = self
+            .backend
+            .map_solana_account(address, |info| **info.lamports.borrow())
+            .await
+            .into();
 
-#[allow(clippy::unnecessary_wraps)]
-#[maybe_async]
-async fn account_info<B: AccountStorage>(
-    state: &mut ExecutorState<'_, B>,
-    address: &Pubkey,
-) -> Result<Vec<u8>> {
-    fn to_solidity_account_value(info: &AccountInfo) -> Vec<u8> {
-        let mut buffer = [0_u8; 5 * 32];
-        let (key, _, lamports, owner, _, executable, _, rent_epoch) =
-            arrayref::mut_array_refs![&mut buffer, 32, 24, 8, 32, 31, 1, 24, 8];
+        let bytes = lamports.to_be_bytes().to_vec();
 
-        *key = info.key.to_bytes();
-        *lamports = info.lamports().to_be_bytes();
-        *owner = info.owner.to_bytes();
-        executable[0] = info.executable.into();
-        *rent_epoch = info.rent_epoch.to_be_bytes();
-
-        buffer.to_vec()
+        Ok(bytes)
     }
 
-    let info = state
-        .backend
-        .map_solana_account(address, to_solidity_account_value)
-        .await;
+    #[allow(clippy::unnecessary_wraps)]
+    #[maybe_async]
+    async fn account_rent_epoch(&mut self, address: &Pubkey) -> Result<Vec<u8>> {
+        let epoch: U256 = self
+            .backend
+            .map_solana_account(address, |info| info.rent_epoch)
+            .await
+            .into();
 
-    Ok(info)
+        let bytes = epoch.to_be_bytes().to_vec();
+
+        Ok(bytes)
+    }
+
+    #[allow(clippy::unnecessary_wraps)]
+    #[maybe_async]
+    async fn account_is_executable(&mut self, address: &Pubkey) -> Result<Vec<u8>> {
+        let executable: U256 = self
+            .backend
+            .map_solana_account(address, |info| info.executable)
+            .await
+            .into();
+
+        let bytes = executable.to_be_bytes().to_vec();
+
+        Ok(bytes)
+    }
+
+    #[allow(clippy::unnecessary_wraps)]
+    #[maybe_async]
+    async fn account_data_length(&mut self, address: &Pubkey) -> Result<Vec<u8>> {
+        let length: U256 = self
+            .backend
+            .map_solana_account(address, |info| info.data.borrow().len())
+            .await
+            .try_into()?;
+
+        let bytes = length.to_be_bytes().to_vec();
+
+        Ok(bytes)
+    }
+
+    #[allow(clippy::unnecessary_wraps)]
+    #[maybe_async]
+    async fn account_data(
+        &mut self,
+        address: &Pubkey,
+        offset: usize,
+        length: usize,
+    ) -> Result<Vec<u8>> {
+        if length == 0 {
+            return Err(Error::Custom(
+                "Query Account: data() - length == 0".to_string(),
+            ));
+        }
+
+        self.backend
+            .map_solana_account(address, |info| {
+                info.data
+                    .borrow()
+                    .get(offset..offset + length)
+                    .map(<[u8]>::to_vec)
+            })
+            .await
+            .ok_or_else(|| Error::Custom("Query Account: data() - out of bounds".to_string()))
+    }
+
+    #[allow(clippy::unnecessary_wraps)]
+    #[maybe_async]
+    async fn account_info(&mut self, address: &Pubkey) -> Result<Vec<u8>> {
+        fn to_solidity_account_value(info: &AccountInfo) -> Vec<u8> {
+            let mut buffer = [0_u8; 5 * 32];
+            let (key, _, lamports, owner, _, executable, _, rent_epoch) =
+                arrayref::mut_array_refs![&mut buffer, 32, 24, 8, 32, 31, 1, 24, 8];
+
+            *key = info.key.to_bytes();
+            *lamports = info.lamports().to_be_bytes();
+            *owner = info.owner.to_bytes();
+            executable[0] = info.executable.into();
+            *rent_epoch = info.rent_epoch.to_be_bytes();
+
+            buffer.to_vec()
+        }
+
+        let info = self
+            .backend
+            .map_solana_account(address, to_solidity_account_value)
+            .await;
+
+        Ok(info)
+    }
 }

--- a/evm_loader/program/src/executor/precompile_extension/spl_token.rs
+++ b/evm_loader/program/src/executor/precompile_extension/spl_token.rs
@@ -33,6 +33,36 @@ use crate::{
 // [0x78, 0x42, 0x3b, 0xcf] : "transfer(bytes32,bytes32,uint64)"
 // [0x7c, 0x0e, 0xb8, 0x10] : "transferWithSeed(bytes32,bytes32,bytes32,uint64)"
 
+#[inline]
+fn read_u8(input: &[u8]) -> Result<u8> {
+    U256::from_be_bytes(*arrayref::array_ref![input, 0, 32])
+        .try_into()
+        .map_err(Into::into)
+}
+
+#[inline]
+fn read_u64(input: &[u8]) -> Result<u64> {
+    U256::from_be_bytes(*arrayref::array_ref![input, 0, 32])
+        .try_into()
+        .map_err(Into::into)
+}
+
+#[inline]
+fn read_pubkey(input: &[u8]) -> Result<Pubkey> {
+    if input.len() < 32 {
+        return Err(Error::OutOfBounds);
+    }
+    Ok(Pubkey::new_from_array(*arrayref::array_ref![input, 0, 32]))
+}
+
+#[inline]
+fn read_salt(input: &[u8]) -> Result<&[u8; 32]> {
+    if input.len() < 32 {
+        return Err(Error::OutOfBounds);
+    }
+    Ok(arrayref::array_ref![input, 0, 32])
+}
+
 impl<B: AccountStorage> ExecutorState<'_, B> {
     #[allow(clippy::too_many_lines)]
     #[maybe_async]
@@ -229,39 +259,7 @@ impl<B: AccountStorage> ExecutorState<'_, B> {
             _ => Err(Error::UnknownPrecompileMethodSelector(*address, selector)),
         }
     }
-}
 
-#[inline]
-fn read_u8(input: &[u8]) -> Result<u8> {
-    U256::from_be_bytes(*arrayref::array_ref![input, 0, 32])
-        .try_into()
-        .map_err(Into::into)
-}
-
-#[inline]
-fn read_u64(input: &[u8]) -> Result<u64> {
-    U256::from_be_bytes(*arrayref::array_ref![input, 0, 32])
-        .try_into()
-        .map_err(Into::into)
-}
-
-#[inline]
-fn read_pubkey(input: &[u8]) -> Result<Pubkey> {
-    if input.len() < 32 {
-        return Err(Error::OutOfBounds);
-    }
-    Ok(Pubkey::new_from_array(*arrayref::array_ref![input, 0, 32]))
-}
-
-#[inline]
-fn read_salt(input: &[u8]) -> Result<&[u8; 32]> {
-    if input.len() < 32 {
-        return Err(Error::OutOfBounds);
-    }
-    Ok(arrayref::array_ref![input, 0, 32])
-}
-
-impl<B: AccountStorage> ExecutorState<'_, B> {
     fn create_account(
         &mut self,
         account: &OwnedAccountInfo,

--- a/evm_loader/program/src/executor/precompile_extension/spl_token.rs
+++ b/evm_loader/program/src/executor/precompile_extension/spl_token.rs
@@ -65,7 +65,9 @@ pub async fn spl_token<B: AccountStorage>(
             let seed = read_salt(input)?;
             let decimals = read_u8(&input[32..])?;
 
-            initialize_mint(context, state, seed, decimals, None, None).await
+            state
+                .initialize_mint(context, seed, decimals, None, None)
+                .await
         }
         [0xc3, 0xf3, 0xf2, 0xf2] => {
             // initializeMint(bytes32 seed, uint8 decimals, bytes32 mint_authority, bytes32 freeze_authority)
@@ -77,15 +79,15 @@ pub async fn spl_token<B: AccountStorage>(
             let decimals = read_u8(&input[32..])?;
             let mint_authority = read_pubkey(&input[64..])?;
             let freeze_authority = read_pubkey(&input[96..])?;
-            initialize_mint(
-                context,
-                state,
-                seed,
-                decimals,
-                Some(mint_authority),
-                Some(freeze_authority),
-            )
-            .await
+            state
+                .initialize_mint(
+                    context,
+                    seed,
+                    decimals,
+                    Some(mint_authority),
+                    Some(freeze_authority),
+                )
+                .await
         }
         [0xda, 0xa1, 0x2c, 0x5c] => {
             // initializeAccount(bytes32 seed, bytes32 mint)
@@ -96,7 +98,7 @@ pub async fn spl_token<B: AccountStorage>(
             let seed = read_salt(input)?;
             let mint = read_pubkey(&input[32..])?;
 
-            initialize_account(context, state, seed, mint, None).await
+            state.initialize_account(context, seed, mint, None).await
         }
         [0xfc, 0x86, 0xb7, 0x17] => {
             // initializeAccount(bytes32 seed, bytes32 mint, bytes32 owner)
@@ -107,7 +109,9 @@ pub async fn spl_token<B: AccountStorage>(
             let seed = read_salt(input)?;
             let mint = read_pubkey(&input[32..])?;
             let owner = read_pubkey(&input[64..])?;
-            initialize_account(context, state, seed, mint, Some(owner)).await
+            state
+                .initialize_account(context, seed, mint, Some(owner))
+                .await
         }
         [0x57, 0x82, 0xa0, 0x43] => {
             // closeAccount(bytes32 account)
@@ -116,7 +120,7 @@ pub async fn spl_token<B: AccountStorage>(
             }
 
             let account = read_pubkey(input)?;
-            close_account(context, state, account)
+            state.close_account(context, account)
         }
         [0xa9, 0xc1, 0x58, 0x06] => {
             // approve(bytes32 source, bytes32 target, uint64 amount)
@@ -127,7 +131,7 @@ pub async fn spl_token<B: AccountStorage>(
             let source = read_pubkey(input)?;
             let target = read_pubkey(&input[32..])?;
             let amount = read_u64(&input[64..])?;
-            approve(context, state, source, target, amount)
+            state.approve(context, source, target, amount)
         }
         [0xb7, 0x5c, 0x7d, 0xc6] => {
             // revoke(bytes32 source)
@@ -136,7 +140,7 @@ pub async fn spl_token<B: AccountStorage>(
             }
 
             let source = read_pubkey(input)?;
-            revoke(context, state, source)
+            state.revoke(context, source)
         }
         [0x78, 0x42, 0x3b, 0xcf] => {
             // transfer(bytes32 source, bytes32 target, uint64 amount)
@@ -147,7 +151,7 @@ pub async fn spl_token<B: AccountStorage>(
             let source = read_pubkey(input)?;
             let target = read_pubkey(&input[32..])?;
             let amount = read_u64(&input[64..])?;
-            transfer(context, state, source, target, amount)
+            state.transfer(context, source, target, amount)
         }
         [0x7c, 0x0e, 0xb8, 0x10] => {
             // transferWithSeed(bytes32,bytes32,bytes32,uint64)
@@ -160,7 +164,7 @@ pub async fn spl_token<B: AccountStorage>(
             let target = read_pubkey(&input[64..])?;
             let amount = read_u64(&input[96..])?;
 
-            transfer_with_seed(context, state, seed, source, target, amount)
+            state.transfer_with_seed(context, seed, source, target, amount)
         }
         [0xc9, 0xd0, 0xe2, 0xfd] => {
             // mintTo(bytes32 mint, bytes32 account, uint64 amount)
@@ -171,7 +175,7 @@ pub async fn spl_token<B: AccountStorage>(
             let mint = read_pubkey(input)?;
             let account = read_pubkey(&input[32..])?;
             let amount = read_u64(&input[64..])?;
-            mint_to(context, state, mint, account, amount)
+            state.mint_to(context, mint, account, amount)
         }
         [0xc0, 0x67, 0xee, 0xbb] => {
             // burn(bytes32 mint, bytes32 account, uint64 amount)
@@ -182,7 +186,7 @@ pub async fn spl_token<B: AccountStorage>(
             let mint = read_pubkey(input)?;
             let account = read_pubkey(&input[32..])?;
             let amount = read_u64(&input[64..])?;
-            burn(context, state, mint, account, amount)
+            state.burn_spl_token(context, mint, account, amount)
         }
         [0x44, 0xef, 0x32, 0x44] => {
             // freeze(bytes32 mint, bytes32 account)
@@ -192,7 +196,7 @@ pub async fn spl_token<B: AccountStorage>(
 
             let mint = read_pubkey(input)?;
             let account = read_pubkey(&input[32..])?;
-            freeze(context, state, mint, account)
+            state.freeze(context, mint, account)
         }
         [0x3d, 0x71, 0x8c, 0x9a] => {
             // thaw(bytes32 mint, bytes32 account)
@@ -202,27 +206,27 @@ pub async fn spl_token<B: AccountStorage>(
 
             let mint = read_pubkey(input)?;
             let account = read_pubkey(&input[32..])?;
-            thaw(context, state, mint, account)
+            state.thaw(context, mint, account)
         }
         [0xeb, 0x7d, 0xa7, 0x8c] => {
             // findAccount(bytes32 seed)
             let seed = read_salt(input)?;
-            find_account(context, state, seed)
+            state.find_account(context, seed)
         }
         [0x6d, 0xa9, 0xde, 0x75] => {
             // isSystemAccount(bytes32 account)
             let account = read_pubkey(input)?;
-            is_system_account(context, state, account).await
+            state.is_system_account(context, account).await
         }
         [0xd1, 0xde, 0x50, 0x11] => {
             // getAccount(bytes32 account)
             let account = read_pubkey(input)?;
-            get_account(context, state, account).await
+            state.get_account(context, account).await
         }
         [0xa2, 0xce, 0x9c, 0x1f] => {
             // getMint(bytes32 account)
             let account = read_pubkey(input)?;
-            get_mint(context, state, account).await
+            state.get_mint(context, account).await
         }
         _ => Err(Error::UnknownPrecompileMethodSelector(*address, selector)),
     }
@@ -258,492 +262,480 @@ fn read_salt(input: &[u8]) -> Result<&[u8; 32]> {
     Ok(arrayref::array_ref![input, 0, 32])
 }
 
-fn create_account<B: AccountStorage>(
-    state: &mut ExecutorState<B>,
-    account: &OwnedAccountInfo,
-    space: usize,
-    seeds: Vec<Vec<u8>>,
-) -> Result<()> {
-    let rent = Rent::get()?;
-    let minimum_balance = rent.minimum_balance(space);
+impl<B: AccountStorage> ExecutorState<'_, B> {
+    fn create_account(
+        &mut self,
+        account: &OwnedAccountInfo,
+        space: usize,
+        seeds: Vec<Vec<u8>>,
+    ) -> Result<()> {
+        let rent = Rent::get()?;
+        let minimum_balance = rent.minimum_balance(space);
 
-    let required_lamports = minimum_balance.saturating_sub(account.lamports);
+        let required_lamports = minimum_balance.saturating_sub(account.lamports);
 
-    if required_lamports > 0 {
-        let transfer = system_instruction::transfer(
-            &state.backend.operator(),
-            &account.key,
-            required_lamports,
+        if required_lamports > 0 {
+            let transfer = system_instruction::transfer(
+                &self.backend.operator(),
+                &account.key,
+                required_lamports,
+            );
+            self.queue_external_instruction(transfer, vec![], required_lamports);
+        }
+
+        let allocate = system_instruction::allocate(&account.key, space.try_into().unwrap());
+        self.queue_external_instruction(allocate, seeds.clone(), 0);
+
+        let assign = system_instruction::assign(&account.key, &spl_token::ID);
+        self.queue_external_instruction(assign, seeds, 0);
+
+        Ok(())
+    }
+
+    #[maybe_async]
+    async fn initialize_mint(
+        &mut self,
+        context: &crate::evm::Context,
+        seed: &[u8],
+        decimals: u8,
+        mint_authority: Option<Pubkey>,
+        freeze_authority: Option<Pubkey>,
+    ) -> Result<Vec<u8>> {
+        let signer = context.caller;
+        let (signer_pubkey, _) = self.backend.contract_pubkey(signer);
+
+        let (mint_key, bump_seed) = Pubkey::find_program_address(
+            &[
+                &[ACCOUNT_SEED_VERSION],
+                b"ContractData",
+                signer.as_bytes(),
+                seed,
+            ],
+            self.backend.program_id(),
         );
-        state.queue_external_instruction(transfer, vec![], required_lamports);
+
+        let account = self.external_account(mint_key).await?;
+        if !system_program::check_id(&account.owner) {
+            return Err(Error::AccountInvalidOwner(mint_key, system_program::ID));
+        }
+
+        let seeds: Vec<Vec<u8>> = vec![
+            vec![ACCOUNT_SEED_VERSION],
+            b"ContractData".to_vec(),
+            signer.as_bytes().to_vec(),
+            seed.to_vec(),
+            vec![bump_seed],
+        ];
+
+        self.create_account(&account, spl_token::state::Mint::LEN, seeds)?;
+
+        let initialize_mint = spl_token::instruction::initialize_mint(
+            &spl_token::ID,
+            &mint_key,
+            &mint_authority.unwrap_or(signer_pubkey),
+            Some(&freeze_authority.unwrap_or(signer_pubkey)),
+            decimals,
+        )?;
+        self.queue_external_instruction(initialize_mint, vec![], 0);
+
+        Ok(mint_key.to_bytes().to_vec())
     }
 
-    let allocate = system_instruction::allocate(&account.key, space.try_into().unwrap());
-    state.queue_external_instruction(allocate, seeds.clone(), 0);
+    #[maybe_async]
+    async fn initialize_account(
+        &mut self,
+        context: &crate::evm::Context,
+        seed: &[u8],
+        mint: Pubkey,
+        owner: Option<Pubkey>,
+    ) -> Result<Vec<u8>> {
+        let signer = context.caller;
+        let (signer_pubkey, _) = self.backend.contract_pubkey(signer);
 
-    let assign = system_instruction::assign(&account.key, &spl_token::ID);
-    state.queue_external_instruction(assign, seeds, 0);
+        let (account_key, bump_seed) = Pubkey::find_program_address(
+            &[
+                &[ACCOUNT_SEED_VERSION],
+                b"ContractData",
+                signer.as_bytes(),
+                seed,
+            ],
+            self.backend.program_id(),
+        );
 
-    Ok(())
-}
+        let account = self.external_account(account_key).await?;
+        if !system_program::check_id(&account.owner) {
+            return Err(Error::AccountInvalidOwner(account_key, system_program::ID));
+        }
 
-#[maybe_async]
-async fn initialize_mint<B: AccountStorage>(
-    context: &crate::evm::Context,
-    state: &mut ExecutorState<'_, B>,
-    seed: &[u8],
-    decimals: u8,
-    mint_authority: Option<Pubkey>,
-    freeze_authority: Option<Pubkey>,
-) -> Result<Vec<u8>> {
-    let signer = context.caller;
-    let (signer_pubkey, _) = state.backend.contract_pubkey(signer);
+        let seeds: Vec<Vec<u8>> = vec![
+            vec![ACCOUNT_SEED_VERSION],
+            b"ContractData".to_vec(),
+            signer.as_bytes().to_vec(),
+            seed.to_vec(),
+            vec![bump_seed],
+        ];
 
-    let (mint_key, bump_seed) = Pubkey::find_program_address(
-        &[
+        self.create_account(&account, spl_token::state::Account::LEN, seeds)?;
+
+        let initialize_mint = spl_token::instruction::initialize_account2(
+            &spl_token::ID,
+            &account_key,
+            &mint,
+            &owner.unwrap_or(signer_pubkey),
+        )?;
+        self.queue_external_instruction(initialize_mint, vec![], 0);
+
+        Ok(account_key.to_bytes().to_vec())
+    }
+
+    fn close_account(&mut self, context: &crate::evm::Context, account: Pubkey) -> Result<Vec<u8>> {
+        let signer = context.caller;
+        let (signer_pubkey, bump_seed) = self.backend.contract_pubkey(signer);
+
+        let seeds = vec![
+            vec![ACCOUNT_SEED_VERSION],
+            signer.as_bytes().to_vec(),
+            vec![bump_seed],
+        ];
+
+        let close_account = spl_token::instruction::close_account(
+            &spl_token::ID,
+            &account,
+            &self.backend.operator(),
+            &signer_pubkey,
+            &[],
+        )?;
+        self.queue_external_instruction(close_account, seeds, 0);
+
+        Ok(vec![])
+    }
+
+    fn approve(
+        &mut self,
+        context: &crate::evm::Context,
+        source: Pubkey,
+        target: Pubkey,
+        amount: u64,
+    ) -> Result<Vec<u8>> {
+        let signer = context.caller;
+        let (signer_pubkey, bump_seed) = self.backend.contract_pubkey(signer);
+
+        let seeds = vec![
+            vec![ACCOUNT_SEED_VERSION],
+            signer.as_bytes().to_vec(),
+            vec![bump_seed],
+        ];
+
+        let approve = spl_token::instruction::approve(
+            &spl_token::ID,
+            &source,
+            &target,
+            &signer_pubkey,
+            &[],
+            amount,
+        )?;
+        self.queue_external_instruction(approve, seeds, 0);
+
+        Ok(vec![])
+    }
+
+    fn revoke(&mut self, context: &crate::evm::Context, account: Pubkey) -> Result<Vec<u8>> {
+        let signer = context.caller;
+        let (signer_pubkey, bump_seed) = self.backend.contract_pubkey(signer);
+
+        let seeds = vec![
+            vec![ACCOUNT_SEED_VERSION],
+            signer.as_bytes().to_vec(),
+            vec![bump_seed],
+        ];
+
+        let revoke = spl_token::instruction::revoke(&spl_token::ID, &account, &signer_pubkey, &[])?;
+        self.queue_external_instruction(revoke, seeds, 0);
+
+        Ok(vec![])
+    }
+
+    fn transfer(
+        &mut self,
+        context: &crate::evm::Context,
+        source: Pubkey,
+        target: Pubkey,
+        amount: u64,
+    ) -> Result<Vec<u8>> {
+        let signer = context.caller;
+        let (signer_pubkey, bump_seed) = self.backend.contract_pubkey(signer);
+
+        let seeds = vec![
+            vec![ACCOUNT_SEED_VERSION],
+            signer.as_bytes().to_vec(),
+            vec![bump_seed],
+        ];
+
+        let transfer = spl_token::instruction::transfer(
+            &spl_token::ID,
+            &source,
+            &target,
+            &signer_pubkey,
+            &[],
+            amount,
+        )?;
+        self.queue_external_instruction(transfer, seeds, 0);
+
+        Ok(vec![])
+    }
+
+    fn transfer_with_seed(
+        &mut self,
+        context: &crate::evm::Context,
+        seed: &[u8; 32],
+        source: Pubkey,
+        target: Pubkey,
+        amount: u64,
+    ) -> Result<Vec<u8>> {
+        let seeds: &[&[u8]] = &[
             &[ACCOUNT_SEED_VERSION],
-            b"ContractData",
-            signer.as_bytes(),
+            b"AUTH",
+            context.caller.as_bytes(),
             seed,
-        ],
-        state.backend.program_id(),
-    );
+        ];
+        let (signer_pubkey, signer_seed) =
+            Pubkey::find_program_address(seeds, self.backend.program_id());
 
-    let account = state.external_account(mint_key).await?;
-    if !system_program::check_id(&account.owner) {
-        return Err(Error::AccountInvalidOwner(mint_key, system_program::ID));
+        let seeds = vec![
+            vec![ACCOUNT_SEED_VERSION],
+            b"AUTH".to_vec(),
+            context.caller.as_bytes().to_vec(),
+            seed.to_vec(),
+            vec![signer_seed],
+        ];
+
+        let transfer = spl_token::instruction::transfer(
+            &spl_token::ID,
+            &source,
+            &target,
+            &signer_pubkey,
+            &[],
+            amount,
+        )?;
+        self.queue_external_instruction(transfer, seeds, 0);
+
+        Ok(vec![])
     }
 
-    let seeds: Vec<Vec<u8>> = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        b"ContractData".to_vec(),
-        signer.as_bytes().to_vec(),
-        seed.to_vec(),
-        vec![bump_seed],
-    ];
+    fn mint_to(
+        &mut self,
+        context: &crate::evm::Context,
+        mint: Pubkey,
+        target: Pubkey,
+        amount: u64,
+    ) -> Result<Vec<u8>> {
+        let signer = context.caller;
+        let (signer_pubkey, bump_seed) = self.backend.contract_pubkey(signer);
 
-    create_account(state, &account, spl_token::state::Mint::LEN, seeds)?;
+        let seeds = vec![
+            vec![ACCOUNT_SEED_VERSION],
+            signer.as_bytes().to_vec(),
+            vec![bump_seed],
+        ];
 
-    let initialize_mint = spl_token::instruction::initialize_mint(
-        &spl_token::ID,
-        &mint_key,
-        &mint_authority.unwrap_or(signer_pubkey),
-        Some(&freeze_authority.unwrap_or(signer_pubkey)),
-        decimals,
-    )?;
-    state.queue_external_instruction(initialize_mint, vec![], 0);
+        let mint_to = spl_token::instruction::mint_to(
+            &spl_token::ID,
+            &mint,
+            &target,
+            &signer_pubkey,
+            &[],
+            amount,
+        )?;
+        self.queue_external_instruction(mint_to, seeds, 0);
 
-    Ok(mint_key.to_bytes().to_vec())
-}
-
-#[maybe_async]
-async fn initialize_account<B: AccountStorage>(
-    context: &crate::evm::Context,
-    state: &mut ExecutorState<'_, B>,
-    seed: &[u8],
-    mint: Pubkey,
-    owner: Option<Pubkey>,
-) -> Result<Vec<u8>> {
-    let signer = context.caller;
-    let (signer_pubkey, _) = state.backend.contract_pubkey(signer);
-
-    let (account_key, bump_seed) = Pubkey::find_program_address(
-        &[
-            &[ACCOUNT_SEED_VERSION],
-            b"ContractData",
-            signer.as_bytes(),
-            seed,
-        ],
-        state.backend.program_id(),
-    );
-
-    let account = state.external_account(account_key).await?;
-    if !system_program::check_id(&account.owner) {
-        return Err(Error::AccountInvalidOwner(account_key, system_program::ID));
+        Ok(vec![])
     }
 
-    let seeds: Vec<Vec<u8>> = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        b"ContractData".to_vec(),
-        signer.as_bytes().to_vec(),
-        seed.to_vec(),
-        vec![bump_seed],
-    ];
+    fn burn_spl_token(
+        &mut self,
+        context: &crate::evm::Context,
+        mint: Pubkey,
+        source: Pubkey,
+        amount: u64,
+    ) -> Result<Vec<u8>> {
+        let signer = context.caller;
+        let (signer_pubkey, bump_seed) = self.backend.contract_pubkey(signer);
 
-    create_account(state, &account, spl_token::state::Account::LEN, seeds)?;
+        let seeds = vec![
+            vec![ACCOUNT_SEED_VERSION],
+            signer.as_bytes().to_vec(),
+            vec![bump_seed],
+        ];
 
-    let initialize_mint = spl_token::instruction::initialize_account2(
-        &spl_token::ID,
-        &account_key,
-        &mint,
-        &owner.unwrap_or(signer_pubkey),
-    )?;
-    state.queue_external_instruction(initialize_mint, vec![], 0);
+        let burn = spl_token::instruction::burn(
+            &spl_token::ID,
+            &source,
+            &mint,
+            &signer_pubkey,
+            &[],
+            amount,
+        )?;
+        self.queue_external_instruction(burn, seeds, 0);
 
-    Ok(account_key.to_bytes().to_vec())
-}
-
-fn close_account<B: AccountStorage>(
-    context: &crate::evm::Context,
-    state: &mut ExecutorState<B>,
-    account: Pubkey,
-) -> Result<Vec<u8>> {
-    let signer = context.caller;
-    let (signer_pubkey, bump_seed) = state.backend.contract_pubkey(signer);
-
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        signer.as_bytes().to_vec(),
-        vec![bump_seed],
-    ];
-
-    let close_account = spl_token::instruction::close_account(
-        &spl_token::ID,
-        &account,
-        &state.backend.operator(),
-        &signer_pubkey,
-        &[],
-    )?;
-    state.queue_external_instruction(close_account, seeds, 0);
-
-    Ok(vec![])
-}
-
-fn approve<B: AccountStorage>(
-    context: &crate::evm::Context,
-    state: &mut ExecutorState<B>,
-    source: Pubkey,
-    target: Pubkey,
-    amount: u64,
-) -> Result<Vec<u8>> {
-    let signer = context.caller;
-    let (signer_pubkey, bump_seed) = state.backend.contract_pubkey(signer);
-
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        signer.as_bytes().to_vec(),
-        vec![bump_seed],
-    ];
-
-    let approve = spl_token::instruction::approve(
-        &spl_token::ID,
-        &source,
-        &target,
-        &signer_pubkey,
-        &[],
-        amount,
-    )?;
-    state.queue_external_instruction(approve, seeds, 0);
-
-    Ok(vec![])
-}
-
-fn revoke<B: AccountStorage>(
-    context: &crate::evm::Context,
-    state: &mut ExecutorState<B>,
-    account: Pubkey,
-) -> Result<Vec<u8>> {
-    let signer = context.caller;
-    let (signer_pubkey, bump_seed) = state.backend.contract_pubkey(signer);
-
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        signer.as_bytes().to_vec(),
-        vec![bump_seed],
-    ];
-
-    let revoke = spl_token::instruction::revoke(&spl_token::ID, &account, &signer_pubkey, &[])?;
-    state.queue_external_instruction(revoke, seeds, 0);
-
-    Ok(vec![])
-}
-
-fn transfer<B: AccountStorage>(
-    context: &crate::evm::Context,
-    state: &mut ExecutorState<B>,
-    source: Pubkey,
-    target: Pubkey,
-    amount: u64,
-) -> Result<Vec<u8>> {
-    let signer = context.caller;
-    let (signer_pubkey, bump_seed) = state.backend.contract_pubkey(signer);
-
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        signer.as_bytes().to_vec(),
-        vec![bump_seed],
-    ];
-
-    let transfer = spl_token::instruction::transfer(
-        &spl_token::ID,
-        &source,
-        &target,
-        &signer_pubkey,
-        &[],
-        amount,
-    )?;
-    state.queue_external_instruction(transfer, seeds, 0);
-
-    Ok(vec![])
-}
-
-fn transfer_with_seed<B: AccountStorage>(
-    context: &crate::evm::Context,
-    state: &mut ExecutorState<B>,
-    seed: &[u8; 32],
-    source: Pubkey,
-    target: Pubkey,
-    amount: u64,
-) -> Result<Vec<u8>> {
-    let seeds: &[&[u8]] = &[
-        &[ACCOUNT_SEED_VERSION],
-        b"AUTH",
-        context.caller.as_bytes(),
-        seed,
-    ];
-    let (signer_pubkey, signer_seed) =
-        Pubkey::find_program_address(seeds, state.backend.program_id());
-
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        b"AUTH".to_vec(),
-        context.caller.as_bytes().to_vec(),
-        seed.to_vec(),
-        vec![signer_seed],
-    ];
-
-    let transfer = spl_token::instruction::transfer(
-        &spl_token::ID,
-        &source,
-        &target,
-        &signer_pubkey,
-        &[],
-        amount,
-    )?;
-    state.queue_external_instruction(transfer, seeds, 0);
-
-    Ok(vec![])
-}
-
-fn mint_to<B: AccountStorage>(
-    context: &crate::evm::Context,
-    state: &mut ExecutorState<B>,
-    mint: Pubkey,
-    target: Pubkey,
-    amount: u64,
-) -> Result<Vec<u8>> {
-    let signer = context.caller;
-    let (signer_pubkey, bump_seed) = state.backend.contract_pubkey(signer);
-
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        signer.as_bytes().to_vec(),
-        vec![bump_seed],
-    ];
-
-    let mint_to = spl_token::instruction::mint_to(
-        &spl_token::ID,
-        &mint,
-        &target,
-        &signer_pubkey,
-        &[],
-        amount,
-    )?;
-    state.queue_external_instruction(mint_to, seeds, 0);
-
-    Ok(vec![])
-}
-
-fn burn<B: AccountStorage>(
-    context: &crate::evm::Context,
-    state: &mut ExecutorState<B>,
-    mint: Pubkey,
-    source: Pubkey,
-    amount: u64,
-) -> Result<Vec<u8>> {
-    let signer = context.caller;
-    let (signer_pubkey, bump_seed) = state.backend.contract_pubkey(signer);
-
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        signer.as_bytes().to_vec(),
-        vec![bump_seed],
-    ];
-
-    #[rustfmt::skip]
-    let burn = spl_token::instruction::burn(
-        &spl_token::ID,
-        &source,
-        &mint,
-        &signer_pubkey,
-        &[],
-        amount
-    )?;
-    state.queue_external_instruction(burn, seeds, 0);
-
-    Ok(vec![])
-}
-
-fn freeze<B: AccountStorage>(
-    context: &crate::evm::Context,
-    state: &mut ExecutorState<B>,
-    mint: Pubkey,
-    target: Pubkey,
-) -> Result<Vec<u8>> {
-    let signer = context.caller;
-    let (signer_pubkey, bump_seed) = state.backend.contract_pubkey(signer);
-
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        signer.as_bytes().to_vec(),
-        vec![bump_seed],
-    ];
-
-    let freeze = spl_token::instruction::freeze_account(
-        &spl_token::ID,
-        &target,
-        &mint,
-        &signer_pubkey,
-        &[],
-    )?;
-    state.queue_external_instruction(freeze, seeds, 0);
-
-    Ok(vec![])
-}
-
-fn thaw<B: AccountStorage>(
-    context: &crate::evm::Context,
-    state: &mut ExecutorState<B>,
-    mint: Pubkey,
-    target: Pubkey,
-) -> Result<Vec<u8>> {
-    let signer = context.caller;
-    let (signer_pubkey, bump_seed) = state.backend.contract_pubkey(signer);
-
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        signer.as_bytes().to_vec(),
-        vec![bump_seed],
-    ];
-
-    #[rustfmt::skip]
-    let thaw = spl_token::instruction::thaw_account(
-        &spl_token::ID,
-        &target,
-        &mint,
-        &signer_pubkey,
-        &[]
-    )?;
-    state.queue_external_instruction(thaw, seeds, 0);
-
-    Ok(vec![])
-}
-
-#[allow(clippy::unnecessary_wraps)]
-fn find_account<B: AccountStorage>(
-    context: &crate::evm::Context,
-    state: &mut ExecutorState<B>,
-    seed: &[u8],
-) -> Result<Vec<u8>> {
-    let signer = context.caller;
-
-    let (account_key, _) = Pubkey::find_program_address(
-        &[
-            &[ACCOUNT_SEED_VERSION],
-            b"ContractData",
-            signer.as_bytes(),
-            seed,
-        ],
-        state.backend.program_id(),
-    );
-
-    Ok(account_key.to_bytes().to_vec())
-}
-
-#[maybe_async]
-async fn is_system_account<B: AccountStorage>(
-    _context: &crate::evm::Context,
-    state: &mut ExecutorState<'_, B>,
-    account: Pubkey,
-) -> Result<Vec<u8>> {
-    let account = state.external_account(account).await?;
-    if system_program::check_id(&account.owner) {
-        let mut result = vec![0_u8; 32];
-        result[31] = 1; // return true
-
-        Ok(result)
-    } else {
-        Ok(vec![0_u8; 32])
+        Ok(vec![])
     }
-}
 
-#[maybe_async]
-async fn get_account<B: AccountStorage>(
-    _context: &crate::evm::Context,
-    state: &mut ExecutorState<'_, B>,
-    account: Pubkey,
-) -> Result<Vec<u8>> {
-    let account = state.external_account(account).await?;
-    let token = if spl_token::check_id(&account.owner) {
-        spl_token::state::Account::unpack(&account.data)?
-    } else if system_program::check_id(&account.owner) {
-        spl_token::state::Account::default()
-    } else {
-        return Err(ProgramError::IllegalOwner.into());
-    };
+    fn freeze(
+        &mut self,
+        context: &crate::evm::Context,
+        mint: Pubkey,
+        target: Pubkey,
+    ) -> Result<Vec<u8>> {
+        let signer = context.caller;
+        let (signer_pubkey, bump_seed) = self.backend.contract_pubkey(signer);
 
-    debug_print!("spl_token get_account: {:?}", token);
+        let seeds = vec![
+            vec![ACCOUNT_SEED_VERSION],
+            signer.as_bytes().to_vec(),
+            vec![bump_seed],
+        ];
 
-    let mut result = [0_u8; 7 * 32];
-    let (mint, owner, _, amount, delegate, _, delegated_amount, close_authority, state) =
-        arrayref::mut_array_refs![&mut result, 32, 32, 24, 8, 32, 24, 8, 32, 32];
+        let freeze = spl_token::instruction::freeze_account(
+            &spl_token::ID,
+            &target,
+            &mint,
+            &signer_pubkey,
+            &[],
+        )?;
+        self.queue_external_instruction(freeze, seeds, 0);
 
-    *mint = token.mint.to_bytes();
-    *owner = token.owner.to_bytes();
-    *amount = token.amount.to_be_bytes();
-    *delegate = token.delegate.map(Pubkey::to_bytes).unwrap_or_default();
-    *delegated_amount = token.delegated_amount.to_be_bytes();
-    *close_authority = token
-        .close_authority
-        .map(Pubkey::to_bytes)
-        .unwrap_or_default();
-    state[31] = token.state as u8;
+        Ok(vec![])
+    }
 
-    Ok(result.to_vec())
-}
+    fn thaw(
+        &mut self,
+        context: &crate::evm::Context,
+        mint: Pubkey,
+        target: Pubkey,
+    ) -> Result<Vec<u8>> {
+        let signer = context.caller;
+        let (signer_pubkey, bump_seed) = self.backend.contract_pubkey(signer);
 
-#[maybe_async]
-async fn get_mint<B: AccountStorage>(
-    _context: &crate::evm::Context,
-    state: &mut ExecutorState<'_, B>,
-    account: Pubkey,
-) -> Result<Vec<u8>> {
-    let account = state.external_account(account).await?;
-    let mint = if spl_token::check_id(&account.owner) {
-        spl_token::state::Mint::unpack(&account.data)?
-    } else if system_program::check_id(&account.owner) {
-        spl_token::state::Mint::default()
-    } else {
-        return Err(ProgramError::IllegalOwner.into());
-    };
+        let seeds = vec![
+            vec![ACCOUNT_SEED_VERSION],
+            signer.as_bytes().to_vec(),
+            vec![bump_seed],
+        ];
 
-    debug_print!("spl_token get_mint: {:?}", mint);
+        let thaw = spl_token::instruction::thaw_account(
+            &spl_token::ID,
+            &target,
+            &mint,
+            &signer_pubkey,
+            &[],
+        )?;
+        self.queue_external_instruction(thaw, seeds, 0);
 
-    let mut result = [0_u8; 5 * 32];
-    let (_, supply, _, decimals, _, is_initialized, freeze_authority, mint_authority) =
-        arrayref::mut_array_refs![&mut result, 24, 8, 31, 1, 31, 1, 32, 32];
+        Ok(vec![])
+    }
 
-    *supply = mint.supply.to_be_bytes();
-    *decimals = mint.decimals.to_be_bytes();
-    *is_initialized = if mint.is_initialized { [1_u8] } else { [0_u8] };
-    *freeze_authority = mint
-        .freeze_authority
-        .map(Pubkey::to_bytes)
-        .unwrap_or_default();
-    *mint_authority = mint
-        .mint_authority
-        .map(Pubkey::to_bytes)
-        .unwrap_or_default();
+    #[allow(clippy::unnecessary_wraps)]
+    fn find_account(&mut self, context: &crate::evm::Context, seed: &[u8]) -> Result<Vec<u8>> {
+        let signer = context.caller;
 
-    Ok(result.to_vec())
+        let (account_key, _) = Pubkey::find_program_address(
+            &[
+                &[ACCOUNT_SEED_VERSION],
+                b"ContractData",
+                signer.as_bytes(),
+                seed,
+            ],
+            self.backend.program_id(),
+        );
+
+        Ok(account_key.to_bytes().to_vec())
+    }
+
+    #[maybe_async]
+    async fn is_system_account(
+        &mut self,
+        _context: &crate::evm::Context,
+        account: Pubkey,
+    ) -> Result<Vec<u8>> {
+        let account = self.external_account(account).await?;
+        if system_program::check_id(&account.owner) {
+            let mut result = vec![0_u8; 32];
+            result[31] = 1; // return true
+
+            Ok(result)
+        } else {
+            Ok(vec![0_u8; 32])
+        }
+    }
+
+    #[maybe_async]
+    async fn get_account(
+        &mut self,
+        _context: &crate::evm::Context,
+        account: Pubkey,
+    ) -> Result<Vec<u8>> {
+        let account = self.external_account(account).await?;
+        let token = if spl_token::check_id(&account.owner) {
+            spl_token::state::Account::unpack(&account.data)?
+        } else if system_program::check_id(&account.owner) {
+            spl_token::state::Account::default()
+        } else {
+            return Err(ProgramError::IllegalOwner.into());
+        };
+
+        debug_print!("spl_token get_account: {:?}", token);
+
+        let mut result = [0_u8; 7 * 32];
+        let (mint, owner, _, amount, delegate, _, delegated_amount, close_authority, state) =
+            arrayref::mut_array_refs![&mut result, 32, 32, 24, 8, 32, 24, 8, 32, 32];
+
+        *mint = token.mint.to_bytes();
+        *owner = token.owner.to_bytes();
+        *amount = token.amount.to_be_bytes();
+        *delegate = token.delegate.map(Pubkey::to_bytes).unwrap_or_default();
+        *delegated_amount = token.delegated_amount.to_be_bytes();
+        *close_authority = token
+            .close_authority
+            .map(Pubkey::to_bytes)
+            .unwrap_or_default();
+        state[31] = token.state as u8;
+
+        Ok(result.to_vec())
+    }
+
+    #[maybe_async]
+    async fn get_mint(
+        &mut self,
+        _context: &crate::evm::Context,
+        account: Pubkey,
+    ) -> Result<Vec<u8>> {
+        let account = self.external_account(account).await?;
+        let mint = if spl_token::check_id(&account.owner) {
+            spl_token::state::Mint::unpack(&account.data)?
+        } else if system_program::check_id(&account.owner) {
+            spl_token::state::Mint::default()
+        } else {
+            return Err(ProgramError::IllegalOwner.into());
+        };
+
+        debug_print!("spl_token get_mint: {:?}", mint);
+
+        let mut result = [0_u8; 5 * 32];
+        let (_, supply, _, decimals, _, is_initialized, freeze_authority, mint_authority) =
+            arrayref::mut_array_refs![&mut result, 24, 8, 31, 1, 31, 1, 32, 32];
+
+        *supply = mint.supply.to_be_bytes();
+        *decimals = mint.decimals.to_be_bytes();
+        *is_initialized = if mint.is_initialized { [1_u8] } else { [0_u8] };
+        *freeze_authority = mint
+            .freeze_authority
+            .map(Pubkey::to_bytes)
+            .unwrap_or_default();
+        *mint_authority = mint
+            .mint_authority
+            .map(Pubkey::to_bytes)
+            .unwrap_or_default();
+
+        Ok(result.to_vec())
+    }
 }


### PR DESCRIPTION
The `<B: AccountStorage> ExecutorState<'_, B>` type parameter is duplicated 36 times in `precompile_extension` module. 

This PR reduces the usage of `<B: AccountStorage> ExecutorState<'_, B>` to only 5 by converting functions in `precompile_extension` module to methods with `ExecutorState<'_, B>` receiver.

Any change to `ExecutorState<'_, B>` type requires updating all these duplicated type parameters and it is cumbersome. I did it once in #158 and I might need to do it again as part of debug methods implementation.

I suggest reviewing each commit in turn, using `Split Diff View` with whitespace hidden.
<img width="1710" alt="image" src="https://github.com/neonlabsorg/neon-evm/assets/8200650/77bf0e10-b522-4b22-8384-f6a13de44a42">
