### PR TITLE
Eliminate RefCell in KeysCache

### DIFF
--- a/evm_loader/lib/src/account_storage.rs
+++ b/evm_loader/lib/src/account_storage.rs
@@ -537,7 +537,7 @@ impl<T: Rpc> AccountStorage for EmulatorAccountStorage<'_, T> {
         }
     }
 
-    async fn nonce(&self, address: Address, chain_id: u64) -> u64 {
+    async fn nonce(&mut self, address: Address, chain_id: u64) -> u64 {
         info!("nonce {address}  {chain_id}");
 
         let nonce_override = self.account_override(address, |a| a.nonce);
@@ -555,7 +555,7 @@ impl<T: Rpc> AccountStorage for EmulatorAccountStorage<'_, T> {
         .await
     }
 
-    async fn balance(&self, address: Address, chain_id: u64) -> U256 {
+    async fn balance(&mut self, address: Address, chain_id: u64) -> U256 {
         info!("balance {address} {chain_id}");
 
         let balance_override = self.account_override(address, |a| a.balance);
@@ -603,7 +603,7 @@ impl<T: Rpc> AccountStorage for EmulatorAccountStorage<'_, T> {
         unreachable!();
     }
 
-    async fn contract_chain_id(&self, address: Address) -> evm_loader::error::Result<u64> {
+    async fn contract_chain_id(&mut self, address: Address) -> evm_loader::error::Result<u64> {
         use evm_loader::error::Error;
 
         let default_value = Err(Error::Custom(std::format!(
@@ -619,11 +619,11 @@ impl<T: Rpc> AccountStorage for EmulatorAccountStorage<'_, T> {
         .await
     }
 
-    fn contract_pubkey(&self, address: Address) -> (Pubkey, u8) {
+    fn contract_pubkey(&mut self, address: Address) -> (Pubkey, u8) {
         address.find_solana_address(self.program_id())
     }
 
-    async fn code_hash(&self, address: Address, chain_id: u64) -> [u8; 32] {
+    async fn code_hash(&mut self, address: Address, chain_id: u64) -> [u8; 32] {
         use solana_sdk::keccak::hash;
 
         info!("code_hash {address} {chain_id}");
@@ -644,13 +644,13 @@ impl<T: Rpc> AccountStorage for EmulatorAccountStorage<'_, T> {
         hash(&[]).to_bytes()
     }
 
-    async fn code_size(&self, address: Address) -> usize {
+    async fn code_size(&mut self, address: Address) -> usize {
         info!("code_size {address}");
 
         self.code(address).await.len()
     }
 
-    async fn code(&self, address: Address) -> evm_loader::evm::Buffer {
+    async fn code(&mut self, address: Address) -> evm_loader::evm::Buffer {
         use evm_loader::evm::Buffer;
 
         info!("code {address}");
@@ -672,7 +672,7 @@ impl<T: Rpc> AccountStorage for EmulatorAccountStorage<'_, T> {
         Buffer::from_vec(code)
     }
 
-    async fn storage(&self, address: Address, index: U256) -> [u8; 32] {
+    async fn storage(&mut self, address: Address, index: U256) -> [u8; 32] {
         let storage_override = self.account_override(address, |a| a.storage(index));
         if let Some(storage_override) = storage_override {
             return storage_override;

--- a/evm_loader/lib/src/types/mod.rs
+++ b/evm_loader/lib/src/types/mod.rs
@@ -52,7 +52,10 @@ pub struct TxParams {
 }
 
 impl TxParams {
-    pub async fn into_transaction(self, backend: &impl AccountStorage) -> (Address, Transaction) {
+    pub async fn into_transaction(
+        self,
+        backend: &mut impl AccountStorage,
+    ) -> (Address, Transaction) {
         let chain_id = self.chain_id.unwrap_or_else(|| backend.default_chain_id());
 
         let origin_nonce = backend.nonce(self.from, chain_id).await;

--- a/evm_loader/program/src/account/ether_balance.rs
+++ b/evm_loader/program/src/account/ether_balance.rs
@@ -45,9 +45,9 @@ impl<'a> BalanceAccount<'a> {
         address: Address,
         chain_id: u64,
         accounts: &AccountsDB<'a>,
-        keys: Option<&KeysCache>,
+        mut keys: Option<&mut KeysCache>,
     ) -> Result<Self> {
-        let (pubkey, bump_seed) = keys.map_or_else(
+        let (pubkey, bump_seed) = keys.as_mut().map_or_else(
             || address.find_balance_address(&crate::ID, chain_id),
             |keys| keys.balance_with_bump_seed(&crate::ID, address, chain_id),
         );

--- a/evm_loader/program/src/account/ether_contract.rs
+++ b/evm_loader/program/src/account/ether_contract.rs
@@ -58,7 +58,7 @@ impl<'a> ContractAccount<'a> {
         code: &[u8],
         rent: &Rent,
         accounts: &AccountsDB,
-        keys: Option<&KeysCache>,
+        keys: Option<&mut KeysCache>,
     ) -> Result<AllocateResult> {
         let (pubkey, bump_seed) = keys.map_or_else(
             || address.find_solana_address(&crate::ID),
@@ -108,7 +108,7 @@ impl<'a> ContractAccount<'a> {
         generation: u32,
         code: &[u8],
         accounts: &AccountsDB<'a>,
-        keys: Option<&KeysCache>,
+        keys: Option<&mut KeysCache>,
     ) -> Result<Self> {
         let (pubkey, _) = keys.map_or_else(
             || address.find_solana_address(&crate::ID),

--- a/evm_loader/program/src/account/legacy/mod.rs
+++ b/evm_loader/program/src/account/legacy/mod.rs
@@ -58,7 +58,7 @@ fn kill_account(account: &AccountInfo) -> Result<u64> {
 fn update_ether_account(
     legacy_data: &LegacyEtherData,
     db: &AccountsDB,
-    keys: &KeysCache,
+    keys: &mut KeysCache,
 ) -> Result<u64> {
     let pubkey = keys.contract(&crate::ID, legacy_data.address);
     let account = db.get(&pubkey);
@@ -116,7 +116,7 @@ fn update_ether_account(
 fn update_storage_account(
     legacy_data: &LegacyStorageData,
     db: &AccountsDB,
-    keys: &KeysCache,
+    keys: &mut KeysCache,
 ) -> Result<u64> {
     let mut lamports_collected = 0_u64;
 
@@ -185,7 +185,7 @@ pub fn update_holder_account(account: &AccountInfo) -> Result<u8> {
 }
 
 pub fn update_legacy_accounts(accounts: &AccountsDB) -> Result<u64> {
-    let keys = KeysCache::new();
+    let mut keys = KeysCache::new();
 
     let mut lamports_collected = 0_u64;
     let mut legacy_storage = Vec::with_capacity(accounts.accounts_len());
@@ -203,7 +203,7 @@ pub fn update_legacy_accounts(accounts: &AccountsDB) -> Result<u64> {
         match tag {
             LegacyEtherData::TAG => {
                 let legacy_data = LegacyEtherData::from_account(&crate::ID, account)?;
-                lamports_collected += update_ether_account(&legacy_data, accounts, &keys)?;
+                lamports_collected += update_ether_account(&legacy_data, accounts, &mut keys)?;
             }
             LegacyStorageData::TAG => {
                 let legacy_data = LegacyStorageData::from_account(&crate::ID, account)?;
@@ -214,7 +214,7 @@ pub fn update_legacy_accounts(accounts: &AccountsDB) -> Result<u64> {
     }
 
     for data in legacy_storage {
-        lamports_collected += update_storage_account(&data, accounts, &keys)?;
+        lamports_collected += update_storage_account(&data, accounts, &mut keys)?;
     }
 
     Ok(lamports_collected)

--- a/evm_loader/program/src/account_storage/apply.rs
+++ b/evm_loader/program/src/account_storage/apply.rs
@@ -57,7 +57,7 @@ impl<'a> ProgramAccountStorage<'a> {
                     code,
                     &rent,
                     &self.accounts,
-                    Some(&mut self.keys.borrow_mut()),
+                    Some(&mut self.keys),
                 )?;
 
                 if result == AllocateResult::NeedMore {
@@ -119,7 +119,7 @@ impl<'a> ProgramAccountStorage<'a> {
                         0,
                         &code,
                         &self.accounts,
-                        Some(&mut self.keys.borrow_mut()),
+                        Some(&mut self.keys),
                     )?;
                 }
                 Action::EvmSelfDestruct { address: _ } => {
@@ -200,17 +200,11 @@ impl<'a> ProgramAccountStorage<'a> {
             }
 
             for (index, values) in infinite_values {
-                let cell_address =
-                    self.keys
-                        .borrow_mut()
-                        .storage_cell_address(&crate::ID, address, index);
+                let cell_address = self.keys.storage_cell_address(&crate::ID, address, index);
 
                 let account = self.accounts.get(cell_address.pubkey());
                 if system_program::check_id(account.owner) {
-                    let (_, bump) = self
-                        .keys
-                        .borrow_mut()
-                        .contract_with_bump_seed(&crate::ID, address);
+                    let (_, bump) = self.keys.contract_with_bump_seed(&crate::ID, address);
                     let sign: &[&[u8]] = &[&[ACCOUNT_SEED_VERSION], address.as_bytes(), &[bump]];
 
                     let len = values.len();

--- a/evm_loader/program/src/account_storage/backend.rs
+++ b/evm_loader/program/src/account_storage/backend.rs
@@ -70,6 +70,7 @@ impl<'a> AccountStorage for ProgramAccountStorage<'a> {
 
     fn contract_pubkey(&self, address: Address) -> (Pubkey, u8) {
         self.keys
+            .borrow_mut()
             .contract_with_bump_seed(self.program_id(), address)
     }
 

--- a/evm_loader/program/src/account_storage/mod.rs
+++ b/evm_loader/program/src/account_storage/mod.rs
@@ -25,7 +25,7 @@ pub use keys_cache::KeysCache;
 pub struct ProgramAccountStorage<'a> {
     clock: Clock,
     accounts: AccountsDB<'a>,
-    keys: keys_cache::KeysCache,
+    keys: core::cell::RefCell<keys_cache::KeysCache>,
 }
 
 /// Account storage

--- a/evm_loader/program/src/account_storage/mod.rs
+++ b/evm_loader/program/src/account_storage/mod.rs
@@ -25,7 +25,7 @@ pub use keys_cache::KeysCache;
 pub struct ProgramAccountStorage<'a> {
     clock: Clock,
     accounts: AccountsDB<'a>,
-    keys: core::cell::RefCell<keys_cache::KeysCache>,
+    keys: keys_cache::KeysCache,
 }
 
 /// Account storage
@@ -45,28 +45,28 @@ pub trait AccountStorage {
     async fn block_hash(&self, number: u64) -> [u8; 32];
 
     /// Get account nonce
-    async fn nonce(&self, address: Address, chain_id: u64) -> u64;
+    async fn nonce(&mut self, address: Address, chain_id: u64) -> u64;
     /// Get account balance
-    async fn balance(&self, address: Address, chain_id: u64) -> U256;
+    async fn balance(&mut self, address: Address, chain_id: u64) -> U256;
 
     fn is_valid_chain_id(&self, chain_id: u64) -> bool;
     fn chain_id_to_token(&self, chain_id: u64) -> Pubkey;
     fn default_chain_id(&self) -> u64;
 
     /// Get contract chain_id
-    async fn contract_chain_id(&self, address: Address) -> Result<u64>;
+    async fn contract_chain_id(&mut self, address: Address) -> Result<u64>;
     /// Get contract solana address
-    fn contract_pubkey(&self, address: Address) -> (Pubkey, u8);
+    fn contract_pubkey(&mut self, address: Address) -> (Pubkey, u8);
 
     /// Get code hash
-    async fn code_hash(&self, address: Address, chain_id: u64) -> [u8; 32];
+    async fn code_hash(&mut self, address: Address, chain_id: u64) -> [u8; 32];
     /// Get code size
-    async fn code_size(&self, address: Address) -> usize;
+    async fn code_size(&mut self, address: Address) -> usize;
     /// Get code data
-    async fn code(&self, address: Address) -> crate::evm::Buffer;
+    async fn code(&mut self, address: Address) -> crate::evm::Buffer;
 
     /// Get data from storage
-    async fn storage(&self, address: Address, index: U256) -> [u8; 32];
+    async fn storage(&mut self, address: Address, index: U256) -> [u8; 32];
 
     /// Clone existing solana account
     async fn clone_solana_account(&self, address: &Pubkey) -> OwnedAccountInfo;

--- a/evm_loader/program/src/evm/database.rs
+++ b/evm_loader/program/src/evm/database.rs
@@ -8,12 +8,12 @@ use solana_program::{account_info::AccountInfo, pubkey::Pubkey};
 pub trait Database {
     fn default_chain_id(&self) -> u64;
     fn is_valid_chain_id(&self, chain_id: u64) -> bool;
-    async fn contract_chain_id(&self, address: Address) -> Result<u64>;
+    async fn contract_chain_id(&mut self, address: Address) -> Result<u64>;
 
-    async fn nonce(&self, address: Address, chain_id: u64) -> Result<u64>;
+    async fn nonce(&mut self, address: Address, chain_id: u64) -> Result<u64>;
     fn increment_nonce(&mut self, address: Address, chain_id: u64) -> Result<()>;
 
-    async fn balance(&self, address: Address, chain_id: u64) -> Result<U256>;
+    async fn balance(&mut self, address: Address, chain_id: u64) -> Result<U256>;
     async fn transfer(
         &mut self,
         source: Address,
@@ -22,13 +22,13 @@ pub trait Database {
         value: U256,
     ) -> Result<()>;
 
-    async fn code_hash(&self, address: Address, chain_id: u64) -> Result<[u8; 32]>;
-    async fn code_size(&self, address: Address) -> Result<usize>;
-    async fn code(&self, address: Address) -> Result<Buffer>;
+    async fn code_hash(&mut self, address: Address, chain_id: u64) -> Result<[u8; 32]>;
+    async fn code_size(&mut self, address: Address) -> Result<usize>;
+    async fn code(&mut self, address: Address) -> Result<Buffer>;
     fn set_code(&mut self, address: Address, chain_id: u64, code: Vec<u8>) -> Result<()>;
     fn selfdestruct(&mut self, address: Address) -> Result<()>;
 
-    async fn storage(&self, address: Address, index: U256) -> Result<[u8; 32]>;
+    async fn storage(&mut self, address: Address, index: U256) -> Result<[u8; 32]>;
     fn set_storage(&mut self, address: Address, index: U256, value: [u8; 32]) -> Result<()>;
 
     async fn block_hash(&self, number: U256) -> Result<[u8; 32]>;

--- a/evm_loader/program/src/instruction/transaction_execute.rs
+++ b/evm_loader/program/src/instruction/transaction_execute.rs
@@ -36,7 +36,7 @@ pub fn execute(
     let mut account_storage = ProgramAccountStorage::new(accounts)?;
 
     let (exit_reason, apply_state) = {
-        let mut backend = ExecutorState::new(&account_storage);
+        let mut backend = ExecutorState::new(&mut account_storage);
 
         let mut evm = Machine::new(trx, origin, &mut backend)?;
         let (result, _) = evm.execute(u64::MAX, &mut backend)?;

--- a/evm_loader/program/src/instruction/transaction_step.rs
+++ b/evm_loader/program/src/instruction/transaction_step.rs
@@ -19,17 +19,22 @@ pub fn do_begin<'a>(
 ) -> Result<()> {
     debug_print!("do_begin");
 
-    let accounts = ProgramAccountStorage::new(accounts)?;
+    let mut accounts = ProgramAccountStorage::new(accounts)?;
 
-    let mut backend = ExecutorState::new(&accounts);
+    let mut backend = ExecutorState::new(&mut accounts);
     let evm = Machine::new(trx, origin, &mut backend)?;
+
+    // Serialized was moved before the token burn to accomodate the ownership rules. The serialized
+    // data of `backend` and `evm` is not affected by the `&mut accounts` they hold. I am not sure
+    // updating `storage` before the burn is okay though. There is nothing preventing anyone from
+    // changing the serialization implementation and invalidating these assumptions though.
+    serialize_evm_state(&mut storage, &backend, &evm)?;
 
     // Burn `gas_limit` tokens from the origin account
     // Later we will mint them to the operator
     let mut origin_balance = accounts.create_balance_account(origin, storage.trx_chain_id())?;
     origin_balance.burn(storage.gas_limit_in_tokens()?)?;
 
-    serialize_evm_state(&mut storage, &backend, &evm)?;
     finalize(0, storage, accounts, None, gasometer)
 }
 
@@ -47,8 +52,8 @@ pub fn do_continue<'a>(
         )));
     }
 
-    let account_storage = ProgramAccountStorage::new(accounts)?;
-    let (mut backend, mut evm) = deserialize_evm_state(&storage, &account_storage)?;
+    let mut account_storage = ProgramAccountStorage::new(accounts)?;
+    let (mut backend, mut evm) = deserialize_evm_state(&storage, &mut account_storage)?;
 
     let (result, steps_executed) = {
         match backend.exit_status() {
@@ -163,7 +168,7 @@ fn serialize_evm_state(
 
 fn deserialize_evm_state<'a, 'r>(
     state: &StateAccount<'a>,
-    account_storage: &'r ProgramAccountStorage<'a>,
+    account_storage: &'r mut ProgramAccountStorage<'a>,
 ) -> Result<(EvmBackend<'a, 'r>, Evm<'a, 'r>)> {
     let (evm_state_len, evm_machine_len) = state.buffer_variables();
     let buffer = state.buffer();


### PR DESCRIPTION
I believe we can get rid of the `RefCell`s used in `KeysCache`. Doing so would mean that the program can no longer fail at run time because we violate the borrowing rules. In other words, we can have a compile-time guarantee instead of run-time checking. 

https://neonlabs.atlassian.net/browse/NDEV-2511
