### PR TITLE
Remove GetLargestAccounts RPC request

### DIFF
--- a/ci/deploy-evm.sh
+++ b/ci/deploy-evm.sh
@@ -29,4 +29,5 @@ fi
 echo "Deployed finished from " $(solana address) " with " $(solana balance)
 neon-cli --url $SOLANA_URL --evm_loader $EVM_LOADER \
   --keypair evm_loader-keypair.json \
+  --solana_key_for_config BMp6gEnveANdvSvspESJUrNczuHz1GF5UQKjVLCkAZih \
   --loglevel debug init-environment --send-trx --keys-dir keys/

--- a/ci/docker-compose-ci.yml
+++ b/ci/docker-compose-ci.yml
@@ -31,12 +31,10 @@ services:
       NEON_API_LISTENER_ADDR: 0.0.0.0:8085
       SOLANA_URL: http://solana:8899
       EVM_LOADER: 53DfF883gyixYNXnM7s5xhdeyV8mVk9T4i2hGV9vG9io
-      NEON_TOKEN_MINT: HPsV9Deocecw3GeZv1FkAPNCBRfuVyfw9MMwjwRe1xaU
-      NEON_CHAIN_ID: 111
+      # operator-keypairs/id.json
+      SOLANA_KEY_FOR_CONFIG: BMp6gEnveANdvSvspESJUrNczuHz1GF5UQKjVLCkAZih
       COMMITMENT: confirmed
       NEON_DB_CLICKHOUSE_URLS: "http://45.250.253.36:8123;http://45.250.253.38:8123"
-      KEYPAIR: /opt/operator-keypairs/id.json
-      FEEPAIR: /opt/operator-keypairs/id.json
     image: ${EVM_LOADER_IMAGE}
     ports:
     - "8085"

--- a/ci/docker-compose-test.yml
+++ b/ci/docker-compose-test.yml
@@ -34,12 +34,10 @@ services:
       NEON_API_LISTENER_ADDR: 0.0.0.0:8085
       SOLANA_URL: http://solana:8899
       EVM_LOADER: 53DfF883gyixYNXnM7s5xhdeyV8mVk9T4i2hGV9vG9io
-      NEON_TOKEN_MINT: HPsV9Deocecw3GeZv1FkAPNCBRfuVyfw9MMwjwRe1xaU
-      NEON_CHAIN_ID: 111
+      # operator-keypairs/id.json
+      SOLANA_KEY_FOR_CONFIG: BMp6gEnveANdvSvspESJUrNczuHz1GF5UQKjVLCkAZih
       COMMITMENT: confirmed
       NEON_DB_CLICKHOUSE_URLS: "http://45.250.253.36:8123;http://45.250.253.38:8123"
-      KEYPAIR: /opt/operator-keypairs/id.json
-      FEEPAIR: /opt/operator-keypairs/id.json
     image: ${EVM_LOADER_IMAGE}
     ports:
     - "8085:8085"

--- a/ci/solana-run-neon.sh
+++ b/ci/solana-run-neon.sh
@@ -42,6 +42,7 @@ solana-test-validator "${VALIDATOR_ARGS[@]}" > /dev/null &
 neon-cli --url http://localhost:8899 --evm_loader $EVM_LOADER \
   --commitment confirmed \
   --keypair ${EVM_LOADER_AUTHORITY_KEYPAIR} \
+  --solana_key_for_config BMp6gEnveANdvSvspESJUrNczuHz1GF5UQKjVLCkAZih \
   --loglevel trace init-environment --send-trx --keys-dir /opt/keys
 
 tail +1f test-ledger/validator.log

--- a/evm_loader/api/src/api_server/state.rs
+++ b/evm_loader/api/src/api_server/state.rs
@@ -1,4 +1,4 @@
-use crate::Config;
+use neon_lib::config::APIOptions;
 use neon_lib::rpc::{CallDbClient, CloneRpcClient, RpcEnum};
 use neon_lib::types::TracerDb;
 use neon_lib::NeonError;
