### PR TITLE
NDEV-2514: Refactor get_config module

### DIFF
--- a/evm_loader/lib/src/commands/get_config.rs
+++ b/evm_loader/lib/src/commands/get_config.rs
@@ -364,7 +364,7 @@ impl CloneRpcClient {
                 commitment: Some(self.commitment()),
                 filter: None,
             })
-            .await?; // TODO: This is very inefficient and needs to be removed
+            .await?; // TODO https://neonlabs.atlassian.net/browse/NDEV-2462 replace with more efficient RPC call
 
         Ok(Pubkey::from_str(&r.value[0].address).unwrap())
     }

--- a/evm_loader/lib/src/commands/get_config.rs
+++ b/evm_loader/lib/src/commands/get_config.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use base64::Engine;
 use enum_dispatch::enum_dispatch;
 use std::collections::BTreeMap;
-use tokio::sync::{Mutex, MutexGuard, OnceCell};
+use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use solana_program_test::{ProgramTest, ProgramTestContext};
@@ -20,9 +20,11 @@ use solana_sdk::{
 
 use crate::{rpc::Rpc, NeonError, NeonResult};
 
-use crate::rpc::{CallDbClient, CloneRpcClient, SolanaRpc};
+use crate::rpc::{CallDbClient, CloneRpcClient};
 use serde_with::{serde_as, DisplayFromStr};
-use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_client::client_error::Result as ClientResult;
+use solana_client::rpc_config::{RpcLargestAccountsConfig, RpcSimulateTransactionConfig};
+use tokio::sync::{Mutex, MutexGuard, OnceCell};
 
 #[derive(Debug, Serialize)]
 pub enum Status {
@@ -51,58 +53,58 @@ pub struct GetConfigResponse {
     pub config: BTreeMap<String, String>,
 }
 
-static PROGRAM_TEST: OnceCell<Mutex<ProgramTestContext>> = OnceCell::const_new();
-
-async fn read_program_data_from_account(
-    rpc: &CallDbClient,
-    program_id: Pubkey,
-) -> NeonResult<Vec<u8>> {
-    let Some(account) = rpc.get_account(&program_id).await?.value else {
-        return Err(NeonError::AccountNotFound(program_id));
-    };
-
-    if account.owner == bpf_loader::id() || account.owner == bpf_loader_deprecated::id() {
-        return Ok(account.data);
-    }
-
-    if account.owner != bpf_loader_upgradeable::id() {
-        return Err(NeonError::AccountIsNotBpf(program_id));
-    }
-
-    if let Ok(UpgradeableLoaderState::Program {
-        programdata_address,
-    }) = account.state()
-    {
-        let Some(programdata_account) = rpc.get_account(&programdata_address).await?.value else {
-            return Err(NeonError::AssociatedPdaNotFound(programdata_address, program_id));
+impl CallDbClient {
+    async fn read_program_data_from_account(&self, program_id: Pubkey) -> NeonResult<Vec<u8>> {
+        let Some(account) = self.get_account(&program_id).await?.value else {
+            return Err(NeonError::AccountNotFound(program_id));
         };
 
-        let offset = UpgradeableLoaderState::size_of_programdata_metadata();
-        let program_data = &programdata_account.data[offset..];
+        if account.owner == bpf_loader::id() || account.owner == bpf_loader_deprecated::id() {
+            return Ok(account.data);
+        }
 
-        Ok(program_data.to_vec())
-    } else {
-        Err(NeonError::AccountIsNotUpgradeable(program_id))
+        if account.owner != bpf_loader_upgradeable::id() {
+            return Err(NeonError::AccountIsNotBpf(program_id));
+        }
+
+        if let Ok(UpgradeableLoaderState::Program {
+            programdata_address,
+        }) = account.state()
+        {
+            let Some(programdata_account) = self.get_account(&programdata_address).await?.value else {
+                return Err(NeonError::AssociatedPdaNotFound(programdata_address, program_id));
+            };
+
+            let offset = UpgradeableLoaderState::size_of_programdata_metadata();
+            let program_data = &programdata_account.data[offset..];
+
+            Ok(program_data.to_vec())
+        } else {
+            Err(NeonError::AccountIsNotUpgradeable(program_id))
+        }
     }
 }
 
-async fn lock_program_test(
-    program_id: Pubkey,
-    program_data: Vec<u8>,
-) -> MutexGuard<'static, ProgramTestContext> {
-    async fn init_program_test() -> Mutex<ProgramTestContext> {
-        let program_test = ProgramTest::default();
-        let context = program_test.start_with_context().await;
-        Mutex::new(context)
+async fn program_test_context() -> MutexGuard<'static, ProgramTestContext> {
+    static PROGRAM_TEST_CONTEXT: OnceCell<Mutex<ProgramTestContext>> = OnceCell::const_new();
+
+    async fn init_program_test_context() -> Mutex<ProgramTestContext> {
+        Mutex::new(ProgramTest::default().start_with_context().await)
     }
 
-    let mut context = PROGRAM_TEST
-        .get_or_init(init_program_test)
+    PROGRAM_TEST_CONTEXT
+        .get_or_init(init_program_test_context)
         .await
         .lock()
-        .await;
+        .await
+}
 
-    context.set_account(
+fn set_program_account(
+    program_test_context: &mut ProgramTestContext,
+    program_id: Pubkey,
+    program_data: Vec<u8>,
+) {
+    program_test_context.set_account(
         &program_id,
         &AccountSharedData::from(Account {
             lamports: Rent::default().minimum_balance(program_data.len()).max(1),
@@ -112,13 +114,11 @@ async fn lock_program_test(
             rent_epoch: 0,
         }),
     );
-
-    context
 }
 
 pub enum ConfigSimulator<'r> {
-    Rpc(Pubkey, &'r RpcClient),
-    ProgramTest(MutexGuard<'static, ProgramTestContext>),
+    CloneRpcClient(Pubkey, &'r CloneRpcClient),
+    ProgramTestContext(Pubkey, MutexGuard<'static, ProgramTestContext>),
 }
 
 #[async_trait(?Send)]
@@ -129,71 +129,116 @@ pub trait BuildConfigSimulator {
 
 #[async_trait(?Send)]
 impl BuildConfigSimulator for CloneRpcClient {
-    async fn build_config_simulator(&self, _program_id: Pubkey) -> NeonResult<ConfigSimulator> {
-        Ok(ConfigSimulator::Rpc(
-            self.get_account_with_sol().await?,
-            self,
-        ))
+    async fn build_config_simulator(&self, program_id: Pubkey) -> NeonResult<ConfigSimulator> {
+        Ok(ConfigSimulator::CloneRpcClient(program_id, self))
     }
 }
 
 #[async_trait(?Send)]
 impl BuildConfigSimulator for CallDbClient {
     async fn build_config_simulator(&self, program_id: Pubkey) -> NeonResult<ConfigSimulator> {
-        let program_data = read_program_data_from_account(self, program_id).await?;
-        let mut program_test = lock_program_test(program_id, program_data).await;
-        program_test.get_new_latest_blockhash().await?;
+        let program_data = self.read_program_data_from_account(program_id).await?;
 
-        Ok(ConfigSimulator::ProgramTest(program_test))
+        let mut program_test_context = program_test_context().await;
+
+        set_program_account(&mut program_test_context, program_id, program_data);
+        program_test_context.get_new_latest_blockhash().await?;
+
+        Ok(ConfigSimulator::ProgramTestContext(
+            program_id,
+            program_test_context,
+        ))
+    }
+}
+
+impl CloneRpcClient {
+    async fn simulate_solana_instruction(
+        &self,
+        instruction: Instruction,
+    ) -> NeonResult<Vec<String>> {
+        let tx =
+            Transaction::new_with_payer(&[instruction], Some(&self.get_account_with_sol().await?));
+
+        let result = self
+            .simulate_transaction_with_config(
+                &tx,
+                RpcSimulateTransactionConfig {
+                    sig_verify: false,
+                    replace_recent_blockhash: true,
+                    ..RpcSimulateTransactionConfig::default()
+                },
+            )
+            .await?
+            .value;
+
+        if let Some(e) = result.err {
+            return Err(e.into());
+        }
+        Ok(result.logs.unwrap())
+    }
+}
+
+#[async_trait(?Send)]
+trait SolanaInstructionSimulator {
+    async fn simulate_solana_instruction(
+        &mut self,
+        instruction: Instruction,
+    ) -> NeonResult<Vec<String>>;
+}
+
+#[async_trait(?Send)]
+impl SolanaInstructionSimulator for ProgramTestContext {
+    async fn simulate_solana_instruction(
+        &mut self,
+        instruction: Instruction,
+    ) -> NeonResult<Vec<String>> {
+        let tx = Transaction::new_signed_with_payer(
+            &[instruction],
+            Some(&self.payer.pubkey()),
+            &[&self.payer],
+            self.last_blockhash,
+        );
+
+        // TODO: Fix failure to simulate transaction
+        // it can come from old NeonEVM program without chain_id support for old tx, when it should return default chain_id info
+        let result = self
+            .banks_client
+            .simulate_transaction(tx)
+            .await
+            .map_err(|e| NeonError::from(Box::new(e)))?;
+
+        result.result.unwrap()?;
+
+        Ok(result.simulation_details.unwrap().logs)
     }
 }
 
 impl ConfigSimulator<'_> {
-    async fn simulate_config(
+    fn program_id(&self) -> Pubkey {
+        match self {
+            ConfigSimulator::CloneRpcClient(program_id, _) => *program_id,
+            ConfigSimulator::ProgramTestContext(program_id, _) => *program_id,
+        }
+    }
+
+    async fn simulate_evm_instruction(
         &mut self,
-        program_id: Pubkey,
-        instruction: u8,
+        evm_instruction: u8,
         data: &[u8],
     ) -> NeonResult<Vec<u8>> {
         fn base64_decode(s: &str) -> Vec<u8> {
             base64::engine::general_purpose::STANDARD.decode(s).unwrap()
         }
 
-        let input = [&[instruction], data].concat();
+        let program_id = self.program_id();
 
-        let logs = match self {
-            ConfigSimulator::Rpc(signer, rpc) => {
-                let result = rpc
-                    .simulate_transaction_with_instructions(
-                        Some(*signer),
-                        &[Instruction::new_with_bytes(program_id, &input, vec![])],
-                    )
-                    .await?
-                    .value;
-
-                if let Some(e) = result.err {
-                    return Err(e.into());
-                }
-                result.logs.unwrap()
-            }
-            ConfigSimulator::ProgramTest(context) => {
-                let payer_pubkey = context.payer.pubkey();
-                let tx = Transaction::new_signed_with_payer(
-                    &[Instruction::new_with_bytes(program_id, &input, vec![])],
-                    Some(&payer_pubkey),
-                    &[&context.payer],
-                    context.last_blockhash,
-                );
-                let result = context
-                    .banks_client
-                    .simulate_transaction(tx)
-                    .await
-                    .map_err(|e| NeonError::from(Box::new(e)))?;
-
-                result.result.unwrap()?;
-                result.simulation_details.unwrap().logs
-            }
-        };
+        let logs = self
+            .simulate_solana_instruction(Instruction::new_with_bytes(
+                program_id,
+                &[&[evm_instruction], data].concat(),
+                vec![],
+            ))
+            .await?;
 
         // Program return: 53DfF883gyixYNXnM7s5xhdeyV8mVk9T4i2hGV9vG9io AQAAAAAAAAA=
         let return_data = logs
@@ -207,15 +252,33 @@ impl ConfigSimulator<'_> {
         Ok(return_data)
     }
 
-    async fn get_version(&mut self, program_id: Pubkey) -> NeonResult<(String, String)> {
-        let return_data = self.simulate_config(program_id, 0xA7, &[]).await?;
+    async fn simulate_solana_instruction(
+        &mut self,
+        instruction: Instruction,
+    ) -> NeonResult<Vec<String>> {
+        match self {
+            ConfigSimulator::CloneRpcClient(_, clone_rpc_client) => {
+                clone_rpc_client
+                    .simulate_solana_instruction(instruction)
+                    .await
+            }
+            ConfigSimulator::ProgramTestContext(_, program_test_context) => {
+                program_test_context
+                    .simulate_solana_instruction(instruction)
+                    .await
+            }
+        }
+    }
+
+    async fn get_version(&mut self) -> NeonResult<(String, String)> {
+        let return_data = self.simulate_evm_instruction(0xA7, &[]).await?;
         let (version, revision) = bincode::deserialize(&return_data)?;
 
         Ok((version, revision))
     }
 
-    async fn get_status(&mut self, program_id: Pubkey) -> NeonResult<Status> {
-        let return_data = self.simulate_config(program_id, 0xA6, &[]).await?;
+    async fn get_status(&mut self) -> NeonResult<Status> {
+        let return_data = self.simulate_evm_instruction(0xA6, &[]).await?;
         match return_data[0] {
             0 => Ok(Status::Emergency),
             1 => Ok(Status::Ok),
@@ -223,23 +286,23 @@ impl ConfigSimulator<'_> {
         }
     }
 
-    async fn get_environment(&mut self, program_id: Pubkey) -> NeonResult<String> {
-        let return_data = self.simulate_config(program_id, 0xA2, &[]).await?;
+    async fn get_environment(&mut self) -> NeonResult<String> {
+        let return_data = self.simulate_evm_instruction(0xA2, &[]).await?;
         let environment = String::from_utf8(return_data)?;
 
         Ok(environment)
     }
 
-    async fn get_chains(&mut self, program_id: Pubkey) -> NeonResult<Vec<ChainInfo>> {
+    async fn get_chains(&mut self) -> NeonResult<Vec<ChainInfo>> {
         let mut result = Vec::new();
 
-        let return_data = self.simulate_config(program_id, 0xA0, &[]).await?;
+        let return_data = self.simulate_evm_instruction(0xA0, &[]).await?;
         let chain_count = return_data.as_slice().try_into()?;
         let chain_count = usize::from_le_bytes(chain_count);
 
         for i in 0..chain_count {
             let index = i.to_le_bytes();
-            let return_data = self.simulate_config(program_id, 0xA1, &index).await?;
+            let return_data = self.simulate_evm_instruction(0xA1, &index).await?;
 
             let (id, name, token) = bincode::deserialize(&return_data)?;
             result.push(ChainInfo { id, name, token });
@@ -248,16 +311,16 @@ impl ConfigSimulator<'_> {
         Ok(result)
     }
 
-    async fn get_properties(&mut self, program_id: Pubkey) -> NeonResult<BTreeMap<String, String>> {
+    async fn get_properties(&mut self) -> NeonResult<BTreeMap<String, String>> {
         let mut result = BTreeMap::new();
 
-        let return_data = self.simulate_config(program_id, 0xA3, &[]).await?;
+        let return_data = self.simulate_evm_instruction(0xA3, &[]).await?;
         let count = return_data.as_slice().try_into()?;
         let count = usize::from_le_bytes(count);
 
         for i in 0..count {
             let index = i.to_le_bytes();
-            let return_data = self.simulate_config(program_id, 0xA4, &index).await?;
+            let return_data = self.simulate_evm_instruction(0xA4, &index).await?;
 
             let (name, value) = bincode::deserialize(&return_data)?;
             result.insert(name, value);
@@ -273,15 +336,15 @@ pub async fn execute(
 ) -> NeonResult<GetConfigResponse> {
     let mut simulator = rpc.build_config_simulator(program_id).await?;
 
-    let (version, revision) = simulator.get_version(program_id).await?;
+    let (version, revision) = simulator.get_version().await?;
 
     Ok(GetConfigResponse {
         version,
         revision,
-        status: simulator.get_status(program_id).await?,
-        environment: simulator.get_environment(program_id).await?,
-        chains: simulator.get_chains(program_id).await?,
-        config: simulator.get_properties(program_id).await?,
+        status: simulator.get_status().await?,
+        environment: simulator.get_environment().await?,
+        chains: simulator.get_chains().await?,
+        config: simulator.get_properties().await?,
     })
 }
 
@@ -291,5 +354,35 @@ pub async fn read_chains(
 ) -> NeonResult<Vec<ChainInfo>> {
     let mut simulator = rpc.build_config_simulator(program_id).await?;
 
-    simulator.get_chains(program_id).await
+    simulator.get_chains().await
+}
+
+impl CloneRpcClient {
+    async fn get_account_with_sol(&self) -> ClientResult<Pubkey> {
+        let r = self
+            .get_largest_accounts_with_config(RpcLargestAccountsConfig {
+                commitment: Some(self.commitment()),
+                filter: None,
+            })
+            .await?; // TODO: This is very inefficient and needs to be removed
+
+        Ok(Pubkey::from_str(&r.value[0].address).unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bpf_loader_pubkey() {
+        let pubkey = Pubkey::from([
+            2, 168, 246, 145, 78, 136, 161, 110, 57, 90, 225, 40, 148, 143, 250, 105, 86, 147, 55,
+            104, 24, 221, 71, 67, 82, 33, 243, 198, 0, 0, 0, 0,
+        ]);
+        assert_eq!(
+            format!("{}", pubkey),
+            "BPFLoader2111111111111111111111111111111111"
+        );
+    }
 }

--- a/evm_loader/lib/src/rpc/mod.rs
+++ b/evm_loader/lib/src/rpc/mod.rs
@@ -3,7 +3,6 @@ mod validator_client;
 
 pub use db_call_client::CallDbClient;
 pub use validator_client::CloneRpcClient;
-pub use validator_client::SolanaRpc;
 
 use crate::commands::get_config::{BuildConfigSimulator, ConfigSimulator};
 use crate::{NeonError, NeonResult};

--- a/evm_loader/lib/src/rpc/validator_client.rs
+++ b/evm_loader/lib/src/rpc/validator_client.rs
@@ -1,21 +1,16 @@
 use super::Rpc;
 use async_trait::async_trait;
 use solana_client::{
-    client_error::Result as ClientResult,
-    nonblocking::rpc_client::RpcClient,
-    rpc_config::{RpcLargestAccountsConfig, RpcSimulateTransactionConfig},
-    rpc_response::{RpcResult, RpcSimulateTransactionResult},
+    client_error::Result as ClientResult, nonblocking::rpc_client::RpcClient,
+    rpc_response::RpcResult,
 };
 use solana_sdk::{
     account::Account,
     clock::{Slot, UnixTimestamp},
     commitment_config::CommitmentConfig,
-    instruction::Instruction,
     pubkey::Pubkey,
-    transaction::Transaction,
 };
 use std::ops::Deref;
-use std::str::FromStr;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -70,55 +65,5 @@ impl Rpc for CloneRpcClient {
 
     async fn get_slot(&self) -> ClientResult<Slot> {
         self.0.get_slot().await
-    }
-}
-
-#[async_trait(?Send)]
-pub trait SolanaRpc {
-    async fn simulate_transaction_with_instructions(
-        &self,
-        signer: Option<Pubkey>,
-        instructions: &[Instruction],
-    ) -> RpcResult<RpcSimulateTransactionResult>;
-
-    async fn get_account_with_sol(&self) -> ClientResult<Pubkey>;
-}
-
-#[async_trait(?Send)]
-impl SolanaRpc for RpcClient {
-    async fn simulate_transaction_with_instructions(
-        &self,
-        signer: Option<Pubkey>,
-        instructions: &[Instruction],
-    ) -> RpcResult<RpcSimulateTransactionResult> {
-        let payer_pubkey = if let Some(signer) = signer {
-            signer
-        } else {
-            self.get_account_with_sol().await?
-        };
-
-        let tx = Transaction::new_with_payer(instructions, Some(&payer_pubkey));
-
-        self.simulate_transaction_with_config(
-            &tx,
-            RpcSimulateTransactionConfig {
-                sig_verify: false,
-                replace_recent_blockhash: true,
-                ..RpcSimulateTransactionConfig::default()
-            },
-        )
-        .await
-    }
-
-    async fn get_account_with_sol(&self) -> ClientResult<Pubkey> {
-        let r = self
-            .get_largest_accounts_with_config(RpcLargestAccountsConfig {
-                commitment: Some(self.commitment()),
-                filter: None,
-            })
-            .await?;
-
-        let pubkey = Pubkey::from_str(&r.value[0].address).unwrap();
-        Ok(pubkey)
     }
 }

--- a/evm_loader/lib/src/syscall_stubs.rs
+++ b/evm_loader/lib/src/syscall_stubs.rs
@@ -3,10 +3,6 @@ use solana_sdk::{program_error::ProgramError, program_stubs::SyscallStubs, sysva
 
 use crate::{errors::NeonError, rpc::Rpc};
 
-pub struct DefaultStubs;
-
-impl SyscallStubs for DefaultStubs {}
-
 pub struct EmulatorStubs {
     rent: Rent,
 }

--- a/evm_loader/program/src/account/program.rs
+++ b/evm_loader/program/src/account/program.rs
@@ -7,29 +7,6 @@ use solana_program::{rent::Rent, system_instruction, sysvar::Sysvar};
 use std::convert::From;
 use std::ops::Deref;
 
-pub struct Neon<'a>(&'a AccountInfo<'a>);
-
-impl<'a> Neon<'a> {
-    pub fn from_account(
-        program_id: &Pubkey,
-        info: &'a AccountInfo<'a>,
-    ) -> Result<Self, ProgramError> {
-        if program_id != info.key {
-            return Err!(ProgramError::InvalidArgument; "Account {} - is not Neon program", info.key);
-        }
-
-        Ok(Self(info))
-    }
-}
-
-impl<'a> Deref for Neon<'a> {
-    type Target = AccountInfo<'a>;
-
-    fn deref(&self) -> &Self::Target {
-        self.0
-    }
-}
-
 pub struct System<'a>(&'a AccountInfo<'a>);
 
 impl<'a> From<&System<'a>> for &'a AccountInfo<'a> {


### PR DESCRIPTION
- Moved all code related to retrieving chain configuration into `get_config` module.
- Added more object orientation, by adding the `program_id: Pubkey` to `ConfigSimulator` enum variants and converting most functions to methods on `ConfigSimulator` enum.
- Isolated `ProgramTestContext` retrieval from `PROGRAM_TEST_CONTEXT` static variable inside `program_test_context` function, so it can be easier changed to a new `ProgramTestContext` for each request model during testing.
- A few renames to make it clear the difference between `simulate_evm_instruction` vs `simulate_solana_instruction`.
- Removed some unused code.