### PR TITLE
NDEV-2620: Add executor_state: &impl Database parameter to EventListener::event method

### DIFF
--- a/evm_loader/api/src/api_server/handlers/emulate.rs
+++ b/evm_loader/api/src/api_server/handlers/emulate.rs
@@ -1,5 +1,6 @@
 use actix_request_identifier::RequestId;
 use actix_web::{http::StatusCode, post, web::Json, Responder};
+use neon_lib::tracing::tracers::TracerTypeEnum;
 use std::convert::Into;
 use tracing::info;
 
@@ -26,8 +27,14 @@ pub async fn emulate(
     };
 
     process_result(
-        &EmulateCommand::execute(&rpc, state.config.evm_loader, emulate_request.body, None)
-            .await
-            .map_err(Into::into),
+        &EmulateCommand::execute(
+            &rpc,
+            state.config.evm_loader,
+            emulate_request.body,
+            None::<TracerTypeEnum>,
+        )
+        .await
+        .map(|(response, _)| response)
+        .map_err(Into::into),
     )
 }

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -29,6 +29,7 @@ use crate::build_info::get_build_info;
 use evm_loader::types::Address;
 use neon_lib::errors::NeonError;
 use neon_lib::rpc::{CallDbClient, RpcEnum};
+use neon_lib::tracing::tracers::TracerTypeEnum;
 use neon_lib::types::TracerDb;
 use solana_clap_utils::keypair::signer_from_path;
 use solana_sdk::signature::Signer;
