### PR TITLE
Represent empty buffer with none

### DIFF
--- a/evm_loader/lib/src/account_storage.rs
+++ b/evm_loader/lib/src/account_storage.rs
@@ -630,7 +630,7 @@ impl<T: Rpc> AccountStorage for EmulatorAccountStorage<'_, T> {
         info!("code_hash {address} {chain_id}");
 
         if let Some(code) = self.code(address).await.as_deref() {
-            return hash(&code).to_bytes();
+            return hash(code).to_bytes();
         }
 
         // https://eips.ethereum.org/EIPS/eip-1052

--- a/evm_loader/program/src/account/ether_contract.rs
+++ b/evm_loader/program/src/account/ether_contract.rs
@@ -2,6 +2,7 @@ use crate::{
     account::TAG_EMPTY,
     account_storage::KeysCache,
     error::{Error, Result},
+    evm::Buffer,
     types::Address,
 };
 use solana_program::{
@@ -176,11 +177,11 @@ impl<'a> ContractAccount<'a> {
     }
 
     #[must_use]
-    pub fn code_buffer(&self) -> crate::evm::Buffer {
+    pub fn code_buffer(&self) -> Buffer {
         let begin = CODE_OFFSET;
         let end = begin + self.code_len();
 
-        unsafe { crate::evm::Buffer::from_account(&self.account, begin..end) }
+        unsafe { Buffer::from_account(&self.account, begin..end) }
     }
 
     #[must_use]

--- a/evm_loader/program/src/account_storage/backend.rs
+++ b/evm_loader/program/src/account_storage/backend.rs
@@ -1,6 +1,7 @@
 use crate::account_storage::{AccountStorage, ProgramAccountStorage};
 use crate::config::STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT;
 use crate::error::Result;
+use crate::evm::Buffer;
 use crate::executor::OwnedAccountInfo;
 use crate::types::Address;
 use ethnum::U256;
@@ -100,9 +101,8 @@ impl<'a> AccountStorage for ProgramAccountStorage<'a> {
         self.contract_account(address).map_or(0, |a| a.code_len())
     }
 
-    fn code(&self, address: Address) -> crate::evm::Buffer {
-        self.contract_account(address)
-            .map_or_else(|_| crate::evm::Buffer::empty(), |a| a.code_buffer())
+    fn code(&self, address: Address) -> Option<Buffer> {
+        self.contract_account(address).map(|a| a.code_buffer()).ok()
     }
 
     fn storage(&self, address: Address, index: U256) -> [u8; 32] {

--- a/evm_loader/program/src/account_storage/mod.rs
+++ b/evm_loader/program/src/account_storage/mod.rs
@@ -1,6 +1,6 @@
-use crate::error::Result;
 use crate::executor::OwnedAccountInfo;
 use crate::types::Address;
+use crate::{error::Result, evm::Buffer};
 use ethnum::U256;
 use maybe_async::maybe_async;
 use solana_program::account_info::AccountInfo;
@@ -63,7 +63,7 @@ pub trait AccountStorage {
     /// Get code size
     async fn code_size(&self, address: Address) -> usize;
     /// Get code data
-    async fn code(&self, address: Address) -> crate::evm::Buffer;
+    async fn code(&self, address: Address) -> Option<Buffer>;
 
     /// Get data from storage
     async fn storage(&self, address: Address, index: U256) -> [u8; 32];

--- a/evm_loader/program/src/evm/buffer.rs
+++ b/evm_loader/program/src/evm/buffer.rs
@@ -66,11 +66,6 @@ impl Buffer {
     }
 
     #[must_use]
-    pub fn empty() -> Option<Self> {
-        None
-    }
-
-    #[must_use]
     pub fn is_initialized(&self) -> bool {
         !matches!(self, Buffer::AccountUninit { .. })
     }
@@ -195,7 +190,7 @@ impl<'de> serde::Deserialize<'de> for OptionBuffer {
             where
                 E: serde::de::Error,
             {
-                Ok(Buffer::empty().into())
+                Ok(None.into())
             }
 
             fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
@@ -226,7 +221,7 @@ impl<'de> serde::Deserialize<'de> for OptionBuffer {
 
                 let (index, variant) = data.variant::<u32>()?;
                 match index {
-                    0 => variant.unit_variant().map(|_| Buffer::empty().into()),
+                    0 => variant.unit_variant().map(|_| None.into()),
                     1 => variant
                         .newtype_variant()
                         .map(Buffer::from_slice)

--- a/evm_loader/program/src/evm/database.rs
+++ b/evm_loader/program/src/evm/database.rs
@@ -24,7 +24,7 @@ pub trait Database {
 
     async fn code_hash(&self, address: Address, chain_id: u64) -> Result<[u8; 32]>;
     async fn code_size(&self, address: Address) -> Result<usize>;
-    async fn code(&self, address: Address) -> Result<Buffer>;
+    async fn code(&self, address: Address) -> Result<Option<Buffer>>;
     fn set_code(&mut self, address: Address, chain_id: u64, code: Vec<u8>) -> Result<()>;
     fn selfdestruct(&mut self, address: Address) -> Result<()>;
 

--- a/evm_loader/program/src/evm/memory.rs
+++ b/evm_loader/program/src/evm/memory.rs
@@ -206,7 +206,7 @@ impl Memory {
     }
 
     #[inline]
-    pub fn read_buffer(&mut self, offset: usize, length: usize) -> Result<Buffer, Error> {
+    pub fn read_buffer(&mut self, offset: usize, length: usize) -> Result<Option<Buffer>, Error> {
         let slice = self.read(offset, length)?;
         Ok(Buffer::from_slice(slice))
     }

--- a/evm_loader/program/src/evm/mod.rs
+++ b/evm_loader/program/src/evm/mod.rs
@@ -378,18 +378,12 @@ impl<B: Database> Machine<B> {
         assert!(self
             .execution_code
             .as_ref()
-            .map(|buffer| buffer.is_initialized())
-            .unwrap_or(true));
-        assert!(self
-            .call_data
-            .as_ref()
-            .map(|buffer| buffer.is_initialized())
-            .unwrap_or(true));
+            .map_or(true, Buffer::is_initialized));
+        assert!(self.call_data.as_ref().map_or(true, Buffer::is_initialized));
         assert!(self
             .return_data
             .as_ref()
-            .map(|buffer| buffer.is_initialized())
-            .unwrap_or(true));
+            .map_or(true, Buffer::is_initialized));
 
         let mut step = 0_u64;
 

--- a/evm_loader/program/src/evm/opcode.rs
+++ b/evm_loader/program/src/evm/opcode.rs
@@ -1132,10 +1132,7 @@ impl<B: Database> Machine<B> {
             self,
             super::tracing::Event::BeginVM {
                 context,
-                code: code
-                    .as_deref()
-                    .map(|code| code.to_vec())
-                    .unwrap_or_default(),
+                code: code.as_deref().map(<[u8]>::to_vec).unwrap_or_default(),
             }
         );
 
@@ -1190,10 +1187,7 @@ impl<B: Database> Machine<B> {
             self,
             super::tracing::Event::BeginVM {
                 context,
-                code: code
-                    .as_deref()
-                    .map(|code| code.to_vec())
-                    .unwrap_or_default(),
+                code: code.as_deref().map(<[u8]>::to_vec).unwrap_or_default(),
             }
         );
 
@@ -1246,10 +1240,7 @@ impl<B: Database> Machine<B> {
             self,
             super::tracing::Event::BeginVM {
                 context,
-                code: code
-                    .as_deref()
-                    .map(|code| code.to_vec())
-                    .unwrap_or_default(),
+                code: code.as_deref().map(<[u8]>::to_vec).unwrap_or_default(),
             }
         );
 
@@ -1298,10 +1289,7 @@ impl<B: Database> Machine<B> {
             self,
             super::tracing::Event::BeginVM {
                 context,
-                code: code
-                    .as_deref()
-                    .map(|code| code.to_vec())
-                    .unwrap_or_default(),
+                code: code.as_deref().map(<[u8]>::to_vec).unwrap_or_default(),
             }
         );
 

--- a/evm_loader/program/src/executor/state.rs
+++ b/evm_loader/program/src/executor/state.rs
@@ -9,7 +9,7 @@ use solana_program::pubkey::Pubkey;
 use crate::account_storage::AccountStorage;
 use crate::error::{Error, Result};
 use crate::evm::database::Database;
-use crate::evm::{Context, ExitStatus};
+use crate::evm::{Buffer, Context, ExitStatus};
 use crate::types::Address;
 
 use super::action::Action;
@@ -298,11 +298,11 @@ impl<'a, B: AccountStorage> Database for ExecutorState<'a, B> {
         Ok(self.backend.code_hash(from_address, chain_id).await)
     }
 
-    async fn code(&self, from_address: Address) -> Result<crate::evm::Buffer> {
+    async fn code(&self, from_address: Address) -> Result<Option<Buffer>> {
         for action in &self.actions {
             if let Action::EvmSetCode { address, code, .. } = action {
                 if &from_address == address {
-                    return Ok(crate::evm::Buffer::from_slice(code));
+                    return Ok(Buffer::from_slice(code));
                 }
             }
         }

--- a/evm_loader/program/src/types/transaction.rs
+++ b/evm_loader/program/src/types/transaction.rs
@@ -1,7 +1,7 @@
 use ethnum::U256;
 use std::convert::TryInto;
 
-use crate::error::Error;
+use crate::{error::Error, evm::Buffer};
 
 use super::Address;
 
@@ -516,11 +516,11 @@ impl Transaction {
     }
 
     #[must_use]
-    pub fn into_call_data(self) -> crate::evm::Buffer {
+    pub fn into_call_data(self) -> Option<Buffer> {
         match self.transaction {
             TransactionPayload::Legacy(LegacyTx { call_data, .. })
             | TransactionPayload::AccessList(AccessListTx { call_data, .. }) => {
-                crate::evm::Buffer::from_vec(call_data)
+                Buffer::from_vec(call_data)
             }
         }
     }


### PR DESCRIPTION
What I learned:

- We store the ptr and len inside of the Buffer type to avoid needing to discriminate between the different types of buffers when trying to access the underlying data.

Open questions:

- Why do we ensure buffers are non-empty (vec and slice constructor)?

- Could we refactor Machine to get static guarantees during execution? `execute` now starts with some asserts but it would be nicer if we can capture those asserts in types. That also means we will improve performance because we don't have to check if buffers are uninitialized.

