### PR TITLE
NDEV-2568: Enable Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,12 @@ updates:
       directory: "/evm_loader"
       schedule:
           interval: "daily"
-          time: "10:00"
-          timezone: "UTC"
       target-branch: "develop"
       open-pull-requests-limit: 1
-      assignees:
+      reviewers:
         - "anton-lisanin"
         - "s-medvedev"
+        - "andreisilviudragnea"
       ignore:
         - dependency-name: "solana-program"
         - dependency-name: "spl-token"


### PR DESCRIPTION
For an unknown reason, Dependabot updates do not work anymore.

This PR tries to re-enable them by updating the `dependabot.yml` file. Most probably `timezone: "UTC"` is the problem, since "UTC" is not a valid timezone identifier.