### PR TITLE
NDEV-1837 Remove syscall_stub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN cargo fmt --check && \
 
 
 # Add neon_test_invoke_program to the genesis
-FROM neonlabsorg/neon_test_programs:develop AS neon_test_programs
+FROM neonlabsorg/neon_test_programs:latest AS neon_test_programs
 
 # Define solana-image that contains utility
 FROM builder AS base

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN cargo fmt --check && \
 
 
 # Add neon_test_invoke_program to the genesis
-FROM neonlabsorg/neon_test_invoke_program:develop AS neon_test_invoke_program
+FROM neonlabsorg/neon_test_programs:develop AS neon_test_programs
 
 # Define solana-image that contains utility
 FROM builder AS base
@@ -40,8 +40,8 @@ COPY --from=evm-loader-builder /opt/neon-evm/evm_loader/target/deploy/evm_loader
 COPY --from=evm-loader-builder /opt/neon-evm/evm_loader/target/deploy/evm_loader-dump.txt /opt/
 COPY --from=evm-loader-builder /opt/neon-evm/evm_loader/target/release/neon-cli /opt/
 COPY --from=evm-loader-builder /opt/neon-evm/evm_loader/target/release/neon-api /opt/
-COPY --from=neon_test_invoke_program /opt/neon_test_invoke_program.so /opt/
-COPY --from=neon_test_invoke_program /opt/neon_test_invoke_program-keypair.json /opt/
+
+COPY --from=neon_test_programs /opt/deploy/ /opt/deploy/
 
 COPY ci/wait-for-solana.sh \
     ci/wait-for-neon.sh \

--- a/ci/solana-run-neon.sh
+++ b/ci/solana-run-neon.sh
@@ -22,7 +22,7 @@ VALIDATOR_ARGS=(
   --bpf-program ${METAPLEX} ${METAPLEX_PATH}
 )
 
-LIST_OF_TEST_PROGRAMS=("test_invoke_program" "counter" "cross_program_invocation" "transfer_sol")
+LIST_OF_TEST_PROGRAMS=("test_invoke_program" "counter" "cross_program_invocation" "transfer_sol" "transfer_tokens")
 
 for program in "${LIST_OF_TEST_PROGRAMS[@]}"; do
   keypair="${NEON_BIN}/deploy/${program}/${program}-keypair.json"

--- a/ci/solana-run-neon.sh
+++ b/ci/solana-run-neon.sh
@@ -12,9 +12,6 @@ EVM_LOADER_PATH=${NEON_BIN}/evm_loader.so
 METAPLEX=metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s
 METAPLEX_PATH=${NEON_BIN}/metaplex.so
 