@@ -44,9 +45,9 @@ async fn run(options: &ArgMatches<'_>) -> NeonCliResult {
             let rpc = build_rpc(options, config).await?;
 
             let request = read_tx_from_stdin()?;
-            emulate::execute(&rpc, config.evm_loader, request, None)
+            emulate::execute(&rpc, config.evm_loader, request, None::<TracerTypeEnum>)
                 .await
-                .map(|result| json!(result))
+                .map(|(result, _)| json!(result))
         }
         ("trace", Some(_)) => {
             let rpc = build_rpc(options, config).await?;

--- a/evm_loader/lib/Cargo.toml
+++ b/evm_loader/lib/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 thiserror = "1.0"
 anyhow = "1.0"
 bincode = "1.3.1"
-evm-loader = { path = "../program", default-features = false, features = ["log", "async-trait", "serde_json"] }
+evm-loader = { path = "../program", default-features = false, features = ["log", "async-trait"] }
 solana-sdk = "=1.16.23"
 solana-client = "=1.16.23"
 solana-clap-utils = "=1.16.23"

--- a/evm_loader/lib/src/commands/emulate.rs
+++ b/evm_loader/lib/src/commands/emulate.rs
@@ -15,7 +15,7 @@ use crate::{
     errors::NeonError,
     NeonResult,
 };
-use evm_loader::evm::tracing::EventListener;
+use evm_loader::evm::tracing::Tracer;
 use evm_loader::{
     config::{EVM_STEPS_MIN, PAYMENT_TO_TREASURE},
     evm::{ExitStatus, Machine},
@@ -51,7 +51,7 @@ impl EmulateResponse {
     }
 }
 
-pub async fn execute<T: EventListener>(
+pub async fn execute<T: Tracer>(
     rpc: &(impl Rpc + BuildConfigSimulator),
     program_id: Pubkey,
     emulate_request: EmulateRequest,
@@ -82,7 +82,7 @@ pub async fn execute<T: EventListener>(
     emulate_trx(emulate_request.tx, &mut storage, step_limit, tracer).await
 }
 
-async fn emulate_trx<T: EventListener>(
+async fn emulate_trx<T: Tracer>(
     tx_params: TxParams,
     storage: &mut EmulatorAccountStorage<'_, impl Rpc>,
     step_limit: u64,

--- a/evm_loader/lib/src/commands/emulate.rs
+++ b/evm_loader/lib/src/commands/emulate.rs
@@ -9,13 +9,13 @@ use solana_sdk::pubkey::Pubkey;
 use crate::commands::get_config::BuildConfigSimulator;
 use crate::rpc::Rpc;
 use crate::syscall_stubs::setup_emulator_syscall_stubs;
+use crate::tracing::tracers::Tracer;
 use crate::types::{EmulateRequest, TxParams};
 use crate::{
     account_storage::{EmulatorAccountStorage, SolanaAccount},
     errors::NeonError,
     NeonResult,
 };
-use evm_loader::evm::tracing::Tracer;
 use evm_loader::{
     config::{EVM_STEPS_MIN, PAYMENT_TO_TREASURE},
     evm::{ExitStatus, Machine},

--- a/evm_loader/lib/src/commands/emulate.rs
+++ b/evm_loader/lib/src/commands/emulate.rs
@@ -2,6 +2,7 @@ use evm_loader::account::ContractAccount;
 use evm_loader::error::build_revert_message;
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use solana_sdk::entrypoint::MAX_PERMITTED_DATA_INCREASE;
 use solana_sdk::pubkey::Pubkey;
 
@@ -14,7 +15,7 @@ use crate::{
     errors::NeonError,
     NeonResult,
 };
-use evm_loader::evm::tracing::TracerType;
+use evm_loader::evm::tracing::EventListener;
 use evm_loader::{
     config::{EVM_STEPS_MIN, PAYMENT_TO_TREASURE},
     evm::{ExitStatus, Machine},
@@ -50,12 +51,12 @@ impl EmulateResponse {
     }
 }
 
-pub async fn execute(
+pub async fn execute<T: EventListener>(
     rpc: &(impl Rpc + BuildConfigSimulator),
     program_id: Pubkey,
     emulate_request: EmulateRequest,
-    tracer: Option<TracerType>,
-) -> NeonResult<EmulateResponse> {
+    tracer: Option<T>,
+) -> NeonResult<(EmulateResponse, Option<Value>)> {
     let block_overrides = emulate_request
         .trace_config
         .as_ref()
@@ -81,12 +82,12 @@ pub async fn execute(
     emulate_trx(emulate_request.tx, &mut storage, step_limit, tracer).await
 }
 
-async fn emulate_trx(
+async fn emulate_trx<T: EventListener>(
     tx_params: TxParams,
     storage: &mut EmulatorAccountStorage<'_, impl Rpc>,
     step_limit: u64,
-    tracer: Option<TracerType>,
-) -> NeonResult<EmulateResponse> {
+    tracer: Option<T>,
+) -> NeonResult<(EmulateResponse, Option<Value>)> {
     info!("tx_params: {:?}", tx_params);
 
     let (origin, tx) = tx_params.into_transaction(storage).await;
@@ -94,21 +95,18 @@ async fn emulate_trx(
     info!("origin: {:?}", origin);
     info!("tx: {:?}", tx);
 
-    let (exit_status, actions, steps_executed) = {
-        let mut backend = ExecutorState::new(storage);
-        let mut evm = match Machine::new(tx, origin, &mut backend, tracer).await {
-            Ok(evm) => evm,
-            Err(e) => return Ok(EmulateResponse::revert(e)),
-        };
-
-        let (result, steps_executed) = evm.execute(step_limit, &mut backend).await?;
-        if result == ExitStatus::StepLimit {
-            return Err(NeonError::TooManySteps);
-        }
-
-        let actions = backend.into_actions();
-        (result, actions, steps_executed)
+    let mut backend = ExecutorState::new(storage);
+    let mut evm = match Machine::new(tx, origin, &mut backend, tracer).await {
+        Ok(evm) => evm,
+        Err(e) => return Ok((EmulateResponse::revert(e), None)),
     };
+
+    let (exit_status, steps_executed, tracer) = evm.execute(step_limit, &mut backend).await?;
+    if exit_status == ExitStatus::StepLimit {
+        return Err(NeonError::TooManySteps);
+    }
+
+    let actions = backend.into_actions();
 
     storage.apply_actions(actions.clone()).await?;
     storage.mark_legacy_accounts().await?;
@@ -128,14 +126,17 @@ async fn emulate_trx(
 
     let solana_accounts = storage.accounts.borrow().values().cloned().collect();
 
-    Ok(EmulateResponse {
-        exit_status: exit_status.to_string(),
-        steps_executed,
-        used_gas,
-        solana_accounts,
-        result: exit_status.into_result().unwrap_or_default(),
-        iterations,
-    })
+    Ok((
+        EmulateResponse {
+            exit_status: exit_status.to_string(),
+            steps_executed,
+            used_gas,
+            solana_accounts,
+            result: exit_status.into_result().unwrap_or_default(),
+            iterations,
+        },
+        tracer.map(|tracer| tracer.into_traces()),
+    ))
 }
 
 fn realloc_iterations(actions: &[Action]) -> u64 {

--- a/evm_loader/lib/src/tracing/tracers/mod.rs
+++ b/evm_loader/lib/src/tracing/tracers/mod.rs
@@ -1,21 +1,39 @@
 use crate::tracing::tracers::struct_logger::StructLogger;
 use crate::tracing::TraceConfig;
-use evm_loader::evm::tracing::TracerType;
-use std::cell::RefCell;
-use std::rc::Rc;
+use evm_loader::evm::database::Database;
+use evm_loader::evm::tracing::{Event, EventListener};
+use serde_json::Value;
 
 pub mod struct_logger;
 
-pub fn new_tracer(trace_config: &TraceConfig) -> evm_loader::error::Result<TracerType> {
-    Ok(Rc::new(RefCell::new(
-        match trace_config.tracer.as_deref() {
-            None | Some("") => Box::new(StructLogger::new(trace_config)),
-            _ => {
-                return Err(evm_loader::error::Error::Custom(format!(
-                    "Unsupported tracer: {:?}",
-                    trace_config.tracer
-                )))
+pub enum TracerTypeEnum {
+    StructLogger(StructLogger),
+}
+
+impl EventListener for TracerTypeEnum {
+    fn event(&mut self, executor_state: &impl Database, event: Event) {
+        match self {
+            TracerTypeEnum::StructLogger(struct_logger) => {
+                struct_logger.event(executor_state, event)
             }
-        },
-    )))
+        }
+    }
+
+    fn into_traces(self) -> Value {
+        match self {
+            TracerTypeEnum::StructLogger(struct_logger) => struct_logger.into_traces(),
+        }
+    }
+}
+
+pub fn new_tracer(trace_config: &TraceConfig) -> evm_loader::error::Result<TracerTypeEnum> {
+    match trace_config.tracer.as_deref() {
+        None | Some("") => Ok(TracerTypeEnum::StructLogger(StructLogger::new(
+            trace_config,
+        ))),
+        _ => Err(evm_loader::error::Error::Custom(format!(
+            "Unsupported tracer: {:?}",
+            trace_config.tracer
+        ))),
+    }
 }

--- a/evm_loader/lib/src/tracing/tracers/mod.rs
+++ b/evm_loader/lib/src/tracing/tracers/mod.rs
@@ -1,7 +1,7 @@
 use crate::tracing::tracers::struct_logger::StructLogger;
 use crate::tracing::TraceConfig;
 use evm_loader::evm::database::Database;
-use evm_loader::evm::tracing::{Event, EventListener, Tracer};
+use evm_loader::evm::tracing::{Event, EventListener};
 use serde_json::Value;
 
 pub mod struct_logger;
@@ -18,6 +18,10 @@ impl EventListener for TracerTypeEnum {
             }
         }
     }
+}
+
+pub trait Tracer: EventListener {
+    fn into_traces(self) -> Value;
 }
 
 impl Tracer for TracerTypeEnum {

--- a/evm_loader/lib/src/tracing/tracers/mod.rs
+++ b/evm_loader/lib/src/tracing/tracers/mod.rs
@@ -1,7 +1,7 @@
 use crate::tracing::tracers::struct_logger::StructLogger;
 use crate::tracing::TraceConfig;
 use evm_loader::evm::database::Database;
-use evm_loader::evm::tracing::{Event, EventListener};
+use evm_loader::evm::tracing::{Event, EventListener, Tracer};
 use serde_json::Value;
 
 pub mod struct_logger;
@@ -18,7 +18,9 @@ impl EventListener for TracerTypeEnum {
             }
         }
     }
+}
 
+impl Tracer for TracerTypeEnum {
     fn into_traces(self) -> Value {
         match self {
             TracerTypeEnum::StructLogger(struct_logger) => struct_logger.into_traces(),

--- a/evm_loader/lib/src/tracing/tracers/struct_logger.rs
+++ b/evm_loader/lib/src/tracing/tracers/struct_logger.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use ethnum::U256;
+use evm_loader::evm::database::Database;
 use evm_loader::evm::ExitStatus;
 use serde::Serialize;
 use serde_json::Value;
@@ -138,7 +139,7 @@ impl StructLogger {
 }
 
 impl EventListener for StructLogger {
-    fn event(&mut self, event: Event) {
+    fn event(&mut self, _executor_state: &impl Database, event: Event) {
         match event {
             Event::BeginVM { .. } => {
                 self.depth += 1;
@@ -204,7 +205,7 @@ impl EventListener for StructLogger {
         };
     }
 
-    fn into_traces(self: Box<Self>) -> Value {
+    fn into_traces(self) -> Value {
         let exit_status = self.exit_status.expect("Emulation is not completed");
         let result = StructLoggerResult {
             gas: 0,

--- a/evm_loader/lib/src/tracing/tracers/struct_logger.rs
+++ b/evm_loader/lib/src/tracing/tracers/struct_logger.rs
@@ -7,9 +7,10 @@ use serde::Serialize;
 use serde_json::Value;
 use web3::types::Bytes;
 
+use crate::tracing::tracers::Tracer;
 use crate::tracing::TraceConfig;
 use evm_loader::evm::opcode_table::OPNAMES;
-use evm_loader::evm::tracing::{Event, EventListener, Tracer};
+use evm_loader::evm::tracing::{Event, EventListener};
 
 /// `StructLoggerResult` groups all structured logs emitted by the EVM
 /// while replaying a transaction in debug mode as well as transaction

--- a/evm_loader/lib/src/tracing/tracers/struct_logger.rs
+++ b/evm_loader/lib/src/tracing/tracers/struct_logger.rs
@@ -9,7 +9,7 @@ use web3::types::Bytes;
 
 use crate::tracing::TraceConfig;
 use evm_loader::evm::opcode_table::OPNAMES;
-use evm_loader::evm::tracing::{Event, EventListener};
+use evm_loader::evm::tracing::{Event, EventListener, Tracer};
 
 /// `StructLoggerResult` groups all structured logs emitted by the EVM
 /// while replaying a transaction in debug mode as well as transaction
@@ -204,7 +204,9 @@ impl EventListener for StructLogger {
             }
         };
     }
+}
 
+impl Tracer for StructLogger {
     fn into_traces(self) -> Value {
         let exit_status = self.exit_status.expect("Emulation is not completed");
         let result = StructLoggerResult {

--- a/evm_loader/program/Cargo.toml
+++ b/evm_loader/program/Cargo.toml
@@ -51,7 +51,7 @@ borsh = "0.9"
 bincode = "1"
 serde_bytes = "0.11.12"
 serde = { version = "1.0.186", default-features = false, features = ["derive", "rc"] }
-serde_json = { version = "1.0.107", features = ["preserve_order"], optional = true }
+serde_json = { version = "1.0.107", features = ["preserve_order"] }
 ethnum = { version = "1.4", default-features = false, features = ["serde"] }
 cfg-if = { version = "1.0" }
 log = { version = "0.4", default-features = false, optional = true }

--- a/evm_loader/program/Cargo.toml
+++ b/evm_loader/program/Cargo.toml
@@ -51,7 +51,6 @@ borsh = "0.9"
 bincode = "1"
 serde_bytes = "0.11.12"
 serde = { version = "1.0.186", default-features = false, features = ["derive", "rc"] }
-serde_json = { version = "1.0.107", features = ["preserve_order"] }
 ethnum = { version = "1.4", default-features = false, features = ["serde"] }
 cfg-if = { version = "1.0" }
 log = { version = "0.4", default-features = false, optional = true }
@@ -64,6 +63,7 @@ features = ["is_sync"]
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
+serde_json = { version = "1.0.107", features = ["preserve_order"] }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/evm_loader/program/src/evm/precompile/mod.rs
+++ b/evm_loader/program/src/evm/precompile/mod.rs
@@ -1,3 +1,4 @@
+use crate::evm::tracing::EventListener;
 use crate::evm::{database::Database, Machine};
 use crate::types::Address;
 
@@ -56,7 +57,7 @@ pub fn is_precompile_address(address: &Address) -> bool {
         || *address == SYSTEM_ACCOUNT_BLAKE2F
 }
 
-impl<B: Database> Machine<B> {
+impl<B: Database, T: EventListener> Machine<B, T> {
     #[must_use]
     pub fn precompile(address: &Address, data: &[u8]) -> Option<Vec<u8>> {
         match *address {

--- a/evm_loader/program/src/evm/tracing.rs
+++ b/evm_loader/program/src/evm/tracing.rs
@@ -8,11 +8,17 @@ pub struct NoopEventListener;
 
 pub trait EventListener {
     fn event(&mut self, executor_state: &impl Database, event: Event);
+}
+
+pub trait Tracer: EventListener {
     fn into_traces(self) -> Value;
 }
 
 impl EventListener for NoopEventListener {
     fn event(&mut self, _executor_state: &impl Database, _event: Event) {}
+}
+
+impl Tracer for NoopEventListener {
     fn into_traces(self) -> Value {
         Value::Null
     }

--- a/evm_loader/program/src/evm/tracing.rs
+++ b/evm_loader/program/src/evm/tracing.rs
@@ -1,19 +1,22 @@
-use std::cell::RefCell;
-use std::fmt::Debug;
-use std::rc::Rc;
-
+use crate::evm::database::Database;
 use ethnum::U256;
 use serde_json::Value;
 
 use super::{Context, ExitStatus};
 
-pub trait EventListener: Debug {
-    fn event(&mut self, event: Event);
-    fn into_traces(self: Box<Self>) -> Value;
+pub struct NoopEventListener;
+
+pub trait EventListener {
+    fn event(&mut self, executor_state: &impl Database, event: Event);
+    fn into_traces(self) -> Value;
 }
 
-pub type TracerType = Rc<RefCell<Box<dyn EventListener>>>;
-pub type TracerTypeOpt = Option<TracerType>;
+impl EventListener for NoopEventListener {
+    fn event(&mut self, _executor_state: &impl Database, _event: Event) {}
+    fn into_traces(self) -> Value {
+        Value::Null
+    }
+}
 
 /// Trace event
 pub enum Event {

--- a/evm_loader/program/src/evm/tracing.rs
+++ b/evm_loader/program/src/evm/tracing.rs
@@ -1,8 +1,6 @@
+use super::{Context, ExitStatus};
 use crate::evm::database::Database;
 use ethnum::U256;
-use serde_json::Value;
-
-use super::{Context, ExitStatus};
 
 pub struct NoopEventListener;
 
@@ -10,18 +8,8 @@ pub trait EventListener {
     fn event(&mut self, executor_state: &impl Database, event: Event);
 }
 
-pub trait Tracer: EventListener {
-    fn into_traces(self) -> Value;
-}
-
 impl EventListener for NoopEventListener {
     fn event(&mut self, _executor_state: &impl Database, _event: Event) {}
-}
-
-impl Tracer for NoopEventListener {
-    fn into_traces(self) -> Value {
-        Value::Null
-    }
 }
 
 /// Trace event

--- a/evm_loader/program/src/instruction/transaction_execute.rs
+++ b/evm_loader/program/src/instruction/transaction_execute.rs
@@ -3,6 +3,7 @@ use solana_program::pubkey::Pubkey;
 use crate::account::{AccountsDB, AllocateResult};
 use crate::account_storage::ProgramAccountStorage;
 use crate::error::{Error, Result};
+use crate::evm::tracing::NoopEventListener;
 use crate::evm::Machine;
 use crate::executor::ExecutorState;
 use crate::gasometer::Gasometer;
@@ -38,8 +39,8 @@ pub fn execute(
     let (exit_reason, apply_state) = {
         let mut backend = ExecutorState::new(&account_storage);
 
-        let mut evm = Machine::new(trx, origin, &mut backend)?;
-        let (result, _) = evm.execute(u64::MAX, &mut backend)?;
+        let mut evm = Machine::new(trx, origin, &mut backend, None::<NoopEventListener>)?;
+        let (result, _, _) = evm.execute(u64::MAX, &mut backend)?;
 
         let actions = backend.into_actions();
 


### PR DESCRIPTION
This PR changes signature of `EventListener::event` method from:
```Rust
    fn event(&mut self, event: Event);
```
to:
```Rust
    fn event(&mut self, executor_state: &impl Database, event: Event);
```

Most changes in this PR come from fixing the object safety error encountered while adding this parameter:
```
error[E0038]: the trait `EventListener` cannot be made into an object
   --> program/src/evm/mod.rs:167:13
    |
167 |     tracer: TracerTypeOpt,
    |             ^^^^^^^^^^^^^ `EventListener` cannot be made into an object
    |
note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> program/src/evm/tracing.rs:12:8
    |
11  | pub trait EventListener: Debug {
    |           ------------- this trait cannot be made into an object...
12  |     fn event(&mut self, executor_state: &impl Database, event: Event);
    |        ^^^^^ ...because method `event` has generic type parameters
    = help: consider moving `event` to another trait
```

Since `executor_state: &impl Database` is a generic type parameter, dynamic dispatch needs to be replaced with static dispatch, similar to #233.

The `executor_state: &impl Database` parameter is needed to intercept state changes in tracer implementations. It is passed as an explicit parameter in order to avoid wrapping `executor_state: &impl Database` into `Rc<RefCell<>>`.