### PR TITLE
NDEV-2555: Remove duplication in tracing code

### DIFF
--- a/evm_loader/program/src/evm/mod.rs
+++ b/evm_loader/program/src/evm/mod.rs
@@ -12,7 +12,7 @@ use solana_program::log::sol_log_data;
 pub use buffer::Buffer;
 
 #[cfg(not(target_os = "solana"))]
-use crate::evm::tracing::TracerTypeOpt;
+use crate::evm::tracing::{Event, TracerTypeOpt};
 use crate::{
     error::{build_revert_message, Error, Result},
     evm::{opcode::Action, precompile::is_precompile_address},
@@ -445,7 +445,7 @@ impl<B: Database> Machine<B> {
     #[allow(clippy::too_many_arguments)]
     fn fork(
         &mut self,
-        _backend: &mut B,
+        backend: &mut B,
         reason: Reason,
         chain_id: u64,
         context: Context,
@@ -453,6 +453,14 @@ impl<B: Database> Machine<B> {
         call_data: Buffer,
         gas_limit: Option<U256>,
     ) {
+        tracing_event!(
+            self,
+            Event::BeginVM {
+                context,
+                code: execution_code.to_vec()
+            }
+        );
+
         let mut other = Self {
             origin: self.origin,
             chain_id,

--- a/evm_loader/program/src/evm/mod.rs
+++ b/evm_loader/program/src/evm/mod.rs
@@ -11,6 +11,7 @@ use solana_program::log::sol_log_data;
 
 pub use buffer::Buffer;
 
+use crate::evm::database::DatabaseExt;
 #[cfg(not(target_os = "solana"))]
 use crate::evm::tracing::{Event, TracerTypeOpt};
 use crate::{
@@ -326,8 +327,7 @@ impl<B: Database> Machine<B> {
         let target = Address::from_create(&origin, trx.nonce());
         sol_log_data(&[b"ENTER", b"CREATE", target.as_bytes()]);
 
-        if (backend.nonce(target, chain_id).await? != 0) || (backend.code_size(target).await? != 0)
-        {
+        if backend.is_non_empty(target, chain_id).await? {
             return Err(Error::DeployToExistingAccount(target, origin));
         }
 

--- a/evm_loader/program/src/evm/mod.rs
+++ b/evm_loader/program/src/evm/mod.rs
@@ -484,6 +484,8 @@ impl<B: Database> Machine<B> {
 
         core::mem::swap(self, &mut other);
         self.parent = Some(Box::new(other));
+
+        backend.snapshot();
     }
 
     fn join(&mut self) -> Self {

--- a/evm_loader/program/src/evm/mod.rs
+++ b/evm_loader/program/src/evm/mod.rs
@@ -442,8 +442,10 @@ impl<B: Database> Machine<B> {
         Ok((status, step))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn fork(
         &mut self,
+        _backend: &mut B,
         reason: Reason,
         chain_id: u64,
         context: Context,

--- a/evm_loader/program/src/evm/opcode.rs
+++ b/evm_loader/program/src/evm/opcode.rs
@@ -1071,14 +1071,6 @@ impl<B: Database> Machine<B> {
             code_address: None,
         };
 
-        tracing_event!(
-            self,
-            super::tracing::Event::BeginVM {
-                context,
-                code: init_code.to_vec()
-            }
-        );
-
         self.fork(
             backend,
             Reason::Create,
@@ -1132,14 +1124,6 @@ impl<B: Database> Machine<B> {
             code_address: Some(address),
         };
 
-        tracing_event!(
-            self,
-            super::tracing::Event::BeginVM {
-                context,
-                code: code.to_vec()
-            }
-        );
-
         self.fork(
             backend,
             Reason::Call,
@@ -1188,14 +1172,6 @@ impl<B: Database> Machine<B> {
             ..self.context
         };
 
-        tracing_event!(
-            self,
-            super::tracing::Event::BeginVM {
-                context,
-                code: code.to_vec()
-            }
-        );
-
         self.fork(
             backend,
             Reason::Call,
@@ -1242,14 +1218,6 @@ impl<B: Database> Machine<B> {
             ..self.context
         };
 
-        tracing_event!(
-            self,
-            super::tracing::Event::BeginVM {
-                context,
-                code: code.to_vec()
-            }
-        );
-
         self.fork(
             backend,
             Reason::Call,
@@ -1291,14 +1259,6 @@ impl<B: Database> Machine<B> {
             value: U256::ZERO,
             code_address: Some(address),
         };
-
-        tracing_event!(
-            self,
-            super::tracing::Event::BeginVM {
-                context,
-                code: code.to_vec()
-            }
-        );
 
         self.fork(
             backend,

--- a/evm_loader/program/src/evm/opcode.rs
+++ b/evm_loader/program/src/evm/opcode.rs
@@ -1080,7 +1080,6 @@ impl<B: Database> Machine<B> {
             Buffer::empty(),
             None,
         );
-        backend.snapshot();
 
         sol_log_data(&[b"ENTER", b"CREATE", address.as_bytes()]);
 
@@ -1133,7 +1132,6 @@ impl<B: Database> Machine<B> {
             call_data,
             Some(gas_limit),
         );
-        backend.snapshot();
 
         sol_log_data(&[b"ENTER", b"CALL", address.as_bytes()]);
 
@@ -1181,7 +1179,6 @@ impl<B: Database> Machine<B> {
             call_data,
             Some(gas_limit),
         );
-        backend.snapshot();
 
         sol_log_data(&[b"ENTER", b"CALLCODE", address.as_bytes()]);
 
@@ -1227,7 +1224,6 @@ impl<B: Database> Machine<B> {
             call_data,
             Some(gas_limit),
         );
-        backend.snapshot();
 
         sol_log_data(&[b"ENTER", b"DELEGATECALL", address.as_bytes()]);
 
@@ -1270,8 +1266,6 @@ impl<B: Database> Machine<B> {
             Some(gas_limit),
         );
         self.is_static = true;
-
-        backend.snapshot();
 
         sol_log_data(&[b"ENTER", b"STATICCALL", address.as_bytes()]);
 

--- a/evm_loader/program/src/evm/opcode.rs
+++ b/evm_loader/program/src/evm/opcode.rs
@@ -1080,6 +1080,7 @@ impl<B: Database> Machine<B> {
         );
 
         self.fork(
+            backend,
             Reason::Create,
             chain_id,
             context,
@@ -1140,6 +1141,7 @@ impl<B: Database> Machine<B> {
         );
 
         self.fork(
+            backend,
             Reason::Call,
             chain_id,
             context,
@@ -1195,6 +1197,7 @@ impl<B: Database> Machine<B> {
         );
 
         self.fork(
+            backend,
             Reason::Call,
             chain_id,
             context,
@@ -1248,6 +1251,7 @@ impl<B: Database> Machine<B> {
         );
 
         self.fork(
+            backend,
             Reason::Call,
             self.chain_id,
             context,
@@ -1297,6 +1301,7 @@ impl<B: Database> Machine<B> {
         );
 
         self.fork(
+            backend,
             Reason::Call,
             chain_id,
             context,

--- a/evm_loader/program/src/evm/opcode.rs
+++ b/evm_loader/program/src/evm/opcode.rs
@@ -1083,9 +1083,7 @@ impl<B: Database> Machine<B> {
 
         sol_log_data(&[b"ENTER", b"CREATE", address.as_bytes()]);
 
-        if (backend.nonce(address, chain_id).await? != 0)
-            || (backend.code_size(address).await? != 0)
-        {
+        if backend.is_non_empty(address, chain_id).await? {
             return Err(Error::DeployToExistingAccount(address, self.context.caller));
         }
 


### PR DESCRIPTION
- Removed all duplicated `tracing::Event::BeginVM` macro calls before `Machine::fork` method calls, by moving it at the beginning the `Machine::fork` method.
- Removed all duplicated `backend.snapshot();` calls after `Machine::fork` calls, by moving it at the end of `Machine::fork` method.
```Rust
    #[allow(clippy::too_many_arguments)]
    fn fork(
        &mut self,
        backend: &mut B,
        reason: Reason,
        chain_id: u64,
        context: Context,
        execution_code: Buffer,
        call_data: Buffer,
        gas_limit: Option<U256>,
    ) {
        tracing_event!(
            self,
            backend,
            Event::BeginVM {
                context,
                code: execution_code.to_vec()
            }
        );

        ...

        backend.snapshot();
    }
```
- Extracted a `DatabaseExt::is_non_empty` method similar to the one in #253 to remove the duplicated condition.