### PR TITLE
Eliminate `evm::buffer::Inner::Empty`

### DIFF
--- a/evm_loader/program/src/evm/buffer.rs
+++ b/evm_loader/program/src/evm/buffer.rs
@@ -228,3 +228,96 @@ impl<'de> serde::Deserialize<'de> for Buffer {
         deserializer.deserialize_enum("evm_buffer", &["empty", "owned", "account"], BufferVisitor)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    #[test]
+    fn test_deref_owned_empty() {
+        let data = Vec::default();
+        let (ptr, len) = (data.as_ptr(), data.len());
+        let slice = &*Buffer::default();
+        assert_eq!(slice.as_ptr(), ptr);
+        assert_eq!(slice.len(), len);
+    }
+
+    #[test]
+    fn test_deref_owned_non_empty() {
+        let data = vec![1];
+        let (ptr, len) = (data.as_ptr(), data.len());
+        let slice = &*Buffer::from_vec(data);
+        assert_eq!(slice.as_ptr(), ptr);
+        assert_eq!(slice.len(), len);
+    }
+
+    struct OwnedAccountInfo {
+        key: Pubkey,
+        lamports: u64,
+        data: Vec<u8>,
+        owner: Pubkey,
+        rent_epoch: u64,
+        is_signer: bool,
+        is_writable: bool,
+        executable: bool,
+    }
+
+    impl OwnedAccountInfo {
+        fn with_data(data: Vec<u8>) -> Self {
+            OwnedAccountInfo {
+                key: Pubkey::default(),
+                lamports: 0,
+                data,
+                owner: Pubkey::default(),
+                rent_epoch: 0,
+                is_signer: false,
+                is_writable: false,
+                executable: false,
+            }
+        }
+
+        fn as_mut(&mut self) -> AccountInfo<'_> {
+            AccountInfo {
+                key: &self.key,
+                lamports: Rc::new(RefCell::new(&mut self.lamports)),
+                data: Rc::new(RefCell::new(&mut self.data)),
+                owner: &self.owner,
+                rent_epoch: self.rent_epoch,
+                is_signer: self.is_signer,
+                is_writable: self.is_writable,
+                executable: self.executable,
+            }
+        }
+    }
+
+    #[test]
+    fn test_deref_account_empty() {
+        let data = Vec::default();
+        let (ptr, len) = (data.as_ptr(), data.len());
+        let mut account_info = OwnedAccountInfo::with_data(data);
+        let slice = &*unsafe { Buffer::from_account(&account_info.as_mut(), 0..len) };
+        assert_eq!(slice.as_ptr(), ptr);
+        assert_eq!(slice.len(), len);
+    }
+
+    #[test]
+    fn test_deref_account_non_empty() {
+        let data = vec![1];
+        let (ptr, len) = (data.as_ptr(), data.len());
+        let mut account_info = OwnedAccountInfo::with_data(data);
+        let slice = &*unsafe { Buffer::from_account(&account_info.as_mut(), 0..len) };
+        assert_eq!(slice.as_ptr(), ptr);
+        assert_eq!(slice.len(), len);
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed: !self.ptr.is_null()")]
+    fn test_deref_account_uninit() {
+        let _: &[u8] = &Buffer::new(Inner::AccountUninit {
+            key: Pubkey::default(),
+            range: 0..0,
+        });
+    }
+}

--- a/evm_loader/program/src/evm/buffer.rs
+++ b/evm_loader/program/src/evm/buffer.rs
@@ -235,22 +235,27 @@ mod tests {
     use std::cell::RefCell;
     use std::rc::Rc;
 
+    macro_rules! assert_slice_ptr_eq {
+        ($actual:expr, $expected:expr) => {{
+            let actual: &[_] = $actual;
+            let (expected_ptr, expected_len): (*const _, usize) = $expected;
+            assert_eq!(actual.as_ptr(), expected_ptr);
+            assert_eq!(actual.len(), expected_len);
+        }};
+    }
+
     #[test]
     fn test_deref_owned_empty() {
         let data = Vec::default();
-        let (ptr, len) = (data.as_ptr(), data.len());
-        let slice = &*Buffer::default();
-        assert_eq!(slice.as_ptr(), ptr);
-        assert_eq!(slice.len(), len);
+        let expected = (data.as_ptr(), data.len());
+        assert_slice_ptr_eq!(&*Buffer::default(), expected);
     }
 
     #[test]
     fn test_deref_owned_non_empty() {
         let data = vec![1];
-        let (ptr, len) = (data.as_ptr(), data.len());
-        let slice = &*Buffer::from_vec(data);
-        assert_eq!(slice.as_ptr(), ptr);
-        assert_eq!(slice.len(), len);
+        let expected = (data.as_ptr(), data.len());
+        assert_slice_ptr_eq!(&*Buffer::from_vec(data), expected);
     }
 
     struct OwnedAccountInfo {
@@ -295,21 +300,23 @@ mod tests {
     #[test]
     fn test_deref_account_empty() {
         let data = Vec::default();
-        let (ptr, len) = (data.as_ptr(), data.len());
+        let expected = (data.as_ptr(), data.len());
         let mut account_info = OwnedAccountInfo::with_data(data);
-        let slice = &*unsafe { Buffer::from_account(&account_info.as_mut(), 0..len) };
-        assert_eq!(slice.as_ptr(), ptr);
-        assert_eq!(slice.len(), len);
+        assert_slice_ptr_eq!(
+            &*unsafe { Buffer::from_account(&account_info.as_mut(), 0..expected.1) },
+            expected
+        );
     }
 
     #[test]
     fn test_deref_account_non_empty() {
         let data = vec![1];
-        let (ptr, len) = (data.as_ptr(), data.len());
+        let expected = (data.as_ptr(), data.len());
         let mut account_info = OwnedAccountInfo::with_data(data);
-        let slice = &*unsafe { Buffer::from_account(&account_info.as_mut(), 0..len) };
-        assert_eq!(slice.as_ptr(), ptr);
-        assert_eq!(slice.len(), len);
+        assert_slice_ptr_eq!(
+            &*unsafe { Buffer::from_account(&account_info.as_mut(), 0..expected.1) },
+            expected
+        );
     }
 
     #[test]


### PR DESCRIPTION
The `Empty` variant was added when we had different memory allocators. Currently we can also represent the emptyness of the buffer trough the `Inner::Owned` variant since that holds a `Vec` which can be empty.

This commit replaces `Inner::Empty` with `Inner::Owned(Vec::default())`.

This change makes it so that future readers of the code do not need to worry about how `Inner::Empty` is different from `Inner::Owned(Vec::default)`, and what `Empty` then represents exactly. This change is a pre-refactor required to improve how `Buffer` is used in the rest of the code base.