### PR TITLE
NDEV-2622: Remove unused Result types

### DIFF
--- a/evm_loader/program/src/evm/database.rs
+++ b/evm_loader/program/src/evm/database.rs
@@ -24,7 +24,7 @@ pub trait Database {
     async fn code_size(&self, address: Address) -> usize;
     async fn code(&self, address: Address) -> Buffer;
     fn set_code(&mut self, address: Address, chain_id: u64, code: Vec<u8>) -> Result<()>;
-    fn selfdestruct(&mut self, address: Address) -> Result<()>;
+    fn selfdestruct(&mut self, address: Address);
 
     async fn storage(&self, address: Address, index: U256) -> [u8; 32];
     fn set_storage(&mut self, address: Address, index: U256, value: [u8; 32]) -> Result<()>;
@@ -199,7 +199,7 @@ mod tests {
             unimplemented!();
         }
 
-        fn selfdestruct(&mut self, address: Address) -> Result<()> {
+        fn selfdestruct(&mut self, address: Address) {
             unimplemented!();
         }
 

--- a/evm_loader/program/src/evm/database.rs
+++ b/evm_loader/program/src/evm/database.rs
@@ -11,7 +11,7 @@ pub trait Database {
     async fn contract_chain_id(&self, address: Address) -> Result<u64>;
 
     async fn nonce(&self, address: Address, chain_id: u64) -> Result<u64>;
-    fn increment_nonce(&mut self, address: Address, chain_id: u64) -> Result<()>;
+    fn increment_nonce(&mut self, address: Address, chain_id: u64);
 
     async fn balance(&self, address: Address, chain_id: u64) -> Result<U256>;
     async fn transfer(
@@ -162,7 +162,7 @@ mod tests {
                 .unwrap_or_default())
         }
 
-        fn increment_nonce(&mut self, address: Address, chain_id: u64) -> Result<()> {
+        fn increment_nonce(&mut self, address: Address, chain_id: u64) {
             unimplemented!();
         }
 

--- a/evm_loader/program/src/evm/database.rs
+++ b/evm_loader/program/src/evm/database.rs
@@ -30,7 +30,7 @@ pub trait Database {
     fn set_storage(&mut self, address: Address, index: U256, value: [u8; 32]);
 
     async fn block_hash(&self, number: U256) -> [u8; 32];
-    fn block_number(&self) -> Result<U256>;
+    fn block_number(&self) -> U256;
     fn block_timestamp(&self) -> Result<U256>;
 
     async fn map_solana_account<F, R>(&self, address: &Pubkey, action: F) -> R
@@ -215,7 +215,7 @@ mod tests {
             unimplemented!();
         }
 
-        fn block_number(&self) -> Result<U256> {
+        fn block_number(&self) -> U256 {
             unimplemented!();
         }
 

--- a/evm_loader/program/src/evm/database.rs
+++ b/evm_loader/program/src/evm/database.rs
@@ -22,7 +22,7 @@ pub trait Database {
         value: U256,
     ) -> Result<()>;
     async fn code_size(&self, address: Address) -> usize;
-    async fn code(&self, address: Address) -> Result<Buffer>;
+    async fn code(&self, address: Address) -> Buffer;
     fn set_code(&mut self, address: Address, chain_id: u64, code: Vec<u8>) -> Result<()>;
     fn selfdestruct(&mut self, address: Address) -> Result<()>;
 
@@ -76,7 +76,7 @@ impl<T: Database> DatabaseExt for T {
         // We could simplify the implementation by checking if the account exists first, but that
         // would lead to more computation in what we think is the common case where the account
         // exists and contains code.
-        let code = self.code(address).await?;
+        let code = self.code(address).await;
         let bytes_to_hash: Option<&[u8]> = if !code.is_empty() {
             Some(&*code)
         } else if self.account_exists(address, chain_id).await? {
@@ -188,12 +188,11 @@ mod tests {
             unimplemented!();
         }
 
-        async fn code(&self, address: Address) -> Result<Buffer> {
-            Ok(self
-                .0
+        async fn code(&self, address: Address) -> Buffer {
+            self.0
                 .get(&address)
                 .map(|entry| Buffer::from_slice(&entry.code))
-                .unwrap_or_default())
+                .unwrap_or_default()
         }
 
         fn set_code(&mut self, address: Address, chain_id: u64, code: Vec<u8>) -> Result<()> {

--- a/evm_loader/program/src/evm/database.rs
+++ b/evm_loader/program/src/evm/database.rs
@@ -31,7 +31,7 @@ pub trait Database {
 
     async fn block_hash(&self, number: U256) -> [u8; 32];
     fn block_number(&self) -> U256;
-    fn block_timestamp(&self) -> Result<U256>;
+    fn block_timestamp(&self) -> U256;
 
     async fn map_solana_account<F, R>(&self, address: &Pubkey, action: F) -> R
     where
@@ -219,7 +219,7 @@ mod tests {
             unimplemented!();
         }
 
-        fn block_timestamp(&self) -> Result<U256> {
+        fn block_timestamp(&self) -> U256 {
             unimplemented!();
         }
 

--- a/evm_loader/program/src/evm/database.rs
+++ b/evm_loader/program/src/evm/database.rs
@@ -21,7 +21,7 @@ pub trait Database {
         chain_id: u64,
         value: U256,
     ) -> Result<()>;
-    async fn code_size(&self, address: Address) -> Result<usize>;
+    async fn code_size(&self, address: Address) -> usize;
     async fn code(&self, address: Address) -> Result<Buffer>;
     fn set_code(&mut self, address: Address, chain_id: u64, code: Vec<u8>) -> Result<()>;
     fn selfdestruct(&mut self, address: Address) -> Result<()>;
@@ -184,7 +184,7 @@ mod tests {
             unimplemented!();
         }
 
-        async fn code_size(&self, address: Address) -> Result<usize> {
+        async fn code_size(&self, address: Address) -> usize {
             unimplemented!();
         }
 

--- a/evm_loader/program/src/evm/database.rs
+++ b/evm_loader/program/src/evm/database.rs
@@ -27,7 +27,7 @@ pub trait Database {
     fn selfdestruct(&mut self, address: Address);
 
     async fn storage(&self, address: Address, index: U256) -> [u8; 32];
-    fn set_storage(&mut self, address: Address, index: U256, value: [u8; 32]) -> Result<()>;
+    fn set_storage(&mut self, address: Address, index: U256, value: [u8; 32]);
 
     async fn block_hash(&self, number: U256) -> [u8; 32];
     fn block_number(&self) -> Result<U256>;
@@ -207,7 +207,7 @@ mod tests {
             unimplemented!();
         }
 
-        fn set_storage(&mut self, address: Address, index: U256, value: [u8; 32]) -> Result<()> {
+        fn set_storage(&mut self, address: Address, index: U256, value: [u8; 32]) {
             unimplemented!();
         }
 

--- a/evm_loader/program/src/evm/database.rs
+++ b/evm_loader/program/src/evm/database.rs
@@ -29,7 +29,7 @@ pub trait Database {
     async fn storage(&self, address: Address, index: U256) -> Result<[u8; 32]>;
     fn set_storage(&mut self, address: Address, index: U256, value: [u8; 32]) -> Result<()>;
 
-    async fn block_hash(&self, number: U256) -> Result<[u8; 32]>;
+    async fn block_hash(&self, number: U256) -> [u8; 32];
     fn block_number(&self) -> Result<U256>;
     fn block_timestamp(&self) -> Result<U256>;
 
@@ -212,7 +212,7 @@ mod tests {
             unimplemented!();
         }
 
-        async fn block_hash(&self, number: U256) -> Result<[u8; 32]> {
+        async fn block_hash(&self, number: U256) -> [u8; 32] {
             unimplemented!();
         }
 

--- a/evm_loader/program/src/evm/database.rs
+++ b/evm_loader/program/src/evm/database.rs
@@ -26,7 +26,7 @@ pub trait Database {
     fn set_code(&mut self, address: Address, chain_id: u64, code: Vec<u8>) -> Result<()>;
     fn selfdestruct(&mut self, address: Address) -> Result<()>;
 
-    async fn storage(&self, address: Address, index: U256) -> Result<[u8; 32]>;
+    async fn storage(&self, address: Address, index: U256) -> [u8; 32];
     fn set_storage(&mut self, address: Address, index: U256, value: [u8; 32]) -> Result<()>;
 
     async fn block_hash(&self, number: U256) -> [u8; 32];
@@ -203,7 +203,7 @@ mod tests {
             unimplemented!();
         }
 
-        async fn storage(&self, address: Address, index: U256) -> Result<[u8; 32]> {
+        async fn storage(&self, address: Address, index: U256) -> [u8; 32] {
             unimplemented!();
         }
 

--- a/evm_loader/program/src/evm/mod.rs
+++ b/evm_loader/program/src/evm/mod.rs
@@ -276,7 +276,7 @@ impl<B: Database> Machine<B> {
         let target = trx.target().unwrap();
         sol_log_data(&[b"ENTER", b"CALL", target.as_bytes()]);
 
-        backend.increment_nonce(origin, chain_id)?;
+        backend.increment_nonce(origin, chain_id);
         backend.snapshot();
 
         backend
@@ -330,10 +330,10 @@ impl<B: Database> Machine<B> {
             return Err(Error::DeployToExistingAccount(target, origin));
         }
 
-        backend.increment_nonce(origin, chain_id)?;
+        backend.increment_nonce(origin, chain_id);
         backend.snapshot();
 
-        backend.increment_nonce(target, chain_id)?;
+        backend.increment_nonce(target, chain_id);
         backend
             .transfer(origin, target, chain_id, trx.value())
             .await?;

--- a/evm_loader/program/src/evm/mod.rs
+++ b/evm_loader/program/src/evm/mod.rs
@@ -283,7 +283,7 @@ impl<B: Database> Machine<B> {
             .transfer(origin, target, chain_id, trx.value())
             .await?;
 
-        let execution_code = backend.code(target).await?;
+        let execution_code = backend.code(target).await;
 
         Ok(Self {
             origin,

--- a/evm_loader/program/src/evm/mod.rs
+++ b/evm_loader/program/src/evm/mod.rs
@@ -326,8 +326,7 @@ impl<B: Database> Machine<B> {
         let target = Address::from_create(&origin, trx.nonce());
         sol_log_data(&[b"ENTER", b"CREATE", target.as_bytes()]);
 
-        if (backend.nonce(target, chain_id).await? != 0) || (backend.code_size(target).await? != 0)
-        {
+        if (backend.nonce(target, chain_id).await? != 0) || (backend.code_size(target).await != 0) {
             return Err(Error::DeployToExistingAccount(target, origin));
         }
 

--- a/evm_loader/program/src/evm/opcode.rs
+++ b/evm_loader/program/src/evm/opcode.rs
@@ -597,7 +597,7 @@ impl<B: Database> Machine<B> {
     pub async fn opcode_extcodesize(&mut self, backend: &mut B) -> Result<Action> {
         let code_size = {
             let address = self.stack.pop_address()?;
-            backend.code_size(address).await?
+            backend.code_size(address).await
         };
 
         self.stack.push_usize(code_size)?;
@@ -1091,8 +1091,7 @@ impl<B: Database> Machine<B> {
 
         sol_log_data(&[b"ENTER", b"CREATE", address.as_bytes()]);
 
-        if (backend.nonce(address, chain_id).await? != 0)
-            || (backend.code_size(address).await? != 0)
+        if (backend.nonce(address, chain_id).await? != 0) || (backend.code_size(address).await != 0)
         {
             return Err(Error::DeployToExistingAccount(address, self.context.caller));
         }

--- a/evm_loader/program/src/evm/opcode.rs
+++ b/evm_loader/program/src/evm/opcode.rs
@@ -613,7 +613,7 @@ impl<B: Database> Machine<B> {
         let data_offset = self.stack.pop_usize()?;
         let length = self.stack.pop_usize()?;
 
-        let code = backend.code(address).await?;
+        let code = backend.code(address).await;
 
         self.memory
             .write_buffer(memory_offset, length, &code, data_offset)?;
@@ -1119,7 +1119,7 @@ impl<B: Database> Machine<B> {
         self.return_range = return_offset..(return_offset + return_length);
 
         let call_data = self.memory.read_buffer(args_offset, args_length)?;
-        let code = backend.code(address).await?;
+        let code = backend.code(address).await;
 
         let chain_id = self.context.contract_chain_id;
         let context = Context {
@@ -1176,7 +1176,7 @@ impl<B: Database> Machine<B> {
         self.return_range = return_offset..(return_offset + return_length);
 
         let call_data = self.memory.read_buffer(args_offset, args_length)?;
-        let code = backend.code(address).await?;
+        let code = backend.code(address).await;
 
         let chain_id = self.context.contract_chain_id;
         let context = Context {
@@ -1231,7 +1231,7 @@ impl<B: Database> Machine<B> {
         self.return_range = return_offset..(return_offset + return_length);
 
         let call_data = self.memory.read_buffer(args_offset, args_length)?;
-        let code = backend.code(address).await?;
+        let code = backend.code(address).await;
 
         let context = Context {
             code_address: Some(address),
@@ -1276,7 +1276,7 @@ impl<B: Database> Machine<B> {
         self.return_range = return_offset..(return_offset + return_length);
 
         let call_data = self.memory.read_buffer(args_offset, args_length)?;
-        let code = backend.code(address).await?;
+        let code = backend.code(address).await;
 
         let chain_id = self.context.contract_chain_id;
         let context = Context {

--- a/evm_loader/program/src/evm/opcode.rs
+++ b/evm_loader/program/src/evm/opcode.rs
@@ -1462,7 +1462,7 @@ impl<B: Database> Machine<B> {
         backend
             .transfer(self.context.contract, address, chain_id, value)
             .await?;
-        backend.selfdestruct(self.context.contract)?;
+        backend.selfdestruct(self.context.contract);
 
         backend.commit_snapshot();
         sol_log_data(&[b"EXIT", b"SELFDESTRUCT"]);

--- a/evm_loader/program/src/evm/opcode.rs
+++ b/evm_loader/program/src/evm/opcode.rs
@@ -818,7 +818,7 @@ impl<B: Database> Machine<B> {
 
         tracing_event!(self, super::tracing::Event::StorageAccess { index, value });
 
-        backend.set_storage(self.context.contract, index, value)?;
+        backend.set_storage(self.context.contract, index, value);
 
         Ok(Action::Continue)
     }

--- a/evm_loader/program/src/evm/opcode.rs
+++ b/evm_loader/program/src/evm/opcode.rs
@@ -696,7 +696,7 @@ impl<B: Database> Machine<B> {
     /// current block's number
     #[maybe_async]
     pub async fn opcode_number(&mut self, backend: &mut B) -> Result<Action> {
-        let block_number = backend.block_number()?;
+        let block_number = backend.block_number();
 
         self.stack.push_u256(block_number)?;
 

--- a/evm_loader/program/src/evm/opcode.rs
+++ b/evm_loader/program/src/evm/opcode.rs
@@ -1056,7 +1056,7 @@ impl<B: Database> Machine<B> {
             return Err(Error::NonceOverflow(self.context.contract));
         }
 
-        backend.increment_nonce(self.context.contract, chain_id)?;
+        backend.increment_nonce(self.context.contract, chain_id);
 
         self.return_data = Buffer::empty();
         self.return_range = 0..0;
@@ -1096,7 +1096,7 @@ impl<B: Database> Machine<B> {
             return Err(Error::DeployToExistingAccount(address, self.context.caller));
         }
 
-        backend.increment_nonce(address, chain_id)?;
+        backend.increment_nonce(address, chain_id);
         backend
             .transfer(self.context.caller, address, chain_id, value)
             .await?;

--- a/evm_loader/program/src/evm/opcode.rs
+++ b/evm_loader/program/src/evm/opcode.rs
@@ -686,7 +686,7 @@ impl<B: Database> Machine<B> {
     /// current block's Unix timestamp in seconds
     #[maybe_async]
     pub async fn opcode_timestamp(&mut self, backend: &mut B) -> Result<Action> {
-        let timestamp = backend.block_timestamp()?;
+        let timestamp = backend.block_timestamp();
 
         self.stack.push_u256(timestamp)?;
 

--- a/evm_loader/program/src/evm/opcode.rs
+++ b/evm_loader/program/src/evm/opcode.rs
@@ -666,7 +666,7 @@ impl<B: Database> Machine<B> {
         let block_hash = {
             let block_number = self.stack.pop_u256()?;
 
-            backend.block_hash(block_number).await?
+            backend.block_hash(block_number).await
         };
 
         self.stack.push_array(&block_hash)?;

--- a/evm_loader/program/src/evm/opcode.rs
+++ b/evm_loader/program/src/evm/opcode.rs
@@ -797,7 +797,7 @@ impl<B: Database> Machine<B> {
     #[maybe_async]
     pub async fn opcode_sload(&mut self, backend: &mut B) -> Result<Action> {
         let index = self.stack.pop_u256()?;
-        let value = backend.storage(self.context.contract, index).await?;
+        let value = backend.storage(self.context.contract, index).await;
 
         tracing_event!(self, super::tracing::Event::StorageAccess { index, value });
 

--- a/evm_loader/program/src/executor/state.rs
+++ b/evm_loader/program/src/executor/state.rs
@@ -378,9 +378,9 @@ impl<'a, B: AccountStorage> Database for ExecutorState<'a, B> {
         cache.block_number
     }
 
-    fn block_timestamp(&self) -> Result<U256> {
+    fn block_timestamp(&self) -> U256 {
         let cache = self.cache.borrow();
-        Ok(cache.block_timestamp)
+        cache.block_timestamp
     }
 
     async fn map_solana_account<F, R>(&self, address: &Pubkey, action: F) -> R

--- a/evm_loader/program/src/executor/state.rs
+++ b/evm_loader/program/src/executor/state.rs
@@ -317,11 +317,9 @@ impl<'a, B: AccountStorage> Database for ExecutorState<'a, B> {
         Ok(())
     }
 
-    fn selfdestruct(&mut self, address: Address) -> Result<()> {
+    fn selfdestruct(&mut self, address: Address) {
         let suicide = Action::EvmSelfDestruct { address };
         self.actions.push(suicide);
-
-        Ok(())
     }
 
     async fn storage(&self, from_address: Address, from_index: U256) -> [u8; 32] {

--- a/evm_loader/program/src/executor/state.rs
+++ b/evm_loader/program/src/executor/state.rs
@@ -373,9 +373,9 @@ impl<'a, B: AccountStorage> Database for ExecutorState<'a, B> {
         self.backend.block_hash(number).await
     }
 
-    fn block_number(&self) -> Result<U256> {
+    fn block_number(&self) -> U256 {
         let cache = self.cache.borrow();
-        Ok(cache.block_number)
+        cache.block_number
     }
 
     fn block_timestamp(&self) -> Result<U256> {

--- a/evm_loader/program/src/executor/state.rs
+++ b/evm_loader/program/src/executor/state.rs
@@ -352,14 +352,14 @@ impl<'a, B: AccountStorage> Database for ExecutorState<'a, B> {
         Ok(())
     }
 
-    async fn block_hash(&self, number: U256) -> Result<[u8; 32]> {
+    async fn block_hash(&self, number: U256) -> [u8; 32] {
         // geth:
         //  - checks the overflow
         //  - converts to u64
         //  - checks on last 256 blocks
 
         if number >= u64::MAX.as_u256() {
-            return Ok(<[u8; 32]>::default());
+            return <[u8; 32]>::default();
         }
 
         let number = number.as_u64();
@@ -371,10 +371,10 @@ impl<'a, B: AccountStorage> Database for ExecutorState<'a, B> {
         };
 
         if number >= block_slot || lower_block_slot > number {
-            return Ok(<[u8; 32]>::default());
+            return <[u8; 32]>::default();
         }
 
-        Ok(self.backend.block_hash(number).await)
+        self.backend.block_hash(number).await
     }
 
     fn block_number(&self) -> Result<U256> {

--- a/evm_loader/program/src/executor/state.rs
+++ b/evm_loader/program/src/executor/state.rs
@@ -339,15 +339,13 @@ impl<'a, B: AccountStorage> Database for ExecutorState<'a, B> {
         self.backend.storage(from_address, from_index).await
     }
 
-    fn set_storage(&mut self, address: Address, index: U256, value: [u8; 32]) -> Result<()> {
+    fn set_storage(&mut self, address: Address, index: U256, value: [u8; 32]) {
         let set_storage = Action::EvmSetStorage {
             address,
             index,
             value,
         };
         self.actions.push(set_storage);
-
-        Ok(())
     }
 
     async fn block_hash(&self, number: U256) -> [u8; 32] {

--- a/evm_loader/program/src/executor/state.rs
+++ b/evm_loader/program/src/executor/state.rs
@@ -192,11 +192,9 @@ impl<'a, B: AccountStorage> Database for ExecutorState<'a, B> {
         Ok(nonce)
     }
 
-    fn increment_nonce(&mut self, address: Address, chain_id: u64) -> Result<()> {
+    fn increment_nonce(&mut self, address: Address, chain_id: u64) {
         let increment = Action::EvmIncrementNonce { address, chain_id };
         self.actions.push(increment);
-
-        Ok(())
     }
 
     async fn balance(&self, from_address: Address, from_chain_id: u64) -> Result<U256> {

--- a/evm_loader/program/src/executor/state.rs
+++ b/evm_loader/program/src/executor/state.rs
@@ -324,7 +324,7 @@ impl<'a, B: AccountStorage> Database for ExecutorState<'a, B> {
         Ok(())
     }
 
-    async fn storage(&self, from_address: Address, from_index: U256) -> Result<[u8; 32]> {
+    async fn storage(&self, from_address: Address, from_index: U256) -> [u8; 32] {
         for action in self.actions.iter().rev() {
             if let Action::EvmSetStorage {
                 address,
@@ -333,12 +333,12 @@ impl<'a, B: AccountStorage> Database for ExecutorState<'a, B> {
             } = action
             {
                 if (&from_address == address) && (&from_index == index) {
-                    return Ok(*value);
+                    return *value;
                 }
             }
         }
 
-        Ok(self.backend.storage(from_address, from_index).await)
+        self.backend.storage(from_address, from_index).await
     }
 
     fn set_storage(&mut self, address: Address, index: U256, value: [u8; 32]) -> Result<()> {

--- a/evm_loader/program/src/executor/state.rs
+++ b/evm_loader/program/src/executor/state.rs
@@ -284,16 +284,16 @@ impl<'a, B: AccountStorage> Database for ExecutorState<'a, B> {
         self.backend.code_size(from_address).await
     }
 
-    async fn code(&self, from_address: Address) -> Result<crate::evm::Buffer> {
+    async fn code(&self, from_address: Address) -> crate::evm::Buffer {
         for action in &self.actions {
             if let Action::EvmSetCode { address, code, .. } = action {
                 if &from_address == address {
-                    return Ok(crate::evm::Buffer::from_slice(code));
+                    return crate::evm::Buffer::from_slice(code);
                 }
             }
         }
 
-        Ok(self.backend.code(from_address).await)
+        self.backend.code(from_address).await
     }
 
     fn set_code(&mut self, address: Address, chain_id: u64, code: Vec<u8>) -> Result<()> {

--- a/evm_loader/program/src/executor/state.rs
+++ b/evm_loader/program/src/executor/state.rs
@@ -245,7 +245,7 @@ impl<'a, B: AccountStorage> Database for ExecutorState<'a, B> {
 
         let target_chain_id = self.contract_chain_id(target).await.unwrap_or(chain_id);
 
-        if (self.code_size(target).await? > 0) && (target_chain_id != chain_id) {
+        if (self.code_size(target).await > 0) && (target_chain_id != chain_id) {
             return Err(Error::InvalidTransferToken(source, chain_id));
         }
 
@@ -268,20 +268,20 @@ impl<'a, B: AccountStorage> Database for ExecutorState<'a, B> {
         Ok(())
     }
 
-    async fn code_size(&self, from_address: Address) -> Result<usize> {
+    async fn code_size(&self, from_address: Address) -> usize {
         if self.is_precompile_extension(&from_address) {
-            return Ok(1); // This is required in order to make a normal call to an extension contract
+            return 1; // This is required in order to make a normal call to an extension contract
         }
 
         for action in &self.actions {
             if let Action::EvmSetCode { address, code, .. } = action {
                 if &from_address == address {
-                    return Ok(code.len());
+                    return code.len();
                 }
             }
         }
 
-        Ok(self.backend.code_size(from_address).await)
+        self.backend.code_size(from_address).await
     }
 
     async fn code(&self, from_address: Address) -> Result<crate::evm::Buffer> {


### PR DESCRIPTION
Many methods from `Database` trait return `Result` types, even if they never fail. This PR removes the redundant `Result` type from those methods.