@@ -6,14 +6,14 @@ use neon_lib::NeonError;
 pub struct State {
     pub tracer_db: TracerDb,
     pub rpc_client: CloneRpcClient,
-    pub config: Config,
+    pub config: APIOptions,
 }
 
 impl State {
-    pub fn new(config: Config) -> Self {
+    pub fn new(config: APIOptions) -> Self {
         Self {
-            tracer_db: TracerDb::new(config.db_config.as_ref().expect("db-config not found")),
-            rpc_client: config.build_clone_solana_rpc_client(),
+            tracer_db: TracerDb::new(&config.db_config),
+            rpc_client: CloneRpcClient::new_from_api_config(&config),
             config,
         }
     }

--- a/evm_loader/api/src/main.rs
+++ b/evm_loader/api/src/main.rs
@@ -52,10 +52,7 @@ async fn main() -> NeonApiResult<()> {
     info!("{}", get_build_info());
 
     let api_config = config::load_api_config_from_enviroment();
-
-    let config = config::create_from_api_config(&api_config)?;
-
-    let state: NeonApiState = Data::new(api_server::state::State::new(config));
+    let state: NeonApiState = Data::new(api_server::state::State::new(api_config));
 
     let listener_addr = options
         .value_of("host")

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -12,6 +12,7 @@ use neon_lib::{
         cancel_trx, collect_treasury, emulate, get_balance, get_config, get_contract, get_holder,
         get_neon_elf, get_storage_at, init_environment, trace,
     },
+    rpc::CloneRpcClient,
     types::{BalanceAddress, EmulateRequest},
     Config,
 };
@@ -90,7 +91,7 @@ async fn run(options: &ArgMatches<'_>) -> NeonCliResult {
                 .map(|result| json!(result))
         }
         ("cancel-trx", Some(params)) => {
-            let rpc_client = config.build_clone_solana_rpc_client();
+            let rpc_client = CloneRpcClient::new_from_config(config);
             let signer = build_signer(config)?;
 
             let storage_account =
@@ -108,7 +109,7 @@ async fn run(options: &ArgMatches<'_>) -> NeonCliResult {
                 .map(|result| json!(result))
         }
         ("collect-treasury", Some(_)) => {
-            let rpc_client = config.build_clone_solana_rpc_client();
+            let rpc_client = CloneRpcClient::new_from_config(config);
             let signer = build_signer(config)?;
 
             collect_treasury::execute(config, &rpc_client, &*signer)
@@ -116,7 +117,7 @@ async fn run(options: &ArgMatches<'_>) -> NeonCliResult {
                 .map(|result| json!(result))
         }
         ("init-environment", Some(params)) => {
-            let rpc_client = config.build_clone_solana_rpc_client();
+            let rpc_client = CloneRpcClient::new_from_config(config);
             let signer = build_signer(config)?;
 
             let file = params.value_of("file");
@@ -172,7 +173,7 @@ async fn build_rpc(options: &ArgMatches<'_>, config: &Config) -> Result<RpcEnum,
             .await?,
         )
     } else {
-        RpcEnum::CloneRpcClient(config.build_clone_solana_rpc_client())
+        RpcEnum::CloneRpcClient(CloneRpcClient::new_from_config(config))
     })
 }
 

--- a/evm_loader/cli/src/program_options.rs
+++ b/evm_loader/cli/src/program_options.rs
@@ -117,6 +117,16 @@ pub fn parse<'a>() -> ArgMatches<'a> {
                 .help("Pubkey for evm_loader contract")
         )
         .arg(
+            Arg::with_name("solana_key_for_config")
+                .long("solana_key_for_config")
+                .value_name("SOLANA_KEY_FOR_CONFIG")
+                .takes_value(true)
+                .global(true)
+                .required(false)
+                .validator(is_valid_pubkey)
+                .help("Operator pubkey, used for config simulation")
+        )
+        .arg(
             Arg::with_name("commitment")
                 .long("commitment")
                 .takes_value(true)

--- a/evm_loader/lib/src/errors.rs
+++ b/evm_loader/lib/src/errors.rs
@@ -112,6 +112,8 @@ pub enum NeonError {
     FromUtf8Error(#[from] FromUtf8Error),
     #[error("TryFromSlice Error. {0}")]
     TryFromSliceError(#[from] TryFromSliceError),
+    #[error("Solana pubkey for config must be specified.")]
+    SolanaKeyForConfigNotSpecified,
 }
 
 impl NeonError {
@@ -153,6 +155,7 @@ impl NeonError {
             NeonError::BincodeError(_) => 257,
             NeonError::FromUtf8Error(_) => 258,
             NeonError::TryFromSliceError(_) => 259,
+            NeonError::SolanaKeyForConfigNotSpecified => 260,
         }
     }
 }


### PR DESCRIPTION
Removed the GetLargestAccounts RPC request.
Added the "SOLANA_KEY_FOR_CONFIG" environment variable for the API and --solana_key_for_config parameter for the CLI. It must be set to the public key with a SOLs balance. This key is used during simulation of the NeonEVM configuration.

@andreisilviudragnea update the Tracer side
@afalaleev update the proxy
@kristinaNikolaevaa update the tests config

We need to merge all components at the same time.