-TEST_INVOKE_PROGRAM_ID_KEYPAIR=${NEON_BIN}/neon_test_invoke_program-keypair.json
-TEST_INVOKE=$(solana address -k ${TEST_INVOKE_PROGRAM_ID_KEYPAIR})
-TEST_INVOKE_PATH=${NEON_BIN}/neon_test_invoke_program.so
 
 VALIDATOR_ARGS=(
   --reset
@@ -23,8 +20,15 @@ VALIDATOR_ARGS=(
   --ticks-per-slot 16
   --upgradeable-program ${EVM_LOADER} ${EVM_LOADER_PATH} ${EVM_LOADER_AUTHORITY_KEYPAIR}
   --bpf-program ${METAPLEX} ${METAPLEX_PATH}
-  --bpf-program ${TEST_INVOKE} ${TEST_INVOKE_PATH}
 )
+
+LIST_OF_TEST_PROGRAMS=("test_invoke_program" "counter" "cross_program_invocation" "transfer_sol")
+
+for program in "${LIST_OF_TEST_PROGRAMS[@]}"; do
+  keypair="${NEON_BIN}/deploy/${program}/${program}-keypair.json"
+  address=$(solana address -k $keypair)
+  VALIDATOR_ARGS+=(--bpf-program $address ${NEON_BIN}/deploy/$program/$program.so)
+done
 
 if [[ -n $GEYSER_PLUGIN_CONFIG ]]; then
   echo "Using geyser plugin with config: $GEYSER_PLUGIN_CONFIG"

--- a/evm_loader/lib/src/emulator_state.rs
+++ b/evm_loader/lib/src/emulator_state.rs
@@ -12,6 +12,7 @@ use evm_loader::executor::{
 use evm_loader::types::Address;
 use solana_sdk::instruction::Instruction;
 use solana_sdk::pubkey::Pubkey;
+use solana_sdk::rent::Rent;
 
 #[derive(Default, Clone)]
 pub struct ExecuteStatus {
@@ -130,6 +131,14 @@ impl<'a, B: AccountStorage> Database for EmulatorState<'a, B> {
 
     fn block_timestamp(&self) -> Result<U256> {
         self.inner_state.block_timestamp()
+    }
+
+    fn rent(&self) -> &Rent {
+        self.inner_state.rent()
+    }
+
+    fn return_data(&self) -> Option<(Pubkey, Vec<u8>)> {
+        self.inner_state.return_data()
     }
 
     async fn external_account(&self, address: Pubkey) -> Result<OwnedAccountInfo> {

--- a/evm_loader/lib/src/lib.rs
+++ b/evm_loader/lib/src/lib.rs
@@ -7,7 +7,6 @@ pub mod emulator_state;
 pub mod errors;
 pub mod rpc;
 pub mod solana_emulator;
-pub mod syscall_stubs;
 pub mod tracing;
 pub mod types;
 

--- a/evm_loader/lib/src/solana_emulator.rs
+++ b/evm_loader/lib/src/solana_emulator.rs
@@ -6,7 +6,6 @@ use std::collections::BTreeMap;
 use tokio::sync::{Mutex, MutexGuard, OnceCell};
 
 use crate::rpc::Rpc;
-use crate::syscall_stubs;
 use crate::NeonError;
 use evm_loader::{account_storage::AccountStorage, executor::OwnedAccountInfo};
 use solana_program_test::{processor, ProgramTest, ProgramTestContext};
@@ -31,17 +30,6 @@ pub struct SolanaEmulator {
 static SOLANA_EMULATOR: OnceCell<Mutex<SolanaEmulator>> = OnceCell::const_new();
 const SEEDS_PUBKEY: Pubkey = pubkey!("Seeds11111111111111111111111111111111111111");
 
-macro_rules! processor_with_original_stubs {
-    ($process_instruction:expr) => {
-        processor!(|program_id, accounts, instruction_data| {
-            let use_original_stubs_saved = syscall_stubs::use_original_stubs_for_thread(true);
-            let result = $process_instruction(program_id, accounts, instruction_data);
-            syscall_stubs::use_original_stubs_for_thread(use_original_stubs_saved);
-            result
-        })
-    };
-}
-
 pub async fn get_solana_emulator() -> MutexGuard<'static, SolanaEmulator> {
     SOLANA_EMULATOR
         .get()
@@ -59,9 +47,6 @@ pub async fn init_solana_emulator(
             let emulator = SolanaEmulator::new(program_id, rpc_client)
                 .await
                 .expect("Initialize SolanaEmulator");
-            syscall_stubs::setup_emulator_syscall_stubs(rpc_client)
-                .await
-                .expect("Setup emulator syscall stubs");
             Mutex::new(emulator)
         })
         .await
@@ -121,7 +106,7 @@ impl SolanaEmulator {
         program_test.add_program(
             "evm_loader",
             program_id,
-            processor_with_original_stubs!(process_emulator_instruction),
+            processor!(process_emulator_instruction),
         );
 
         // Disable features (get known feature list and disable by actual value)

--- a/evm_loader/program/src/account/ether_balance.rs
+++ b/evm_loader/program/src/account/ether_balance.rs
@@ -11,7 +11,7 @@ use crate::{
     types::Address,
 };
 use ethnum::U256;
-use solana_program::{account_info::AccountInfo, pubkey::Pubkey, system_program};
+use solana_program::{account_info::AccountInfo, pubkey::Pubkey, rent::Rent, system_program};
 
 use super::{AccountsDB, ACCOUNT_PREFIX_LEN, ACCOUNT_SEED_VERSION, TAG_ACCOUNT_BALANCE};
 
@@ -46,6 +46,7 @@ impl<'a> BalanceAccount<'a> {
         chain_id: u64,
         accounts: &AccountsDB<'a>,
         keys: Option<&KeysCache>,
+        rent: &Rent,
     ) -> Result<Self> {
         let (pubkey, bump_seed) = keys.map_or_else(
             || address.find_balance_address(&crate::ID, chain_id),
@@ -93,6 +94,7 @@ impl<'a> BalanceAccount<'a> {
             &account,
             program_seeds,
             ACCOUNT_PREFIX_LEN + size_of::<Header>(),
+            rent,
         )?;
 
         super::set_tag(&crate::ID, &account, TAG_ACCOUNT_BALANCE)?;

--- a/evm_loader/program/src/account/ether_contract.rs
+++ b/evm_loader/program/src/account/ether_contract.rs
@@ -78,7 +78,7 @@ impl<'a> ContractAccount<'a> {
         if system_program::check_id(info.owner) {
             let seeds: &[&[u8]] = &[&[ACCOUNT_SEED_VERSION], address.as_bytes(), &[bump_seed]];
             let space = required_size.min(MAX_PERMITTED_DATA_INCREASE);
-            system.create_pda_account(&crate::ID, operator, info, seeds, space)?;
+            system.create_pda_account(&crate::ID, operator, info, seeds, space, rent)?;
         } else if crate::check_id(info.owner) {
             super::validate_tag(&crate::ID, info, TAG_EMPTY)?;
 

--- a/evm_loader/program/src/account/ether_storage.rs
+++ b/evm_loader/program/src/account/ether_storage.rs
@@ -97,6 +97,7 @@ impl<'a> StorageCell<'a> {
         allocate_cells: usize,
         accounts: &AccountsDB<'a>,
         signer_seeds: &[&[u8]],
+        rent: &Rent,
     ) -> Result<Self> {
         let base_account = accounts.get(&address.base);
         let cell_account = accounts.get(&address.pubkey);
@@ -114,6 +115,7 @@ impl<'a> StorageCell<'a> {
             cell_account,
             address.seed(),
             space,
+            rent,
         )?;
 
         super::set_tag(&crate::ID, cell_account, TAG_STORAGE_CELL)?;
@@ -200,7 +202,7 @@ impl<'a> StorageCell<'a> {
         Ok(())
     }
 
-    pub fn sync_lamports(&mut self, rent: Rent, accounts: &AccountsDB<'a>) -> Result<()> {
+    pub fn sync_lamports(&mut self, rent: &Rent, accounts: &AccountsDB<'a>) -> Result<()> {
         let original_data_len = unsafe { self.account.original_data_len() };
         if original_data_len == self.account.data_len() {
             return Ok(());

--- a/evm_loader/program/src/account/program.rs
+++ b/evm_loader/program/src/account/program.rs
@@ -3,7 +3,7 @@ use solana_program::account_info::AccountInfo;
 use solana_program::program::{invoke_signed_unchecked, invoke_unchecked};
 use solana_program::program_error::ProgramError;
 use solana_program::pubkey::Pubkey;
-use solana_program::{rent::Rent, system_instruction, sysvar::Sysvar};
+use solana_program::{rent::Rent, system_instruction};
 use std::convert::From;
 use std::ops::Deref;
 
@@ -31,8 +31,8 @@ impl<'a> System<'a> {
         new_account: &AccountInfo<'a>,
         new_account_seeds: &[&[u8]],
         space: usize,
+        rent: &Rent,
     ) -> Result<(), ProgramError> {
-        let rent = Rent::get()?;
         let minimum_balance = rent.minimum_balance(space).max(1);
 
         if new_account.lamports() > 0 {
@@ -81,8 +81,9 @@ impl<'a> System<'a> {
         new_account: &AccountInfo<'a>,
         seed: &str,
         space: usize,
+        rent: &Rent,
     ) -> Result<(), ProgramError> {
-        let minimum_balance = Rent::get()?.minimum_balance(space).max(1);
+        let minimum_balance = rent.minimum_balance(space).max(1);
 
         if new_account.lamports() > 0 {
             let required_lamports = minimum_balance.saturating_sub(new_account.lamports());

--- a/evm_loader/program/src/account_storage/backend.rs
+++ b/evm_loader/program/src/account_storage/backend.rs
@@ -6,7 +6,7 @@ use crate::types::Address;
 use ethnum::U256;
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
-use solana_program::{pubkey::Pubkey, sysvar::slot_hashes};
+use solana_program::{pubkey::Pubkey, rent::Rent, sysvar::slot_hashes};
 use std::collections::BTreeMap;
 use std::convert::TryInto;
 
@@ -28,6 +28,14 @@ impl<'a> AccountStorage for ProgramAccountStorage<'a> {
             .unix_timestamp
             .try_into()
             .expect("Timestamp is positive")
+    }
+
+    fn rent(&self) -> &Rent {
+        &self.rent
+    }
+
+    fn return_data(&self) -> Option<(Pubkey, Vec<u8>)> {
+        solana_program::program::get_return_data()
     }
 
     fn block_hash(&self, slot: u64) -> [u8; 32] {

--- a/evm_loader/program/src/account_storage/base.rs
+++ b/evm_loader/program/src/account_storage/base.rs
@@ -6,9 +6,7 @@ use crate::config::DEFAULT_CHAIN_ID;
 use crate::error::Result;
 use crate::types::Address;
 use ethnum::U256;
-use solana_program::clock::Clock;
-use solana_program::system_program;
-use solana_program::sysvar::Sysvar;
+use solana_program::{clock::Clock, rent::Rent, system_program, sysvar::Sysvar};
 
 use super::keys_cache::KeysCache;
 
@@ -16,6 +14,7 @@ impl<'a> ProgramAccountStorage<'a> {
     pub fn new(accounts: AccountsDB<'a>) -> Result<Self> {
         Ok(Self {
             clock: Clock::get()?,
+            rent: Rent::get()?,
             accounts,
             keys: KeysCache::new(),
         })
@@ -88,6 +87,12 @@ impl<'a> ProgramAccountStorage<'a> {
         address: Address,
         chain_id: u64,
     ) -> Result<BalanceAccount<'a>> {
-        BalanceAccount::create(address, chain_id, &self.accounts, Some(&self.keys))
+        BalanceAccount::create(
+            address,
+            chain_id,
+            &self.accounts,
+            Some(&self.keys),
+            &self.rent,
+        )
     }
 }

--- a/evm_loader/program/src/account_storage/mod.rs
+++ b/evm_loader/program/src/account_storage/mod.rs
@@ -5,6 +5,7 @@ use ethnum::U256;
 use maybe_async::maybe_async;
 use solana_program::{
     account_info::AccountInfo, instruction::AccountMeta, instruction::Instruction, pubkey::Pubkey,
+    rent::Rent,
 };
 use std::collections::BTreeMap;
 #[cfg(target_os = "solana")]
@@ -28,6 +29,7 @@ pub use keys_cache::KeysCache;
 #[cfg(target_os = "solana")]
 pub struct ProgramAccountStorage<'a> {
     clock: Clock,
+    rent: Rent,
     accounts: AccountsDB<'a>,
     keys: keys_cache::KeysCache,
 }
@@ -47,6 +49,12 @@ pub trait AccountStorage {
     fn block_timestamp(&self) -> U256;
     /// Get block hash
     async fn block_hash(&self, number: u64) -> [u8; 32];
+
+    /// Get rent info
+    fn rent(&self) -> &Rent;
+
+    /// Get return data from Solana
+    fn return_data(&self) -> Option<(Pubkey, Vec<u8>)>;
 
     /// Get account nonce
     async fn nonce(&self, address: Address, chain_id: u64) -> u64;

--- a/evm_loader/program/src/debug.rs
+++ b/evm_loader/program/src/debug.rs
@@ -15,3 +15,34 @@ macro_rules! debug_print {
 macro_rules! debug_print {
     ($( $args:expr ),*) => {};
 }
+
+#[cfg(target_os = "solana")]
+macro_rules! log_msg {
+    ($($arg:tt)*) => (solana_program::msg!($($arg)*));
+}
+
+#[cfg(not(target_os = "solana"))]
+macro_rules! log_msg {
+    ($($arg:tt)*) => (log::info!($($arg)*));
+}
+
+#[inline]
+pub fn log_data(data: &[&[u8]]) {
+    #[cfg(target_os = "solana")]
+    solana_program::log::sol_log_data(data);
+
+    #[cfg(not(target_os = "solana"))]
+    {
+        let mut messages: Vec<String> = Vec::new();
+
+        for f in data {
+            if let Ok(str) = String::from_utf8(f.to_vec()) {
+                messages.push(str);
+            } else {
+                messages.push(hex::encode(f));
+            }
+        }
+
+        log::info!("Program Data: {}", messages.join(" "));
+    }
+}

--- a/evm_loader/program/src/entrypoint.rs
+++ b/evm_loader/program/src/entrypoint.rs
@@ -49,7 +49,7 @@ fn process_instruction<'a>(
             instruction::config_get_version::process(program_id, accounts, instruction)
         }
         _ => {
-            solana_program::msg!("Emergency image: all instructions are rejected");
+            log_msg!("Emergency image: all instructions are rejected");
             Err(ProgramError::InvalidInstructionData.into())
         }
     }

--- a/evm_loader/program/src/error.rs
+++ b/evm_loader/program/src/error.rs
@@ -187,7 +187,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 impl From<Error> for ProgramError {
     fn from(e: Error) -> Self {
-        solana_program::msg!("{}", e);
+        log_msg!("{}", e);
         match e {
             Error::ProgramError(e) => e,
             _ => Self::Custom(0),
@@ -275,18 +275,18 @@ fn format_revert_panic(msg: &[u8]) -> Option<U256> {
 
 pub fn print_revert_message(msg: &[u8]) {
     if msg.is_empty() {
-        return solana_program::msg!("Revert");
+        return log_msg!("Revert");
     }
 
     if let Some(reason) = format_revert_error(msg) {
-        return solana_program::msg!("Revert: Error(\"{}\")", reason);
+        return log_msg!("Revert: Error(\"{}\")", reason);
     }
 
     if let Some(reason) = format_revert_panic(msg) {
-        return solana_program::msg!("Revert: Panic({:#x})", reason);
+        return log_msg!("Revert: Panic({:#x})", reason);
     }
 
-    solana_program::msg!("Revert: {}", hex::encode(msg));
+    log_msg!("Revert: {}", hex::encode(msg));
 }
 
 #[must_use]

--- a/evm_loader/program/src/evm/database.rs
+++ b/evm_loader/program/src/evm/database.rs
@@ -2,7 +2,9 @@ use super::{Buffer, Context};
 use crate::{error::Result, executor::OwnedAccountInfo, types::Address};
 use ethnum::U256;
 use maybe_async::maybe_async;
-use solana_program::{account_info::AccountInfo, instruction::Instruction, pubkey::Pubkey};
+use solana_program::{
+    account_info::AccountInfo, instruction::Instruction, pubkey::Pubkey, rent::Rent,
+};
 
 #[maybe_async(?Send)]
 pub trait Database {
@@ -39,6 +41,8 @@ pub trait Database {
     async fn block_hash(&self, number: U256) -> Result<[u8; 32]>;
     fn block_number(&self) -> Result<U256>;
     fn block_timestamp(&self) -> Result<U256>;
+    fn rent(&self) -> &Rent;
+    fn return_data(&self) -> Option<(Pubkey, Vec<u8>)>;
 
     async fn external_account(&self, address: Pubkey) -> Result<OwnedAccountInfo>;
     async fn map_solana_account<F, R>(&self, address: &Pubkey, action: F) -> R
@@ -271,6 +275,14 @@ mod tests {
         }
 
         fn block_timestamp(&self) -> Result<U256> {
+            unimplemented!();
+        }
+
+        fn rent(&self) -> &Rent {
+            unimplemented!();
+        }
+
+        fn return_data(&self) -> Option<(Pubkey, Vec<u8>)> {
             unimplemented!();
         }
 

--- a/evm_loader/program/src/evm/mod.rs
+++ b/evm_loader/program/src/evm/mod.rs
@@ -7,13 +7,13 @@ use std::{fmt::Display, marker::PhantomData, ops::Range};
 use ethnum::U256;
 use maybe_async::maybe_async;
 use serde::{Deserialize, Serialize};
-use solana_program::log::sol_log_data;
 
 pub use buffer::Buffer;
 
 #[cfg(not(target_os = "solana"))]
 use crate::evm::tracing::TracerTypeOpt;
 use crate::{
+    debug::log_data,
     error::{build_revert_message, Error, Result},
     evm::{opcode::Action, precompile::is_precompile_address},
     types::{Address, Transaction},
@@ -274,7 +274,7 @@ impl<B: Database> Machine<B> {
         assert!(trx.target().is_some());
 
         let target = trx.target().unwrap();
-        sol_log_data(&[b"ENTER", b"CALL", target.as_bytes()]);
+        log_data(&[b"ENTER", b"CALL", target.as_bytes()]);
 
         backend.increment_nonce(origin, chain_id)?;
         backend.snapshot();
@@ -324,7 +324,7 @@ impl<B: Database> Machine<B> {
         assert!(trx.target().is_none());
 
         let target = Address::from_create(&origin, trx.nonce());
-        sol_log_data(&[b"ENTER", b"CREATE", target.as_bytes()]);
+        log_data(&[b"ENTER", b"CREATE", target.as_bytes()]);
 
         if (backend.nonce(target, chain_id).await? != 0) || (backend.code_size(target).await? != 0)
         {

--- a/evm_loader/program/src/executor/precompile_extension/metaplex.rs
+++ b/evm_loader/program/src/executor/precompile_extension/metaplex.rs
@@ -7,7 +7,7 @@ use mpl_token_metadata::state::{
     Creator, Metadata, TokenMetadataAccount, TokenStandard, CREATE_FEE, MAX_MASTER_EDITION_LEN,
     MAX_METADATA_LEN,
 };
-use solana_program::{pubkey::Pubkey, rent::Rent, sysvar::Sysvar};
+use solana_program::pubkey::Pubkey;
 
 use crate::{
     account::ACCOUNT_SEED_VERSION,
@@ -191,9 +191,7 @@ fn create_metadata<State: Database>(
         None,  // Collection Details
     );
 
-    let rent = Rent::get()?;
-    let fee = rent.minimum_balance(MAX_METADATA_LEN) + CREATE_FEE;
-
+    let fee = state.rent().minimum_balance(MAX_METADATA_LEN) + CREATE_FEE;
     state.queue_external_instruction(instruction, vec![seeds], fee, true)?;
 
     Ok(metadata_pubkey.to_bytes().to_vec())
@@ -228,9 +226,7 @@ fn create_master_edition<State: Database>(
         max_supply,
     );
 
-    let rent = Rent::get()?;
-    let fee = rent.minimum_balance(MAX_MASTER_EDITION_LEN) + CREATE_FEE;
-
+    let fee = state.rent().minimum_balance(MAX_MASTER_EDITION_LEN) + CREATE_FEE;
     state.queue_external_instruction(instruction, vec![seeds], fee, true)?;
 
     Ok(edition_pubkey.to_bytes().to_vec())

--- a/evm_loader/program/src/executor/precompile_extension/mod.rs
+++ b/evm_loader/program/src/executor/precompile_extension/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     types::Address,
 };
 use maybe_async::maybe_async;
-use solana_program::{pubkey::Pubkey, rent::Rent, system_instruction, sysvar::Sysvar};
+use solana_program::{pubkey::Pubkey, system_instruction};
 
 use super::OwnedAccountInfo;
 
@@ -82,8 +82,7 @@ pub fn create_account<State: Database>(
     owner: &Pubkey,
     seeds: Vec<Vec<u8>>,
 ) -> Result<()> {
-    let rent = Rent::get()?;
-    let minimum_balance = rent.minimum_balance(space);
+    let minimum_balance = state.rent().minimum_balance(space);
 
     let required_lamports = minimum_balance.saturating_sub(account.lamports);
 

--- a/evm_loader/program/src/executor/precompile_extension/neon_token.rs
+++ b/evm_loader/program/src/executor/precompile_extension/neon_token.rs
@@ -3,9 +3,7 @@ use std::convert::TryInto;
 use arrayref::array_ref;
 use ethnum::U256;
 use maybe_async::maybe_async;
-use solana_program::{
-    account_info::IntoAccountInfo, program_pack::Pack, pubkey::Pubkey, rent::Rent, sysvar::Sysvar,
-};
+use solana_program::{account_info::IntoAccountInfo, program_pack::Pack, pubkey::Pubkey};
 use spl_associated_token_account::get_associated_token_address;
 
 use crate::{
@@ -116,8 +114,7 @@ async fn withdraw<State: Database>(
             &spl_token::ID,
         );
 
-        let rent = Rent::get()?;
-        let fee = rent.minimum_balance(spl_token::state::Account::LEN);
+        let fee = state.rent().minimum_balance(spl_token::state::Account::LEN);
         state.queue_external_instruction(create_associated, vec![], fee, true)?;
     }
 

--- a/evm_loader/program/src/executor/state.rs
+++ b/evm_loader/program/src/executor/state.rs
@@ -5,6 +5,7 @@ use ethnum::{AsU256, U256};
 use maybe_async::maybe_async;
 use solana_program::instruction::Instruction;
 use solana_program::pubkey::Pubkey;
+use solana_program::rent::Rent;
 
 use crate::account_storage::AccountStorage;
 use crate::error::{Error, Result};
@@ -323,6 +324,14 @@ impl<'a, B: AccountStorage> Database for ExecutorState<'a, B> {
         Ok(cache.block_timestamp)
     }
 
+    fn rent(&self) -> &Rent {
+        self.backend.rent()
+    }
+
+    fn return_data(&self) -> Option<(Pubkey, Vec<u8>)> {
+        self.backend.return_data()
+    }
+
     async fn external_account(&self, address: Pubkey) -> Result<OwnedAccountInfo> {
         let metas = self
             .actions
@@ -377,10 +386,16 @@ impl<'a, B: AccountStorage> Database for ExecutorState<'a, B> {
                             data,
                             meta,
                             &mut accounts,
+                            self.rent(),
                         )?;
                     }
                     program_id if mpl_token_metadata::check_id(program_id) => {
-                        crate::external_programs::metaplex::emulate(data, meta, &mut accounts)?;
+                        crate::external_programs::metaplex::emulate(
+                            data,
+                            meta,
+                            &mut accounts,
+                            self.rent(),
+                        )?;
                     }
                     _ => {
                         return Err(Error::Custom(format!(

--- a/evm_loader/program/src/executor/synced_state.rs
+++ b/evm_loader/program/src/executor/synced_state.rs
@@ -2,6 +2,7 @@ use ethnum::{AsU256, U256};
 use maybe_async::maybe_async;
 use solana_program::instruction::Instruction;
 use solana_program::pubkey::Pubkey;
+use solana_program::rent::Rent;
 
 use crate::account_storage::{AccountStorage, SyncedAccountStorage};
 use crate::error::{Error, Result};
@@ -159,6 +160,14 @@ impl<'a, B: AccountStorage + SyncedAccountStorage> Database for SyncedExecutorSt
 
     fn block_timestamp(&self) -> Result<U256> {
         Ok(self.backend.block_timestamp())
+    }
+
+    fn rent(&self) -> &Rent {
+        self.backend.rent()
+    }
+
+    fn return_data(&self) -> Option<(Pubkey, Vec<u8>)> {
+        self.backend.return_data()
     }
 
     async fn external_account(&self, address: Pubkey) -> Result<OwnedAccountInfo> {

--- a/evm_loader/program/src/external_programs/spl_associated_token.rs
+++ b/evm_loader/program/src/external_programs/spl_associated_token.rs
@@ -4,7 +4,7 @@ use crate::executor::OwnedAccountInfo;
 use borsh::BorshDeserialize;
 use solana_program::{
     entrypoint::ProgramResult, instruction::AccountMeta, program_error::ProgramError,
-    program_pack::Pack, pubkey::Pubkey, rent::Rent, sysvar::Sysvar,
+    program_pack::Pack, pubkey::Pubkey, rent::Rent,
 };
 use spl_associated_token_account::instruction::AssociatedTokenAccountInstruction;
 
@@ -12,6 +12,7 @@ pub fn emulate(
     instruction: &[u8],
     meta: &[AccountMeta],
     accounts: &mut BTreeMap<Pubkey, OwnedAccountInfo>,
+    rent: &Rent,
 ) -> ProgramResult {
     let instruction = if instruction.is_empty() {
         AssociatedTokenAccountInstruction::Create
@@ -33,8 +34,6 @@ pub fn emulate(
 
     let required_lamports = {
         let associated_token_account = &accounts[associated_token_account_key];
-
-        let rent = Rent::get()?;
         rent.minimum_balance(spl_token::state::Account::LEN)
             .max(1)
             .saturating_sub(associated_token_account.lamports)

--- a/evm_loader/program/src/instruction/account_block_add.rs
+++ b/evm_loader/program/src/instruction/account_block_add.rs
@@ -10,7 +10,7 @@ pub fn process<'a>(
     let stack_height = solana_program::instruction::get_stack_height();
     assert_eq!(stack_height, TRANSACTION_LEVEL_STACK_HEIGHT);
 
-    solana_program::msg!("Instruction: Block Accounts");
+    log_msg!("Instruction: Block Accounts");
 
     todo!();
 

--- a/evm_loader/program/src/instruction/account_holder_create.rs
+++ b/evm_loader/program/src/instruction/account_holder_create.rs
@@ -8,7 +8,7 @@ pub fn process<'a>(
     accounts: &'a [AccountInfo<'a>],
     instruction: &[u8],
 ) -> Result<()> {
-    solana_program::msg!("Instruction: Create Holder Account");
+    log_msg!("Instruction: Create Holder Account");
 
     let holder = accounts[0].clone();
     let operator = unsafe { Operator::from_account_not_whitelisted(&accounts[1]) }?;

--- a/evm_loader/program/src/instruction/account_holder_delete.rs
+++ b/evm_loader/program/src/instruction/account_holder_delete.rs
@@ -7,7 +7,7 @@ pub fn process<'a>(
     accounts: &'a [AccountInfo<'a>],
     _instruction: &[u8],
 ) -> Result<()> {
-    solana_program::msg!("Instruction: Delete Holder Account");
+    log_msg!("Instruction: Delete Holder Account");
 
     let holder_info = accounts[0].clone();
     let operator = unsafe { Operator::from_account_not_whitelisted(&accounts[1]) }?;

--- a/evm_loader/program/src/instruction/account_holder_write.rs
+++ b/evm_loader/program/src/instruction/account_holder_write.rs
@@ -1,4 +1,5 @@
 use crate::account::{Holder, Operator};
+use crate::debug::log_data;
 use crate::error::Result;
 use arrayref::array_ref;
 use solana_program::{account_info::AccountInfo, pubkey::Pubkey};
@@ -8,7 +9,7 @@ pub fn process<'a>(
     accounts: &'a [AccountInfo<'a>],
     instruction: &[u8],
 ) -> Result<()> {
-    solana_program::msg!("Instruction: Write To Holder");
+    log_msg!("Instruction: Write To Holder");
 
     let transaction_hash = *array_ref![instruction, 0, 32];
     let offset = usize::from_le_bytes(*array_ref![instruction, 32, 8]);
@@ -23,7 +24,7 @@ pub fn process<'a>(
     holder.validate_owner(&operator)?;
     holder.update_transaction_hash(transaction_hash);
 
-    solana_program::log::sol_log_data(&[b"HASH", &transaction_hash]);
+    log_data(&[b"HASH", &transaction_hash]);
 
     holder.write(offset, data)?;
 

--- a/evm_loader/program/src/instruction/collect_treasury.rs
+++ b/evm_loader/program/src/instruction/collect_treasury.rs
@@ -13,7 +13,7 @@ pub fn process<'a>(
     accounts: &'a [AccountInfo<'a>],
     instruction: &[u8],
 ) -> ProgramResult {
-    solana_program::msg!("Instruction: Collect treasury");
+    log_msg!("Instruction: Collect treasury");
 
     let treasury_index = u32::from_le_bytes(*array_ref![instruction, 0, 4]);
 

--- a/evm_loader/program/src/instruction/config_get_chain_count.rs
+++ b/evm_loader/program/src/instruction/config_get_chain_count.rs
@@ -7,7 +7,7 @@ pub fn process<'a>(
     _accounts: &'a [AccountInfo<'a>],
     _instruction: &[u8],
 ) -> Result<()> {
-    solana_program::msg!("Instruction: Config Get Chain Count");
+    log_msg!("Instruction: Config Get Chain Count");
 
     let count = crate::config::CHAIN_ID_LIST.len();
 

--- a/evm_loader/program/src/instruction/config_get_chain_info.rs
+++ b/evm_loader/program/src/instruction/config_get_chain_info.rs
@@ -7,7 +7,7 @@ pub fn process<'a>(
     _accounts: &'a [AccountInfo<'a>],
     instruction: &[u8],
 ) -> Result<()> {
-    solana_program::msg!("Instruction: Config Get Chain Info");
+    log_msg!("Instruction: Config Get Chain Info");
 
     let bytes = instruction.try_into()?;
     let index = usize::from_le_bytes(bytes);

--- a/evm_loader/program/src/instruction/config_get_environment.rs
+++ b/evm_loader/program/src/instruction/config_get_environment.rs
@@ -7,7 +7,7 @@ pub fn process<'a>(
     _accounts: &'a [AccountInfo<'a>],
     _instruction: &[u8],
 ) -> Result<()> {
-    solana_program::msg!("Instruction: Config Get Environment");
+    log_msg!("Instruction: Config Get Environment");
 
     let environment: &str = if cfg!(feature = "mainnet") {
         "mainnet"

--- a/evm_loader/program/src/instruction/config_get_property_by_index.rs
+++ b/evm_loader/program/src/instruction/config_get_property_by_index.rs
@@ -7,7 +7,7 @@ pub fn process<'a>(
     _accounts: &'a [AccountInfo<'a>],
     instruction: &[u8],
 ) -> Result<()> {
-    solana_program::msg!("Instruction: Config Get Property by Index");
+    log_msg!("Instruction: Config Get Property by Index");
 
     let bytes = instruction.try_into()?;
     let index = usize::from_le_bytes(bytes);

--- a/evm_loader/program/src/instruction/config_get_property_by_name.rs
+++ b/evm_loader/program/src/instruction/config_get_property_by_name.rs
@@ -7,7 +7,7 @@ pub fn process<'a>(
     _accounts: &'a [AccountInfo<'a>],
     instruction: &[u8],
 ) -> Result<()> {
-    solana_program::msg!("Instruction: Config Get Property by Name");
+    log_msg!("Instruction: Config Get Property by Name");
 
     let requested_property = std::str::from_utf8(instruction)?;
 

--- a/evm_loader/program/src/instruction/config_get_property_count.rs
+++ b/evm_loader/program/src/instruction/config_get_property_count.rs
@@ -7,7 +7,7 @@ pub fn process<'a>(
     _accounts: &'a [AccountInfo<'a>],
     _instruction: &[u8],
 ) -> Result<()> {
-    solana_program::msg!("Instruction: Config Get Property Count");
+    log_msg!("Instruction: Config Get Property Count");
 
     let count = crate::config::PARAMETERS.len();
 

--- a/evm_loader/program/src/instruction/config_get_status.rs
+++ b/evm_loader/program/src/instruction/config_get_status.rs
@@ -7,7 +7,7 @@ pub fn process<'a>(
     _accounts: &'a [AccountInfo<'a>],
     _instruction: &[u8],
 ) -> Result<()> {
-    solana_program::msg!("Instruction: Config Get Status");
+    log_msg!("Instruction: Config Get Status");
 
     if cfg!(feature = "emergency") {
         solana_program::program::set_return_data(&[0]);

--- a/evm_loader/program/src/instruction/config_get_version.rs
+++ b/evm_loader/program/src/instruction/config_get_version.rs
@@ -10,7 +10,7 @@ pub fn process<'a>(
     _accounts: &'a [AccountInfo<'a>],
     _instruction: &[u8],
 ) -> Result<()> {
-    solana_program::msg!("Instruction: Config Get Version");
+    log_msg!("Instruction: Config Get Version");
 
     let version = std::str::from_utf8(&NEON_PKG_VERSION)?;
     let revision = std::str::from_utf8(&NEON_REVISION)?;

--- a/evm_loader/program/src/instruction/create_main_treasury.rs
+++ b/evm_loader/program/src/instruction/create_main_treasury.rs
@@ -6,10 +6,11 @@ use crate::{
 use solana_program::{
     account_info::AccountInfo,
     bpf_loader_upgradeable::{self, UpgradeableLoaderState},
-    msg,
     program_pack::Pack,
     pubkey::Pubkey,
+    rent::Rent,
     system_program,
+    sysvar::Sysvar,
 };
 
 struct Accounts<'a> {
@@ -69,7 +70,7 @@ pub fn process<'a>(
     accounts: &'a [AccountInfo<'a>],
     _instruction: &[u8],
 ) -> Result<()> {
-    msg!("Instruction: Create Main Treasury");
+    log_msg!("Instruction: Create Main Treasury");
 
     let accounts = Accounts::from_slice(accounts)?;
     let (expected_key, bump_seed) = MainTreasury::address(program_id);
@@ -120,6 +121,7 @@ pub fn process<'a>(
         accounts.main_treasury,
         &[TREASURY_POOL_SEED.as_bytes(), &[bump_seed]],
         spl_token::state::Account::LEN,
+        &Rent::get()?,
     )?;
 
     accounts.token_program.create_account(

--- a/evm_loader/program/src/instruction/transaction_cancel.rs
+++ b/evm_loader/program/src/instruction/transaction_cancel.rs
@@ -1,4 +1,5 @@
 use crate::account::{AccountsDB, BalanceAccount, Operator, StateAccount};
+use crate::debug::log_data;
 use crate::error::{Error, Result};
 use crate::gasometer::{CANCEL_TRX_COST, LAST_ITERATION_COST};
 use arrayref::array_ref;
@@ -10,7 +11,7 @@ pub fn process<'a>(
     accounts: &'a [AccountInfo<'a>],
     instruction: &[u8],
 ) -> Result<()> {
-    solana_program::msg!("Instruction: Cancel Transaction");
+    log_msg!("Instruction: Cancel Transaction");
 
     let transaction_hash = array_ref![instruction, 0, 32];
 
@@ -18,8 +19,8 @@ pub fn process<'a>(
     let operator = Operator::from_account(&accounts[1])?;
     let operator_balance = BalanceAccount::from_account(program_id, accounts[2].clone())?;
 
-    solana_program::log::sol_log_data(&[b"HASH", transaction_hash]);
-    solana_program::log::sol_log_data(&[b"MINER", operator_balance.address().as_bytes()]);
+    log_data(&[b"HASH", transaction_hash]);
+    log_data(&[b"MINER", operator_balance.address().as_bytes()]);
 
     let accounts_db = AccountsDB::new(&accounts[3..], operator, Some(operator_balance), None, None);
     let storage = StateAccount::restore(program_id, storage_info, &accounts_db, true)?;
@@ -46,7 +47,7 @@ fn execute<'a>(
 ) -> Result<()> {
     let used_gas = U256::ZERO;
     let total_used_gas = storage.gas_used();
-    solana_program::log::sol_log_data(&[
+    log_data(&[
         b"GAS",
         &used_gas.to_le_bytes(),
         &total_used_gas.to_le_bytes(),

--- a/evm_loader/program/src/instruction/transaction_execute.rs
+++ b/evm_loader/program/src/instruction/transaction_execute.rs
@@ -2,6 +2,7 @@ use solana_program::pubkey::Pubkey;
 
 use crate::account::{AccountsDB, AllocateResult};
 use crate::account_storage::ProgramAccountStorage;
+use crate::debug::log_data;
 use crate::error::{Error, Result};
 use crate::evm::Machine;
 use crate::executor::{ExecutorState, SyncedExecutorState};
@@ -60,7 +61,7 @@ pub fn execute(
         return Err(Error::OutOfGas(gas_limit, used_gas));
     }
 
-    solana_program::log::sol_log_data(&[b"GAS", &used_gas.to_le_bytes(), &used_gas.to_le_bytes()]);
+    log_data(&[b"GAS", &used_gas.to_le_bytes(), &used_gas.to_le_bytes()]);
 
     let gas_cost = used_gas.saturating_mul(gas_price);
     account_storage.transfer_gas_payment(origin, chain_id, gas_cost)?;
@@ -99,7 +100,7 @@ pub fn execute_with_solana_call(
         return Err(Error::OutOfGas(gas_limit, used_gas));
     }
 
-    solana_program::log::sol_log_data(&[b"GAS", &used_gas.to_le_bytes(), &used_gas.to_le_bytes()]);
+    log_data(&[b"GAS", &used_gas.to_le_bytes(), &used_gas.to_le_bytes()]);
 
     let gas_cost = used_gas.saturating_mul(gas_price);
     account_storage.transfer_gas_payment(origin, chain_id, gas_cost)?;

--- a/evm_loader/program/src/instruction/transaction_execute_from_account.rs
+++ b/evm_loader/program/src/instruction/transaction_execute_from_account.rs
@@ -1,4 +1,5 @@
 use crate::account::{program, AccountsDB, BalanceAccount, Holder, Operator, Treasury};
+use crate::debug::log_data;
 use crate::error::Result;
 use crate::gasometer::Gasometer;
 use crate::types::Transaction;
@@ -12,7 +13,7 @@ pub fn process<'a>(
     accounts: &'a [AccountInfo<'a>],
     instruction: &[u8],
 ) -> Result<()> {
-    solana_program::msg!("Instruction: Execute Transaction from Account");
+    log_msg!("Instruction: Execute Transaction from Account");
 
     let treasury_index = u32::from_le_bytes(*array_ref![instruction, 0, 4]);
 
@@ -29,8 +30,8 @@ pub fn process<'a>(
 
     let origin = trx.recover_caller_address()?;
 
-    solana_program::log::sol_log_data(&[b"HASH", &trx.hash()]);
-    solana_program::log::sol_log_data(&[b"MINER", operator_balance.address().as_bytes()]);
+    log_data(&[b"HASH", &trx.hash()]);
+    log_data(&[b"MINER", operator_balance.address().as_bytes()]);
 
     let accounts_db = AccountsDB::new(
         &accounts[5..],

--- a/evm_loader/program/src/instruction/transaction_execute_from_account_solana_call.rs
+++ b/evm_loader/program/src/instruction/transaction_execute_from_account_solana_call.rs
@@ -1,4 +1,5 @@
 use crate::account::{program, AccountsDB, BalanceAccount, Holder, Operator, Treasury};
+use crate::debug::log_data;
 use crate::error::Result;
 use crate::gasometer::Gasometer;
 use crate::types::Transaction;
@@ -12,7 +13,7 @@ pub fn process<'a>(
     accounts: &'a [AccountInfo<'a>],
     instruction: &[u8],
 ) -> Result<()> {
-    solana_program::msg!("Instruction: Execute Transaction from Account with Solana call");
+    log_msg!("Instruction: Execute Transaction from Account with Solana call");
 
     let treasury_index = u32::from_le_bytes(*array_ref![instruction, 0, 4]);
 
@@ -29,8 +30,8 @@ pub fn process<'a>(
 
     let origin = trx.recover_caller_address()?;
 
-    solana_program::log::sol_log_data(&[b"HASH", &trx.hash()]);
-    solana_program::log::sol_log_data(&[b"MINER", operator_balance.address().as_bytes()]);
+    log_data(&[b"HASH", &trx.hash()]);
+    log_data(&[b"MINER", operator_balance.address().as_bytes()]);
 
     let accounts_db = AccountsDB::new(
         &accounts[5..],

--- a/evm_loader/program/src/instruction/transaction_execute_from_instruction.rs
+++ b/evm_loader/program/src/instruction/transaction_execute_from_instruction.rs
@@ -1,4 +1,5 @@
 use crate::account::{program, AccountsDB, BalanceAccount, Operator, Treasury};
+use crate::debug::log_data;
 use crate::error::Result;
 use crate::gasometer::Gasometer;
 use crate::types::Transaction;
@@ -12,7 +13,7 @@ pub fn process<'a>(
     accounts: &'a [AccountInfo<'a>],
     instruction: &[u8],
 ) -> Result<()> {
-    solana_program::msg!("Instruction: Execute Transaction from Instruction");
+    log_msg!("Instruction: Execute Transaction from Instruction");
 
     let treasury_index = u32::from_le_bytes(*array_ref![instruction, 0, 4]);
     let messsage = &instruction[4..];
@@ -25,8 +26,8 @@ pub fn process<'a>(
     let trx = Transaction::from_rlp(messsage)?;
     let origin = trx.recover_caller_address()?;
 
-    solana_program::log::sol_log_data(&[b"HASH", &trx.hash()]);
-    solana_program::log::sol_log_data(&[b"MINER", operator_balance.address().as_bytes()]);
+    log_data(&[b"HASH", &trx.hash()]);
+    log_data(&[b"MINER", operator_balance.address().as_bytes()]);
 
     let accounts_db = AccountsDB::new(
         &accounts[4..],

--- a/evm_loader/program/src/instruction/transaction_execute_from_instruction_solana_call.rs
+++ b/evm_loader/program/src/instruction/transaction_execute_from_instruction_solana_call.rs
@@ -1,4 +1,5 @@
 use crate::account::{program, AccountsDB, BalanceAccount, Operator, Treasury};
+use crate::debug::log_data;
 use crate::error::Result;
 use crate::gasometer::Gasometer;
 use crate::types::Transaction;
@@ -12,7 +13,7 @@ pub fn process<'a>(
     accounts: &'a [AccountInfo<'a>],
     instruction: &[u8],
 ) -> Result<()> {
-    solana_program::msg!("Instruction: Execute Transaction from Instruction with Solana call");
+    log_msg!("Instruction: Execute Transaction from Instruction with Solana call");
 
     let treasury_index = u32::from_le_bytes(*array_ref![instruction, 0, 4]);
     let messsage = &instruction[4..];
@@ -25,8 +26,8 @@ pub fn process<'a>(
     let trx = Transaction::from_rlp(messsage)?;
     let origin = trx.recover_caller_address()?;
 
-    solana_program::log::sol_log_data(&[b"HASH", &trx.hash()]);
-    solana_program::log::sol_log_data(&[b"MINER", operator_balance.address().as_bytes()]);
+    log_data(&[b"HASH", &trx.hash()]);
+    log_data(&[b"MINER", operator_balance.address().as_bytes()]);
 
     let accounts_db = AccountsDB::new(
         &accounts[4..],

--- a/evm_loader/program/src/instruction/transaction_step.rs
+++ b/evm_loader/program/src/instruction/transaction_step.rs
@@ -1,6 +1,7 @@
 use crate::account::{AccountsDB, AllocateResult, StateAccount};
 use crate::account_storage::{AccountStorage, ProgramAccountStorage};
 use crate::config::{EVM_STEPS_LAST_ITERATION_MAX, EVM_STEPS_MIN};
+use crate::debug::log_data;
 use crate::error::{Error, Result};
 use crate::evm::{ExitStatus, Machine};
 use crate::executor::{Action, ExecutorState};
@@ -102,7 +103,7 @@ fn finalize<'a>(
 
     let used_gas = gasometer.used_gas();
     let total_used_gas = gasometer.used_gas_total();
-    solana_program::log::sol_log_data(&[
+    log_data(&[
         b"GAS",
         &used_gas.to_le_bytes(),
         &total_used_gas.to_le_bytes(),
@@ -123,8 +124,6 @@ fn finalize<'a>(
 }
 
 pub fn log_return_value(status: &ExitStatus) {
-    use solana_program::log::sol_log_data;
-
     let code: u8 = match status {
         ExitStatus::Stop => 0x11,
         ExitStatus::Return(_) => 0x12,
@@ -133,12 +132,12 @@ pub fn log_return_value(status: &ExitStatus) {
         ExitStatus::StepLimit => unreachable!(),
     };
 
-    solana_program::msg!("exit_status={:#04X}", code); // Tests compatibility
+    log_msg!("exit_status={:#04X}", code); // Tests compatibility
     if let ExitStatus::Revert(msg) = status {
         crate::error::print_revert_message(msg);
     }
 
-    sol_log_data(&[b"RETURN", &[code]]);
+    log_data(&[b"RETURN", &[code]]);
 }
 
 fn serialize_evm_state(

--- a/evm_loader/program/src/instruction/transaction_step_from_account.rs
+++ b/evm_loader/program/src/instruction/transaction_step_from_account.rs
@@ -3,7 +3,7 @@ use crate::account::{
     program, AccountsDB, BalanceAccount, Holder, Operator, StateAccount, Treasury, TAG_HOLDER,
     TAG_STATE, TAG_STATE_FINALIZED,
 };
-
+use crate::debug::log_data;
 use crate::error::{Error, Result};
 use crate::gasometer::Gasometer;
 use crate::instruction::transaction_step::{do_begin, do_continue};
@@ -17,7 +17,7 @@ pub fn process<'a>(
     accounts: &'a [AccountInfo<'a>],
     instruction: &[u8],
 ) -> Result<()> {
-    solana_program::msg!("Instruction: Begin or Continue Transaction from Account");
+    log_msg!("Instruction: Begin or Continue Transaction from Account");
 
     process_inner(program_id, accounts, instruction, false)
 }
@@ -69,8 +69,8 @@ pub fn process_inner<'a>(
                 trx
             };
 
-            solana_program::log::sol_log_data(&[b"HASH", &trx.hash]);
-            solana_program::log::sol_log_data(&[b"MINER", miner_address.as_bytes()]);
+            log_data(&[b"HASH", &trx.hash]);
+            log_data(&[b"MINER", miner_address.as_bytes()]);
 
             let origin = trx.recover_caller_address()?;
 
@@ -101,8 +101,8 @@ pub fn process_inner<'a>(
             let storage =
                 StateAccount::restore(program_id, holder_or_storage.clone(), &accounts_db, false)?;
 
-            solana_program::log::sol_log_data(&[b"HASH", &storage.trx_hash()]);
-            solana_program::log::sol_log_data(&[b"MINER", miner_address.as_bytes()]);
+            log_data(&[b"HASH", &storage.trx_hash()]);
+            log_data(&[b"MINER", miner_address.as_bytes()]);
 
             let mut gasometer = Gasometer::new(storage.gas_used(), accounts_db.operator())?;
             gasometer.record_solana_transaction_cost();

--- a/evm_loader/program/src/instruction/transaction_step_from_account_no_chainid.rs
+++ b/evm_loader/program/src/instruction/transaction_step_from_account_no_chainid.rs
@@ -6,7 +6,7 @@ pub fn process<'a>(
     accounts: &'a [AccountInfo<'a>],
     instruction: &[u8],
 ) -> Result<()> {
-    solana_program::msg!("Instruction: Begin or Continue Transaction from Account Without ChainId");
+    log_msg!("Instruction: Begin or Continue Transaction from Account Without ChainId");
 
     super::transaction_step_from_account::process_inner(program_id, accounts, instruction, true)
 }

--- a/evm_loader/program/src/instruction/transaction_step_from_instruction.rs
+++ b/evm_loader/program/src/instruction/transaction_step_from_instruction.rs
@@ -3,6 +3,7 @@ use crate::account::{
     program, AccountsDB, BalanceAccount, Operator, StateAccount, Treasury, TAG_HOLDER, TAG_STATE,
     TAG_STATE_FINALIZED,
 };
+use crate::debug::log_data;
 use crate::error::{Error, Result};
 use crate::gasometer::Gasometer;
 use crate::instruction::transaction_step::{do_begin, do_continue};
@@ -16,7 +17,7 @@ pub fn process<'a>(
     accounts: &'a [AccountInfo<'a>],
     instruction: &[u8],
 ) -> Result<()> {
-    solana_program::msg!("Instruction: Begin or Continue Transaction from Instruction");
+    log_msg!("Instruction: Begin or Continue Transaction from Instruction");
 
     let treasury_index = u32::from_le_bytes(*array_ref![instruction, 0, 4]);
     let step_count = u64::from(u32::from_le_bytes(*array_ref![instruction, 4, 4]));
@@ -52,8 +53,8 @@ pub fn process<'a>(
             let trx = Transaction::from_rlp(message)?;
             let origin = trx.recover_caller_address()?;
 
-            solana_program::log::sol_log_data(&[b"HASH", &trx.hash()]);
-            solana_program::log::sol_log_data(&[b"MINER", miner_address.as_bytes()]);
+            log_data(&[b"HASH", &trx.hash()]);
+            log_data(&[b"MINER", miner_address.as_bytes()]);
 
             let mut gasometer = Gasometer::new(U256::ZERO, accounts_db.operator())?;
             gasometer.record_solana_transaction_cost();
@@ -69,8 +70,8 @@ pub fn process<'a>(
         TAG_STATE => {
             let storage = StateAccount::restore(program_id, storage_info, &accounts_db, false)?;
 
-            solana_program::log::sol_log_data(&[b"HASH", &storage.trx_hash()]);
-            solana_program::log::sol_log_data(&[b"MINER", miner_address.as_bytes()]);
+            log_data(&[b"HASH", &storage.trx_hash()]);
+            log_data(&[b"MINER", miner_address.as_bytes()]);
 
             let mut gasometer = Gasometer::new(storage.gas_used(), accounts_db.operator())?;
             gasometer.record_solana_transaction_cost();


### PR DESCRIPTION
1. Use AccountStorage to access Rent sysvar and return_data()
2. Implement `log_data()` and `log_msg()` to work with our implementation instead of `syscall_stab` in emulation context