### PR TITLE
NDEV-2301 & NDEV-2328 & NDEV-2299: Implement debug_traceTransaction prestateTracer, callTracer & trace_replayTransaction stateDiff tracer 

### DIFF
--- a/evm_loader/Cargo.lock
+++ b/evm_loader/Cargo.lock
@@ -3359,6 +3359,7 @@ version = "1.11.0-dev"
 dependencies = [
  "abi_stable",
  "anyhow",
+ "arrayref",
  "async-ffi",
  "async-trait",
  "base64 0.22.0",

--- a/evm_loader/lib/Cargo.toml
+++ b/evm_loader/lib/Cargo.toml
@@ -44,6 +44,7 @@ strum = "0.26.1"
 strum_macros = "0.26.1"
 clap = "2.33.3"
 lazy_static = "1.4.0"
+arrayref = "0.3.6"
 
 [build-dependencies]
 build-info-build = "0.0.31"

--- a/evm_loader/lib/src/commands/emulate.rs
+++ b/evm_loader/lib/src/commands/emulate.rs
@@ -76,7 +76,7 @@ pub async fn execute<T: Tracer>(
     )
     .await?;
 
-    let step_limit = emulate_request.step_limit.unwrap_or(100000);
+    let step_limit = emulate_request.step_limit.unwrap_or(100_000);
 
     emulate_trx(emulate_request.tx, &mut storage, step_limit, tracer).await
 }
@@ -137,7 +137,7 @@ async fn emulate_trx<T: Tracer>(
             result: exit_status.into_result().unwrap_or_default(),
             iterations,
         },
-        tracer.map(|tracer| tracer.into_traces()),
+        tracer.map(|tracer| tracer.into_traces(used_gas)),
     ))
 }
 

--- a/evm_loader/lib/src/commands/trace.rs
+++ b/evm_loader/lib/src/commands/trace.rs
@@ -18,13 +18,10 @@ pub async fn trace_transaction(
         .map(|c| c.trace_config.clone())
         .unwrap_or_default();
 
-    let tracer = new_tracer(&trace_config)?;
+    let tracer = new_tracer(&emulate_request.tx, trace_config)?;
 
-    let (r, traces) =
+    let (_, traces) =
         super::emulate::execute(rpc, program_id, emulate_request, Some(tracer)).await?;
 
-    let mut traces = traces.expect("traces should not be None");
-    traces["gas"] = r.used_gas.into();
-
-    Ok(traces)
+    Ok(traces.expect("traces should not be None"))
 }

--- a/evm_loader/lib/src/tracing/mod.rs
+++ b/evm_loader/lib/src/tracing/mod.rs
@@ -1,8 +1,10 @@
-use ethnum::U256;
-use evm_loader::types::Address;
-use serde_json::Value;
 use std::collections::HashMap;
+
+use ethnum::U256;
+use serde_json::Value;
 use web3::types::Bytes;
+
+use evm_loader::types::Address;
 
 pub mod tracers;
 
@@ -65,6 +67,8 @@ pub struct TraceConfig {
     pub disable_stack: bool,
     #[serde(default)]
     pub enable_return_data: bool,
+    #[serde(default)]
+    pub limit: usize,
     pub tracer: Option<String>,
     pub timeout: Option<String>,
     pub tracer_config: Option<Value>,

--- a/evm_loader/lib/src/tracing/tracers/call_tracer.rs
+++ b/evm_loader/lib/src/tracing/tracers/call_tracer.rs
@@ -1,0 +1,307 @@
+use crate::tracing::tracers::state_diff::to_web3_u256;
+use crate::tracing::tracers::Tracer;
+use crate::tracing::TraceConfig;
+use crate::types::TxParams;
+use async_trait::async_trait;
+use evm_loader::error::{format_revert_error, format_revert_panic};
+use evm_loader::evm::database::Database;
+use evm_loader::evm::opcode_table::Opcode;
+use evm_loader::evm::tracing::{Event, EventListener};
+use evm_loader::evm::{opcode_table, Context, ExitStatus};
+use evm_loader::types::Address;
+use lazy_static::lazy_static;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use web3::types::{Bytes, H256, U256};
+
+pub struct CallTracer {
+    config: CallTracerConfig,
+    call_stack: Vec<CallFrame>,
+    depth: usize,
+}
+
+impl CallTracer {
+    pub fn new(trace_config: TraceConfig, tx: &TxParams) -> Self {
+        CallTracer {
+            config: trace_config.into(),
+            call_stack: vec![CallFrame {
+                gas: tx.gas_limit.map(to_web3_u256).unwrap_or_default(),
+                gas_used: tx.actual_gas_used.map(to_web3_u256).unwrap_or_default(),
+                ..CallFrame::default()
+            }],
+            depth: 0,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CallTracerConfig {
+    #[serde(default)]
+    pub only_top_call: bool,
+    // If true, call tracer won't collect any subcalls
+    #[serde(default)]
+    pub with_log: bool, // If true, call tracer will collect event logs
+}
+
+impl From<TraceConfig> for CallTracerConfig {
+    fn from(trace_config: TraceConfig) -> Self {
+        let tracer_config = trace_config
+            .tracer_config
+            .expect("tracer_config should not be None for \"callTracer\"");
+        serde_json::from_value(tracer_config).expect("tracer_config should be CallTracerConfig")
+    }
+}
+
+#[derive(Serialize)]
+pub struct CallLog {
+    address: Address,
+    topics: Vec<H256>,
+    data: Bytes,
+    // Position of the log relative to subcalls within the same trace
+    // See https://github.com/ethereum/go-ethereum/pull/28389 for details
+    position: U256,
+}
+
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CallFrame {
+    from: Address,
+    gas: U256,
+    gas_used: U256,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    to: Option<Address>,
+    input: Bytes,
+    #[serde(skip_serializing_if = "is_empty")]
+    output: Bytes,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    error: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    revert_reason: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    calls: Vec<CallFrame>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    logs: Vec<CallLog>,
+    // Placed at end on purpose. The RLP will be decoded to 0 instead of
+    // nil if there are non-empty elements after in the struct.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    value: Option<U256>,
+    #[serde(rename = "type")]
+    type_string: Opcode,
+}
+
+impl CallFrame {
+    fn process_output(&mut self, status: ExitStatus) {
+        if status.is_succeed().unwrap_or_default() {
+            self.output = status.into_result().unwrap_or_default().into();
+            return;
+        }
+
+        if let ExitStatus::Revert(_) = status {
+            self.error = "execution reverted".to_string();
+        }
+
+        if self.type_string == opcode_table::CREATE || self.type_string == opcode_table::CREATE2 {
+            self.to = None;
+        }
+
+        self.output = status.into_result().unwrap_or_default().into();
+        self.revert_reason = format_revert_message(&self.output.0);
+    }
+
+    // clear_failed_logs clears the logs of a callframe and all its children
+    // in case of execution failure.
+    fn clear_failed_logs(&mut self, parent_failed: bool) {
+        let failed = !self.error.is_empty() || parent_failed;
+        if failed {
+            self.logs.clear();
+        }
+        for call in &mut self.calls {
+            call.clear_failed_logs(failed);
+        }
+    }
+}
+
+fn format_revert_message(msg: &[u8]) -> String {
+    if let Some(reason) = format_revert_error(msg) {
+        return reason.to_string();
+    }
+
+    if let Some(reason) = format_revert_panic(msg) {
+        return get_panic_message(reason);
+    }
+
+    String::new()
+}
+
+fn get_panic_message(reason: ethnum::U256) -> String {
+    let reason = reason.as_u64();
+    PANIC_REASONS
+        .get(&reason)
+        .map(|s| s.to_string())
+        .unwrap_or(format!("unknown panic code: {reason:#x}"))
+}
+
+lazy_static! {
+    // panic_reasons map is for readable panic codes
+    // see this linkage for the details
+    // https://docs.soliditylang.org/en/v0.8.21/control-structures.html#panic-via-assert-and-error-via-require
+    // the reason string list is copied from ethers.js
+    // https://github.com/ethers-io/ethers.js/blob/fa3a883ff7c88611ce766f58bdd4b8ac90814470/src.ts/abi/interface.ts#L207-L218
+    static ref PANIC_REASONS: HashMap<u64, &'static str> = HashMap::from([
+        (0x00, "generic panic"),
+        (0x01, "assert(false)"),
+        (0x11, "arithmetic underflow or overflow"),
+        (0x12, "division or modulo by zero"),
+        (0x21, "enum overflow"),
+        (0x22, "invalid encoded storage byte array accessed"),
+        (0x31, "out-of-bounds array access; popping on an empty array"),
+        (0x32, "out-of-bounds access of an array or bytesN"),
+        (0x41, "out of memory"),
+        (0x51, "uninitialized function"),
+    ]);
+}
+
+fn is_empty(bytes: &Bytes) -> bool {
+    bytes.0.is_empty()
+}
+
+#[async_trait(?Send)]
+impl EventListener for CallTracer {
+    async fn event(
+        &mut self,
+        _executor_state: &impl Database,
+        event: Event,
+    ) -> evm_loader::error::Result<()> {
+        match event {
+            Event::BeginVM {
+                context,
+                opcode,
+                input,
+                ..
+            } => {
+                self.depth += 1;
+                self.handle_begin_vm(context, opcode, input);
+            }
+            Event::EndVM { status, .. } => {
+                self.handle_end_vm(status);
+                self.depth -= 1;
+            }
+            Event::BeginStep {
+                context,
+                opcode,
+                stack,
+                memory,
+                ..
+            } => {
+                // Only logs need to be captured via opcode processing
+                if !self.config.with_log {
+                    return Ok(());
+                }
+
+                // Avoid processing nested calls when only caring about top call
+                if self.config.only_top_call && self.depth > 1 {
+                    return Ok(());
+                }
+
+                match opcode {
+                    opcode_table::LOG0
+                    | opcode_table::LOG1
+                    | opcode_table::LOG2
+                    | opcode_table::LOG3
+                    | opcode_table::LOG4 => {
+                        let size = (opcode.0 - opcode_table::LOG0.0) as usize;
+
+                        let m_start = U256::from(stack[stack.len() - 1]).as_usize();
+                        let m_size = U256::from(stack[stack.len() - 2]).as_usize();
+
+                        let mut topics = Vec::with_capacity(size);
+
+                        for i in 0..size {
+                            topics.push(H256::from(stack[stack.len() - 2 - (i + 1)]));
+                        }
+
+                        let call_log = CallLog {
+                            address: context.contract,
+                            topics,
+                            data: memory[m_start..m_start + m_size].to_vec().into(),
+                            position: self.call_stack.last().unwrap().calls.len().into(),
+                        };
+
+                        self.call_stack.last_mut().unwrap().logs.push(call_log);
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl CallTracer {
+    fn handle_begin_vm(&mut self, context: Context, opcode: Opcode, input: Vec<u8>) {
+        if self.depth == 1 {
+            let call_frame = &mut self.call_stack[0];
+            call_frame.from = context.caller;
+            call_frame.to = Some(context.contract);
+            call_frame.input = input.into();
+            call_frame.value = Some(to_web3_u256(context.value));
+            call_frame.type_string = opcode;
+            return;
+        }
+
+        if self.config.only_top_call {
+            return;
+        }
+
+        self.call_stack.push(CallFrame {
+            from: context.caller,
+            to: Some(context.contract),
+            input: input.into(),
+            value: Some(to_web3_u256(context.value)),
+            type_string: opcode,
+            ..CallFrame::default()
+        })
+    }
+
+    fn handle_end_vm(&mut self, status: ExitStatus) {
+        if self.depth == 1 {
+            self.call_stack[0].process_output(status);
+            if self.config.with_log {
+                self.call_stack[0].clear_failed_logs(false);
+            }
+            return;
+        }
+
+        if self.config.only_top_call {
+            return;
+        }
+
+        if self.call_stack.len() <= 1 {
+            return;
+        }
+
+        let mut call_frame = self.call_stack.pop().unwrap();
+
+        call_frame.process_output(status);
+
+        self.call_stack.last_mut().unwrap().calls.push(call_frame);
+    }
+}
+
+impl Tracer for CallTracer {
+    fn into_traces(mut self, emulator_gas_used: u64) -> Value {
+        if self.call_stack.len() != 1 {
+            panic!("incorrect number of top-level calls");
+        }
+
+        let call_frame = &mut self.call_stack[0];
+        if call_frame.gas_used.is_zero() {
+            call_frame.gas_used = U256::from(emulator_gas_used);
+        }
+
+        serde_json::to_value(call_frame).expect("serialization should not fail")
+    }
+}

--- a/evm_loader/lib/src/tracing/tracers/mod.rs
+++ b/evm_loader/lib/src/tracing/tracers/mod.rs
@@ -1,41 +1,72 @@
+use crate::tracing::tracers::call_tracer::CallTracer;
+use crate::tracing::tracers::openeth::tracer::OpenEthereumTracer;
+use crate::tracing::tracers::prestate_tracer::tracer::PrestateTracer;
 use crate::tracing::tracers::struct_logger::StructLogger;
 use crate::tracing::TraceConfig;
+use crate::types::TxParams;
+use async_trait::async_trait;
+use enum_dispatch::enum_dispatch;
 use evm_loader::evm::database::Database;
-use evm_loader::evm::tracing::{Event, EventListener};
+use evm_loader::evm::tracing::Event;
+use evm_loader::evm::tracing::EventListener;
 use serde_json::Value;
 
+pub mod call_tracer;
+pub mod openeth;
+pub mod prestate_tracer;
+pub mod state_diff;
 pub mod struct_logger;
 
+#[enum_dispatch(Tracer)]
 pub enum TracerTypeEnum {
     StructLogger(StructLogger),
+    OpenEthereumTracer(OpenEthereumTracer),
+    PrestateTracer(PrestateTracer),
+    CallTracer(CallTracer),
 }
 
+// cannot use enum_dispatch because of trait and enum in different crates
+#[async_trait(?Send)]
 impl EventListener for TracerTypeEnum {
-    fn event(&mut self, executor_state: &impl Database, event: Event) {
+    async fn event(
+        &mut self,
+        executor_state: &impl Database,
+        event: Event,
+    ) -> evm_loader::error::Result<()> {
         match self {
-            TracerTypeEnum::StructLogger(struct_logger) => {
-                struct_logger.event(executor_state, event)
-            }
+            TracerTypeEnum::StructLogger(tracer) => tracer.event(executor_state, event).await,
+            TracerTypeEnum::OpenEthereumTracer(tracer) => tracer.event(executor_state, event).await,
+            TracerTypeEnum::PrestateTracer(tracer) => tracer.event(executor_state, event).await,
+            TracerTypeEnum::CallTracer(tracer) => tracer.event(executor_state, event).await,
         }
     }
 }
 
+#[enum_dispatch]
 pub trait Tracer: EventListener {
-    fn into_traces(self) -> Value;
+    fn into_traces(self, emulator_gas_used: u64) -> Value;
 }
 
-impl Tracer for TracerTypeEnum {
-    fn into_traces(self) -> Value {
-        match self {
-            TracerTypeEnum::StructLogger(struct_logger) => struct_logger.into_traces(),
-        }
-    }
-}
-
-pub fn new_tracer(trace_config: &TraceConfig) -> evm_loader::error::Result<TracerTypeEnum> {
+pub fn new_tracer(
+    tx: &TxParams,
+    trace_config: TraceConfig,
+) -> evm_loader::error::Result<TracerTypeEnum> {
     match trace_config.tracer.as_deref() {
         None | Some("") => Ok(TracerTypeEnum::StructLogger(StructLogger::new(
             trace_config,
+            tx,
+        ))),
+        Some("openethereum") => Ok(TracerTypeEnum::OpenEthereumTracer(OpenEthereumTracer::new(
+            trace_config,
+            tx,
+        ))),
+        Some("prestateTracer") => Ok(TracerTypeEnum::PrestateTracer(PrestateTracer::new(
+            trace_config,
+            tx,
+        ))),
+        Some("callTracer") => Ok(TracerTypeEnum::CallTracer(CallTracer::new(
+            trace_config,
+            tx,
         ))),
         _ => Err(evm_loader::error::Error::Custom(format!(
             "Unsupported tracer: {:?}",

--- a/evm_loader/lib/src/tracing/tracers/openeth/mod.rs
+++ b/evm_loader/lib/src/tracing/tracers/openeth/mod.rs
@@ -1,0 +1,3 @@
+pub mod state_diff;
+pub mod tracer;
+pub mod types;

--- a/evm_loader/lib/src/tracing/tracers/openeth/state_diff.rs
+++ b/evm_loader/lib/src/tracing/tracers/openeth/state_diff.rs
@@ -1,0 +1,72 @@
+use crate::tracing::tracers::state_diff::StateMap;
+use std::collections::BTreeMap;
+use web3::types::{AccountDiff, ChangedType, Diff, StateDiff, H160, H256};
+
+pub fn into_state_diff(state_map: StateMap) -> StateDiff {
+    let mut state_diff = BTreeMap::new();
+
+    for (address, states) in state_map.into_iter() {
+        let pre_account = states.pre;
+        let post_account = states.post;
+
+        if pre_account.is_empty() {
+            state_diff.insert(
+                H160::from(address.as_bytes()),
+                AccountDiff {
+                    balance: build_diff(None, Some(post_account.balance)),
+                    nonce: build_diff(None, Some(post_account.nonce.into())),
+                    code: build_diff(None, Some(post_account.code.clone())),
+                    storage: storage_diff(&pre_account.storage, &post_account.storage),
+                },
+            );
+        } else {
+            state_diff.insert(
+                H160::from(address.as_bytes()),
+                AccountDiff {
+                    balance: build_diff(Some(pre_account.balance), Some(post_account.balance)),
+                    nonce: build_diff(
+                        Some(pre_account.nonce.into()),
+                        Some(post_account.nonce.into()),
+                    ),
+                    code: build_diff(
+                        Some(pre_account.code.clone()),
+                        Some(post_account.code.clone()),
+                    ),
+                    storage: storage_diff(&pre_account.storage, &post_account.storage),
+                },
+            );
+        }
+    }
+
+    StateDiff(state_diff)
+}
+
+fn storage_diff(
+    account_initial_storage: &BTreeMap<H256, H256>,
+    account_final_storage: &BTreeMap<H256, H256>,
+) -> BTreeMap<H256, Diff<H256>> {
+    let mut storage_diff = BTreeMap::new();
+
+    for (key, initial_value) in account_initial_storage {
+        let final_value = account_final_storage.get(key).cloned();
+
+        storage_diff.insert(*key, build_diff(Some(*initial_value), final_value));
+    }
+
+    storage_diff
+}
+
+fn build_diff<T: Eq>(from: Option<T>, to: Option<T>) -> Diff<T> {
+    match (from, to) {
+        (None, Some(to)) => Diff::Born(to),
+        (None, None) => Diff::Same,
+        (Some(from), None) => Diff::Died(from),
+        (Some(from), Some(to)) => {
+            if from == to {
+                Diff::Same
+            } else {
+                Diff::Changed(ChangedType { from, to })
+            }
+        }
+    }
+}

--- a/evm_loader/lib/src/tracing/tracers/openeth/tracer.rs
+++ b/evm_loader/lib/src/tracing/tracers/openeth/tracer.rs
@@ -1,0 +1,72 @@
+use async_trait::async_trait;
+
+use evm_loader::evm::database::Database;
+use serde_json::Value;
+use web3::types::Bytes;
+
+use evm_loader::evm::tracing::{Event, EventListener};
+
+use crate::tracing::tracers::openeth::state_diff::into_state_diff;
+use crate::tracing::tracers::openeth::types::{CallAnalytics, TraceResults};
+use crate::tracing::tracers::state_diff::StateDiffTracer;
+use crate::tracing::tracers::Tracer;
+use crate::tracing::TraceConfig;
+use crate::types::TxParams;
+
+pub struct OpenEthereumTracer {
+    output: Option<Bytes>,
+    call_analytics: CallAnalytics,
+    state_diff_tracer: StateDiffTracer,
+}
+
+impl OpenEthereumTracer {
+    #[must_use]
+    pub fn new(trace_config: TraceConfig, tx: &TxParams) -> Self {
+        OpenEthereumTracer {
+            output: None,
+            call_analytics: trace_config.into(),
+            state_diff_tracer: StateDiffTracer::new(tx),
+        }
+    }
+}
+
+impl From<TraceConfig> for CallAnalytics {
+    fn from(trace_config: TraceConfig) -> Self {
+        let tracer_config = trace_config
+            .tracer_config
+            .expect("tracer_config should not be None for \"openethereum\" tracer");
+        serde_json::from_value(tracer_config).expect("tracer_config should be CallAnalytics")
+    }
+}
+
+#[async_trait(?Send)]
+impl EventListener for OpenEthereumTracer {
+    async fn event(
+        &mut self,
+        executor_state: &impl Database,
+        event: Event,
+    ) -> evm_loader::error::Result<()> {
+        if let Event::EndVM { status, .. } = &event {
+            self.output = status.clone().into_result().map(Into::into);
+        }
+        self.state_diff_tracer.event(executor_state, event).await
+    }
+}
+
+impl Tracer for OpenEthereumTracer {
+    fn into_traces(self, emulator_gas_used: u64) -> Value {
+        serde_json::to_value(TraceResults {
+            output: self.output.unwrap_or_default(),
+            trace: vec![],
+            vm_trace: None,
+            state_diff: if self.call_analytics.state_diffing {
+                Some(into_state_diff(
+                    self.state_diff_tracer.into_state_map(emulator_gas_used),
+                ))
+            } else {
+                None
+            },
+        })
+        .expect("serialization should not fail")
+    }
+}

--- a/evm_loader/lib/src/tracing/tracers/openeth/types.rs
+++ b/evm_loader/lib/src/tracing/tracers/openeth/types.rs
@@ -1,0 +1,406 @@
+/// Types copied from <https://github.com/openethereum/openethereum/blob/main/crates/rpc/src/v1/types/trace.rs>
+use std::fmt;
+
+use serde::ser::SerializeStruct;
+use serde::{Deserialize, Serialize, Serializer};
+use web3::types::{Bytes, StateDiff, H160, U256};
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+/// A diff of some chunk of memory.
+pub struct TraceResults {
+    /// The output of the call/create
+    pub output: Bytes,
+    /// The transaction trace.
+    pub state_diff: Option<StateDiff>,
+    /// The transaction trace.
+    pub trace: Vec<Trace>,
+    /// The transaction trace.
+    pub vm_trace: Option<VMTrace>,
+}
+
+/// Trace
+#[derive(Debug, Clone)]
+pub struct Trace {
+    /// Trace address
+    trace_address: Vec<usize>,
+    /// Subtraces
+    subtraces: usize,
+    /// Action
+    action: Action,
+    /// Result
+    result: Res,
+}
+
+impl Serialize for Trace {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut struc = serializer.serialize_struct("Trace", 4)?;
+        match self.action {
+            Action::Call(ref call) => {
+                struc.serialize_field("type", "call")?;
+                struc.serialize_field("action", call)?;
+            }
+            Action::Create(ref create) => {
+                struc.serialize_field("type", "create")?;
+                struc.serialize_field("action", create)?;
+            }
+            Action::Suicide(ref suicide) => {
+                struc.serialize_field("type", "suicide")?;
+                struc.serialize_field("action", suicide)?;
+            }
+            Action::Reward(ref reward) => {
+                struc.serialize_field("type", "reward")?;
+                struc.serialize_field("action", reward)?;
+            }
+        }
+
+        match self.result {
+            Res::Call(ref call) => struc.serialize_field("result", call)?,
+            Res::Create(ref create) => struc.serialize_field("result", create)?,
+            Res::FailedCall(ref error) | Res::FailedCreate(ref error) => {
+                struc.serialize_field("error", &error.to_string())?;
+            }
+            Res::None => struc.serialize_field("result", &None as &Option<u8>)?,
+        }
+
+        struc.serialize_field("traceAddress", &self.trace_address)?;
+        struc.serialize_field("subtraces", &self.subtraces)?;
+
+        struc.end()
+    }
+}
+
+/// Action
+#[derive(Debug, Clone)]
+pub enum Action {
+    /// Call
+    Call(Call),
+    /// Create
+    Create(Create),
+    /// Suicide
+    Suicide(Suicide),
+    /// Reward
+    Reward(Reward),
+}
+
+/// Call response
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Call {
+    /// Sender
+    from: H160,
+    /// Recipient
+    to: H160,
+    /// Transfered Value
+    value: U256,
+    /// Gas
+    gas: U256,
+    /// Input data
+    input: Bytes,
+    /// The type of the call.
+    call_type: CallType,
+}
+
+/// Call type.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CallType {
+    /// None
+    None,
+    /// Call
+    Call,
+    /// Call code
+    CallCode,
+    /// Delegate call
+    DelegateCall,
+    /// Static call
+    StaticCall,
+}
+
+/// Create response
+#[derive(Debug, Clone, Serialize)]
+pub struct Create {
+    /// Sender
+    from: H160,
+    /// Value
+    value: U256,
+    /// Gas
+    gas: U256,
+    /// Initialization code
+    init: Bytes,
+}
+
+/// Suicide
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Suicide {
+    /// Address.
+    pub address: H160,
+    /// Refund address.
+    pub refund_address: H160,
+    /// Balance.
+    pub balance: U256,
+}
+
+/// Reward action
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Reward {
+    /// Author's address.
+    pub author: H160,
+    /// Reward amount.
+    pub value: U256,
+    /// Reward type.
+    pub reward_type: RewardType,
+}
+
+/// Reward type.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RewardType {
+    /// Block
+    Block,
+    /// Uncle
+    Uncle,
+    /// EmptyStep (AuthorityRound)
+    EmptyStep,
+    /// External (attributed as part of an external protocol)
+    External,
+}
+
+#[derive(Debug, Clone, Serialize)]
+/// A record of a full VM trace for a CALL/CREATE.
+pub struct VMTrace {
+    /// The code to be executed.
+    pub code: Bytes,
+    /// The operations executed.
+    pub ops: Vec<VMOperation>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+/// A record of the execution of a single VM operation.
+pub struct VMOperation {
+    /// The program counter.
+    pub pc: usize,
+    /// The gas cost for this instruction.
+    pub cost: u64,
+    /// Information concerning the execution of the operation.
+    pub ex: Option<VMExecutedOperation>,
+    /// Subordinate trace of the CALL/CREATE if applicable.
+    #[serde(bound = "VMTrace: Serialize")]
+    pub sub: Option<VMTrace>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+/// A record of an executed VM operation.
+pub struct VMExecutedOperation {
+    /// The total gas used.
+    pub used: u64,
+    /// The stack item placed, if any.
+    pub push: Vec<U256>,
+    /// If altered, the memory delta.
+    pub mem: Option<MemoryDiff>,
+    /// The altered storage value, if any.
+    pub store: Option<StorageDiff>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+/// A diff of some chunk of memory.
+pub struct MemoryDiff {
+    /// Offset into memory the change begins.
+    pub off: usize,
+    /// The changed data.
+    pub data: Bytes,
+}
+
+#[derive(Debug, Clone, Serialize)]
+/// A diff of some storage value.
+pub struct StorageDiff {
+    /// Which key in storage is changed.
+    pub key: U256,
+    /// What the value has been changed to.
+    pub val: U256,
+}
+
+#[derive(Debug, Clone)]
+pub enum Res {
+    /// Call
+    Call(CallResult),
+    /// Create
+    Create(CreateResult),
+    /// Call failure
+    FailedCall(TraceError),
+    /// Creation failure
+    FailedCreate(TraceError),
+    /// None
+    None,
+}
+
+/// Call Result
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CallResult {
+    /// Gas used
+    gas_used: U256,
+    /// Output bytes
+    output: Bytes,
+}
+
+/// Create Result
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateResult {
+    /// Gas used
+    gas_used: U256,
+    /// Code
+    code: Bytes,
+    /// Assigned address
+    address: H160,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum TraceError {
+    /// `OutOfGas` is returned when transaction execution runs out of gas.
+    OutOfGas,
+    /// `BadJumpDestination` is returned when execution tried to move
+    /// to position that wasn't marked with JUMPDEST instruction
+    BadJumpDestination,
+    /// `BadInstructions` is returned when given instruction is not supported
+    BadInstruction,
+    /// `StackUnderflow` when there is not enough stack elements to execute instruction
+    StackUnderflow,
+    /// When execution would exceed defined Stack Limit
+    OutOfStack,
+    /// When there is not enough subroutine stack elements to return from
+    SubStackUnderflow,
+    /// When execution would exceed defined subroutine Stack Limit
+    OutOfSubStack,
+    /// When the code walks into a subroutine, that is not allowed
+    InvalidSubEntry,
+    /// When builtin contract failed on input data
+    BuiltIn,
+    /// Returned on evm internal error. Should never be ignored during development.
+    /// Likely to cause consensus issues.
+    Internal,
+    /// When execution tries to modify the state in static context
+    MutableCallInStaticContext,
+    /// When invalid code was attempted to deploy
+    InvalidCode,
+    /// Wasm error
+    Wasm,
+    /// Contract tried to access past the return data buffer.
+    OutOfBounds,
+    /// Execution has been reverted with REVERT instruction.
+    Reverted,
+}
+
+impl fmt::Display for TraceError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::TraceError::{
+            BadInstruction, BadJumpDestination, BuiltIn, Internal, InvalidCode, InvalidSubEntry,
+            MutableCallInStaticContext, OutOfBounds, OutOfGas, OutOfStack, OutOfSubStack, Reverted,
+            StackUnderflow, SubStackUnderflow, Wasm,
+        };
+        let message = match *self {
+            OutOfGas => "Out of gas",
+            BadJumpDestination => "Bad jump destination",
+            BadInstruction => "Bad instruction",
+            StackUnderflow => "Stack underflow",
+            OutOfStack => "Out of stack",
+            SubStackUnderflow => "Subroutine stack underflow",
+            OutOfSubStack => "Subroutine stack overflow",
+            BuiltIn => "Built-in failed",
+            InvalidSubEntry => "Invalid subroutine entry",
+            InvalidCode => "Invalid code",
+            Wasm => "Wasm runtime error",
+            Internal => "Internal error",
+            MutableCallInStaticContext => "Mutable Call In Static Context",
+            OutOfBounds => "Out of bounds",
+            Reverted => "Reverted",
+        };
+        message.fmt(f)
+    }
+}
+
+pub type TraceOptions = Vec<String>;
+
+#[must_use]
+pub fn to_call_analytics(flags: &TraceOptions) -> CallAnalytics {
+    CallAnalytics {
+        transaction_tracing: flags.contains(&("trace".to_owned())),
+        vm_tracing: flags.contains(&("vmTrace".to_owned())),
+        state_diffing: flags.contains(&("stateDiff".to_owned())),
+    }
+}
+
+/// Options concerning what analytics we run on the call.
+#[derive(Eq, PartialEq, Default, Clone, Copy, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CallAnalytics {
+    /// Make a transaction trace.
+    pub transaction_tracing: bool,
+    /// Make a VM trace.
+    pub vm_tracing: bool,
+    /// Make a diff.
+    pub state_diffing: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json;
+
+    use super::*;
+
+    #[test]
+    fn test_vmtrace_serialize() {
+        let t = VMTrace {
+            code: vec![0, 1, 2, 3].into(),
+            ops: vec![
+                VMOperation {
+                    pc: 0,
+                    cost: 10,
+                    ex: None,
+                    sub: None,
+                },
+                VMOperation {
+                    pc: 1,
+                    cost: 11,
+                    ex: Some(VMExecutedOperation {
+                        used: 10,
+                        push: vec![69.into()],
+                        mem: None,
+                        store: None,
+                    }),
+                    sub: Some(VMTrace {
+                        code: vec![0].into(),
+                        ops: vec![VMOperation {
+                            pc: 0,
+                            cost: 0,
+                            ex: Some(VMExecutedOperation {
+                                used: 10,
+                                push: vec![42.into()],
+                                mem: Some(MemoryDiff {
+                                    off: 42,
+                                    data: vec![1, 2, 3].into(),
+                                }),
+                                store: Some(StorageDiff {
+                                    key: 69.into(),
+                                    val: 42.into(),
+                                }),
+                            }),
+                            sub: None,
+                        }],
+                    }),
+                },
+            ],
+        };
+        let serialized = serde_json::to_string(&t).unwrap();
+        assert_eq!(
+            serialized,
+            r#"{"code":"0x00010203","ops":[{"pc":0,"cost":10,"ex":null,"sub":null},{"pc":1,"cost":11,"ex":{"used":10,"push":["0x45"],"mem":null,"store":null},"sub":{"code":"0x00","ops":[{"pc":0,"cost":0,"ex":{"used":10,"push":["0x2a"],"mem":{"off":42,"data":"0x010203"},"store":{"key":"0x45","val":"0x2a"}},"sub":null}]}}]}"#
+        );
+    }
+}

--- a/evm_loader/lib/src/tracing/tracers/prestate_tracer/mod.rs
+++ b/evm_loader/lib/src/tracing/tracers/prestate_tracer/mod.rs
@@ -1,0 +1,2 @@
+mod state_diff;
+pub mod tracer;

--- a/evm_loader/lib/src/tracing/tracers/prestate_tracer/state_diff.rs
+++ b/evm_loader/lib/src/tracing/tracers/prestate_tracer/state_diff.rs
@@ -1,0 +1,138 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use web3::types::{Bytes, H256, U256};
+
+use crate::tracing::tracers::state_diff::StateMap;
+use evm_loader::types::Address;
+
+/// See <https://github.com/ethereum/go-ethereum/blob/master/eth/tracers/native/prestate.go#L39>
+type PrestateTracerState = BTreeMap<Address, PrestateTracerAccount>;
+
+/// See <https://github.com/ethereum/go-ethereum/blob/master/eth/tracers/native/prestate.go#L41>
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PrestateTracerAccount {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub balance: Option<U256>,
+    #[serde(skip_serializing_if = "is_empty")]
+    pub code: Option<Bytes>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<u64>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub storage: BTreeMap<H256, H256>,
+}
+
+fn is_empty(bytes: &Option<Bytes>) -> bool {
+    match bytes {
+        None => true,
+        Some(bytes) => bytes.0.is_empty(),
+    }
+}
+
+/// See <https://github.com/ethereum/go-ethereum/blob/master/eth/tracers/native/prestate.go#L255>
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PrestateTracerDiffModeResult {
+    pub post: PrestateTracerState,
+    pub pre: PrestateTracerState,
+}
+
+pub fn build_prestate_tracer_pre_state(state_map: StateMap) -> PrestateTracerState {
+    let mut result = BTreeMap::new();
+
+    for (address, states) in state_map {
+        let pre_account = states.pre;
+
+        if pre_account.is_empty() {
+            continue;
+        }
+
+        result.insert(
+            address,
+            PrestateTracerAccount {
+                balance: Some(pre_account.balance),
+                code: Some(pre_account.code),
+                nonce: Some(pre_account.nonce),
+                storage: pre_account.storage,
+            },
+        );
+    }
+
+    result
+}
+
+/// See <https://github.com/ethereum/go-ethereum/blob/master/eth/tracers/native/prestate.go#L186>
+pub fn build_prestate_tracer_diff_mode_result(state_map: StateMap) -> PrestateTracerDiffModeResult {
+    let mut pre = build_prestate_tracer_pre_state(state_map.clone());
+
+    let mut post = BTreeMap::new();
+
+    for (address, states) in state_map {
+        let pre_account = states.pre;
+        let post_account = states.post;
+
+        let mut modified = false;
+
+        let balance = if post_account.balance != pre_account.balance {
+            modified = true;
+            Some(post_account.balance)
+        } else {
+            None
+        };
+
+        let code = if post_account.code != pre_account.code {
+            modified = true;
+            Some(post_account.code.clone())
+        } else {
+            None
+        };
+
+        let nonce = if post_account.nonce != pre_account.nonce {
+            modified = true;
+            Some(post_account.nonce)
+        } else {
+            None
+        };
+
+        let mut storage = BTreeMap::new();
+
+        for (key, initial_value) in pre_account.storage {
+            // don't include the empty slot
+            if initial_value == H256::zero() {
+                pre.entry(address).and_modify(|account| {
+                    account.storage.remove(&key);
+                });
+            }
+
+            let final_value = post_account.storage.get(&key).cloned().unwrap_or_default();
+
+            // Omit unchanged slots
+            if initial_value == final_value {
+                pre.entry(address).and_modify(|account| {
+                    account.storage.remove(&key);
+                });
+            } else {
+                modified = true;
+                if final_value != H256::zero() {
+                    storage.insert(key, final_value);
+                }
+            }
+        }
+
+        if modified {
+            post.insert(
+                address,
+                PrestateTracerAccount {
+                    balance,
+                    code,
+                    nonce,
+                    storage,
+                },
+            );
+        } else {
+            // if state is not modified, then no need to include into the pre state
+            pre.remove(&address);
+        }
+    }
+
+    PrestateTracerDiffModeResult { post, pre }
+}

--- a/evm_loader/lib/src/tracing/tracers/prestate_tracer/tracer.rs
+++ b/evm_loader/lib/src/tracing/tracers/prestate_tracer/tracer.rs
@@ -1,0 +1,71 @@
+use crate::tracing::tracers::prestate_tracer::state_diff::{
+    build_prestate_tracer_diff_mode_result, build_prestate_tracer_pre_state,
+};
+use crate::tracing::tracers::state_diff::StateDiffTracer;
+use crate::tracing::tracers::Tracer;
+use crate::tracing::TraceConfig;
+use crate::types::TxParams;
+use async_trait::async_trait;
+use evm_loader::evm::database::Database;
+use evm_loader::evm::tracing::{Event, EventListener};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// See <https://github.com/ethereum/go-ethereum/blob/master/eth/tracers/native/prestate.go#L57>
+pub struct PrestateTracer {
+    config: PrestateTracerConfig,
+    state_diff_tracer: StateDiffTracer,
+}
+
+impl PrestateTracer {
+    pub fn new(trace_config: TraceConfig, tx: &TxParams) -> Self {
+        PrestateTracer {
+            config: trace_config.into(),
+            state_diff_tracer: StateDiffTracer::new(tx),
+        }
+    }
+}
+
+impl From<TraceConfig> for PrestateTracerConfig {
+    fn from(trace_config: TraceConfig) -> Self {
+        trace_config
+            .tracer_config
+            .map(|tracer_config| {
+                serde_json::from_value(tracer_config)
+                    .expect("tracer_config should be PrestateTracerConfig")
+            })
+            .unwrap_or_default()
+    }
+}
+
+/// See <https://github.com/ethereum/go-ethereum/blob/master/eth/tracers/native/prestate.go#L72>
+#[derive(Serialize, Deserialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PrestateTracerConfig {
+    #[serde(default)]
+    pub diff_mode: bool,
+}
+
+#[async_trait(?Send)]
+impl EventListener for PrestateTracer {
+    async fn event(
+        &mut self,
+        executor_state: &impl Database,
+        event: Event,
+    ) -> evm_loader::error::Result<()> {
+        self.state_diff_tracer.event(executor_state, event).await
+    }
+}
+
+impl Tracer for PrestateTracer {
+    fn into_traces(self, emulator_gas_used: u64) -> Value {
+        let state_map = self.state_diff_tracer.into_state_map(emulator_gas_used);
+
+        if self.config.diff_mode {
+            serde_json::to_value(build_prestate_tracer_diff_mode_result(state_map))
+        } else {
+            serde_json::to_value(build_prestate_tracer_pre_state(state_map))
+        }
+        .expect("serialization should not fail")
+    }
+}

--- a/evm_loader/lib/src/tracing/tracers/state_diff.rs
+++ b/evm_loader/lib/src/tracing/tracers/state_diff.rs
@@ -1,0 +1,282 @@
+use arrayref::array_ref;
+use async_trait::async_trait;
+use std::collections::btree_map::Entry;
+use std::collections::BTreeMap;
+
+use ethnum::U256;
+use web3::types::{Bytes, H256};
+
+use crate::types::TxParams;
+use evm_loader::evm::database::Database;
+use evm_loader::evm::tracing::{Event, EventListener};
+use evm_loader::evm::{opcode_table, Buffer};
+use evm_loader::types::Address;
+use serde::{Deserialize, Serialize};
+
+pub type StateMap = BTreeMap<Address, States>;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Account {
+    pub balance: web3::types::U256,
+    pub code: Bytes,
+    pub nonce: u64,
+    pub storage: BTreeMap<H256, H256>,
+}
+
+impl Account {
+    pub fn is_empty(&self) -> bool {
+        self.balance.is_zero() && self.nonce == 0 && self.code.0.is_empty()
+    }
+}
+
+// TODO NDEV-2451 - Add operator balance diff to pre and post state
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct States {
+    pub post: Account,
+    pub pre: Account,
+}
+
+fn map_code(buffer: Buffer) -> Bytes {
+    buffer.to_vec().into()
+}
+
+pub(crate) fn to_web3_u256(v: U256) -> web3::types::U256 {
+    web3::types::U256::from(v.to_be_bytes())
+}
+
+#[derive(Default, Debug)]
+pub struct StateDiffTracer {
+    from: Address,
+    gas_price: web3::types::U256,
+    tx_fee: web3::types::U256,
+    depth: usize,
+    state_map: StateMap,
+}
+
+#[async_trait(?Send)]
+impl EventListener for StateDiffTracer {
+    /// See <https://github.com/ethereum/go-ethereum/blob/master/eth/tracers/native/prestate.go#L136>
+    async fn event(
+        &mut self,
+        executor_state: &impl Database,
+        event: Event,
+    ) -> evm_loader::error::Result<()> {
+        match event {
+            Event::BeginVM {
+                context,
+                chain_id,
+                opcode,
+                ..
+            } => {
+                self.depth += 1;
+
+                if self.depth == 1 {
+                    self.lookup_account(executor_state, chain_id, context.caller)
+                        .await?;
+                    self.lookup_account(executor_state, chain_id, context.contract)
+                        .await?;
+
+                    let value = to_web3_u256(context.value);
+
+                    self.state_map
+                        .entry(context.caller)
+                        .or_default()
+                        .pre
+                        .balance += value;
+
+                    self.state_map
+                        .entry(context.contract)
+                        .or_default()
+                        .pre
+                        .balance -= value;
+
+                    self.state_map.entry(context.caller).or_default().pre.nonce -= 1;
+
+                    if opcode == opcode_table::CREATE {
+                        self.state_map
+                            .entry(context.contract)
+                            .or_default()
+                            .pre
+                            .nonce -= 1;
+                    }
+                }
+            }
+            Event::EndVM {
+                context, chain_id, ..
+            } => {
+                if self.depth == 1 {
+                    for (address, states) in &mut self.state_map {
+                        states.post = Account {
+                            balance: to_web3_u256(
+                                executor_state.balance(*address, chain_id).await?,
+                            ),
+                            code: map_code(executor_state.code(*address).await?),
+                            nonce: executor_state.nonce(*address, chain_id).await?,
+                            storage: {
+                                let mut new_storage = BTreeMap::new();
+
+                                for key in states.pre.storage.keys() {
+                                    new_storage.insert(
+                                        *key,
+                                        H256::from(
+                                            executor_state
+                                                .storage(
+                                                    *address,
+                                                    U256::from_be_bytes(key.to_fixed_bytes()),
+                                                )
+                                                .await?,
+                                        ),
+                                    );
+                                }
+
+                                new_storage
+                            },
+                        };
+                    }
+
+                    self.state_map
+                        .entry(context.caller)
+                        .or_default()
+                        .post
+                        .balance -= self.tx_fee;
+                }
+
+                self.depth -= 1;
+            }
+            Event::BeginStep {
+                context,
+                chain_id,
+                opcode,
+                stack,
+                memory,
+                ..
+            } => {
+                let contract = context.contract;
+                match opcode {
+                    opcode_table::SLOAD | opcode_table::SSTORE if !stack.is_empty() => {
+                        let index = H256::from(&stack[stack.len() - 1]);
+                        self.lookup_storage(executor_state, contract, index).await?;
+                    }
+                    opcode_table::EXTCODECOPY
+                    | opcode_table::EXTCODEHASH
+                    | opcode_table::EXTCODESIZE
+                    | opcode_table::BALANCE
+                    | opcode_table::SELFDESTRUCT
+                        if !stack.is_empty() =>
+                    {
+                        let address = Address::from(*array_ref!(stack[stack.len() - 1], 12, 20));
+                        self.lookup_account(executor_state, chain_id, address)
+                            .await?;
+                    }
+                    opcode_table::DELEGATECALL
+                    | opcode_table::CALL
+                    | opcode_table::STATICCALL
+                    | opcode_table::CALLCODE
+                        if stack.len() >= 5 =>
+                    {
+                        let address = Address::from(*array_ref!(stack[stack.len() - 2], 12, 20));
+                        self.lookup_account(executor_state, chain_id, address)
+                            .await?;
+                    }
+                    opcode_table::CREATE => {
+                        let nonce = executor_state
+                            .nonce(contract, context.contract_chain_id)
+                            .await?;
+
+                        let created_address = Address::from_create(&contract, nonce);
+                        self.lookup_account(executor_state, chain_id, created_address)
+                            .await?;
+                    }
+                    opcode_table::CREATE2 if stack.len() >= 4 => {
+                        let offset = U256::from_be_bytes(stack[stack.len() - 2]).as_usize();
+                        let length = U256::from_be_bytes(stack[stack.len() - 3]).as_usize();
+                        let salt = stack[stack.len() - 4];
+
+                        let initialization_code = &memory[offset..offset + length];
+                        let created_address =
+                            Address::from_create2(&contract, &salt, initialization_code);
+                        self.lookup_account(executor_state, chain_id, created_address)
+                            .await?;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl StateDiffTracer {
+    pub fn new(tx: &TxParams) -> Self {
+        StateDiffTracer {
+            from: tx.from,
+            gas_price: tx.gas_price.map(to_web3_u256).unwrap_or_default(),
+            tx_fee: to_web3_u256(
+                tx.actual_gas_used
+                    .unwrap_or_default()
+                    .saturating_mul(tx.gas_price.unwrap_or_default()),
+            ),
+            ..StateDiffTracer::default()
+        }
+    }
+
+    /// See <https://github.com/ethereum/go-ethereum/blob/master/eth/tracers/native/prestate.go#L276>
+    async fn lookup_account(
+        &mut self,
+        executor_state: &impl Database,
+        chain_id: u64,
+        address: Address,
+    ) -> evm_loader::error::Result<()> {
+        match self.state_map.entry(address) {
+            Entry::Vacant(entry) => {
+                entry.insert(States {
+                    post: Default::default(),
+                    pre: Account {
+                        balance: to_web3_u256(executor_state.balance(address, chain_id).await?),
+                        code: map_code(executor_state.code(address).await?),
+                        nonce: executor_state.nonce(address, chain_id).await?,
+                        storage: BTreeMap::new(),
+                    },
+                });
+            }
+            Entry::Occupied(_) => {}
+        };
+        Ok(())
+    }
+
+    /// See <https://github.com/ethereum/go-ethereum/blob/master/eth/tracers/native/prestate.go#L292>
+    async fn lookup_storage(
+        &mut self,
+        executor_state: &impl Database,
+        address: Address,
+        index: H256,
+    ) -> evm_loader::error::Result<()> {
+        match self
+            .state_map
+            .entry(address)
+            .or_default()
+            .pre
+            .storage
+            .entry(index)
+        {
+            Entry::Vacant(entry) => {
+                entry.insert(H256::from(
+                    executor_state
+                        .storage(address, U256::from_be_bytes(index.to_fixed_bytes()))
+                        .await?,
+                ));
+            }
+            Entry::Occupied(_) => {}
+        };
+        Ok(())
+    }
+
+    pub fn into_state_map(mut self, emulator_gas_used: u64) -> StateMap {
+        if self.tx_fee.is_zero() {
+            self.state_map.entry(self.from).or_default().post.balance -=
+                web3::types::U256::from(emulator_gas_used).saturating_mul(self.gas_price);
+        }
+
+        self.state_map
+    }
+}

--- a/evm_loader/lib/src/types/mod.rs
+++ b/evm_loader/lib/src/types/mod.rs
@@ -37,7 +37,7 @@ pub struct AccessListItem {
 
 #[serde_as]
 #[skip_serializing_none]
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Default)]
 pub struct TxParams {
     pub nonce: Option<u64>,
     pub from: Address,
@@ -46,6 +46,7 @@ pub struct TxParams {
     pub data: Option<Vec<u8>>,
     pub value: Option<U256>,
     pub gas_limit: Option<U256>,
+    pub actual_gas_used: Option<U256>,
     pub gas_price: Option<U256>,
     pub access_list: Option<Vec<AccessListItem>>,
     pub chain_id: Option<u64>,

--- a/evm_loader/program/src/error.rs
+++ b/evm_loader/program/src/error.rs
@@ -228,7 +228,7 @@ macro_rules! Err {
 }
 
 #[must_use]
-fn format_revert_error(msg: &[u8]) -> Option<&str> {
+pub fn format_revert_error(msg: &[u8]) -> Option<&str> {
     if msg.starts_with(&[0x08, 0xc3, 0x79, 0xa0]) {
         // Error(string) function selector
         let msg = &msg[4..];
@@ -255,7 +255,7 @@ fn format_revert_error(msg: &[u8]) -> Option<&str> {
 }
 
 #[must_use]
-fn format_revert_panic(msg: &[u8]) -> Option<U256> {
+pub fn format_revert_panic(msg: &[u8]) -> Option<U256> {
     if msg.starts_with(&[0x4e, 0x48, 0x7b, 0x71]) {
         // Panic(uint256) function selector
         let msg = &msg[4..];

--- a/evm_loader/program/src/evm/opcode_table.rs
+++ b/evm_loader/program/src/evm/opcode_table.rs
@@ -4,7 +4,7 @@ use crate::evm::tracing::EventListener;
 use super::{database::Database, opcode::Action, Machine};
 
 macro_rules! opcode_table {
-    ($( $opcode:literal, $opname:literal, $op:path;)*) => {
+    ($($opcode:literal, $opname:ident, $op:path;)*) => {
         #[cfg(target_os = "solana")]
         type OpCode<B, T> = fn(&mut Machine<B, T>, &mut B) -> Result<Action>;
 
@@ -39,168 +39,192 @@ macro_rules! opcode_table {
         pub const OPNAMES: [&str; 256] = {
             let mut opnames: [&str; 256] = ["<invalid>"; 256];
 
-            $(opnames[$opcode as usize] = $opname;)*
+            $(opnames[$opcode as usize] = stringify!($opname);)*
 
             opnames
         };
+
+        #[repr(transparent)]
+        #[derive(PartialEq, Eq, Default)]
+        pub struct Opcode(pub u8);
+
+        #[cfg(not(target_os = "solana"))]
+        $(pub const $opname: Opcode = Opcode($opcode);)*
+
+        #[cfg(not(target_os = "solana"))]
+        impl From<u8> for Opcode {
+            fn from(opcode: u8) -> Self {
+                Opcode(opcode)
+            }
+        }
+
+        #[cfg(not(target_os = "solana"))]
+        impl serde::Serialize for Opcode {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                serializer.serialize_str(OPNAMES[self.0 as usize])
+            }
+        }
     }
 }
 
 opcode_table![
-        0x00, "STOP", Self::opcode_stop;
-        0x01, "ADD", Self::opcode_add;
-        0x02, "MUL", Self::opcode_mul;
-        0x03, "SUB", Self::opcode_sub;
-        0x04, "DIV", Self::opcode_div;
-        0x05, "SDIV", Self::opcode_sdiv;
-        0x06, "MOD", Self::opcode_mod;
-        0x07, "SMOD", Self::opcode_smod;
-        0x08, "ADDMOD", Self::opcode_addmod;
-        0x09, "MULMOD", Self::opcode_mulmod;
-        0x0A, "EXP", Self::opcode_exp;
-        0x0B, "SIGNEXTEND", Self::opcode_signextend;
+        0x00, STOP, Self::opcode_stop;
+        0x01, ADD, Self::opcode_add;
+        0x02, MUL, Self::opcode_mul;
+        0x03, SUB, Self::opcode_sub;
+        0x04, DIV, Self::opcode_div;
+        0x05, SDIV, Self::opcode_sdiv;
+        0x06, MOD, Self::opcode_mod;
+        0x07, SMOD, Self::opcode_smod;
+        0x08, ADDMOD, Self::opcode_addmod;
+        0x09, MULMOD, Self::opcode_mulmod;
+        0x0A, EXP, Self::opcode_exp;
+        0x0B, SIGNEXTEND, Self::opcode_signextend;
 
-        0x10, "LT", Self::opcode_lt;
-        0x11, "GT", Self::opcode_gt;
-        0x12, "SLT", Self::opcode_slt;
-        0x13, "SGT", Self::opcode_sgt;
-        0x14, "EQ", Self::opcode_eq;
-        0x15, "ISZERO", Self::opcode_iszero;
-        0x16, "AND", Self::opcode_and;
-        0x17, "OR", Self::opcode_or;
-        0x18, "XOR", Self::opcode_xor;
-        0x19, "NOT", Self::opcode_not;
-        0x1A, "BYTE", Self::opcode_byte;
-        0x1B, "SHL", Self::opcode_shl;
-        0x1C, "SHR", Self::opcode_shr;
-        0x1D, "SAR", Self::opcode_sar;
+        0x10, LT, Self::opcode_lt;
+        0x11, GT, Self::opcode_gt;
+        0x12, SLT, Self::opcode_slt;
+        0x13, SGT, Self::opcode_sgt;
+        0x14, EQ, Self::opcode_eq;
+        0x15, ISZERO, Self::opcode_iszero;
+        0x16, AND, Self::opcode_and;
+        0x17, OR, Self::opcode_or;
+        0x18, XOR, Self::opcode_xor;
+        0x19, NOT, Self::opcode_not;
+        0x1A, BYTE, Self::opcode_byte;
+        0x1B, SHL, Self::opcode_shl;
+        0x1C, SHR, Self::opcode_shr;
+        0x1D, SAR, Self::opcode_sar;
 
-        0x20, "KECCAK256", Self::opcode_sha3;
+        0x20, KECCAK256, Self::opcode_sha3;
 
-        0x30, "ADDRESS", Self::opcode_address;
-        0x31, "BALANCE", Self::opcode_balance;
-        0x32, "ORIGIN", Self::opcode_origin;
-        0x33, "CALLER", Self::opcode_caller;
-        0x34, "CALLVALUE", Self::opcode_callvalue;
-        0x35, "CALLDATALOAD", Self::opcode_calldataload;
-        0x36, "CALLDATASIZE", Self::opcode_calldatasize;
-        0x37, "CALLDATACOPY", Self::opcode_calldatacopy;
-        0x38, "CODESIZE", Self::opcode_codesize;
-        0x39, "CODECOPY", Self::opcode_codecopy;
-        0x3A, "GASPRICE", Self::opcode_gasprice;
-        0x3B, "EXTCODESIZE", Self::opcode_extcodesize;
-        0x3C, "EXTCODECOPY", Self::opcode_extcodecopy;
-        0x3D, "RETURNDATASIZE", Self::opcode_returndatasize;
-        0x3E, "RETURNDATACOPY", Self::opcode_returndatacopy;
-        0x3F, "EXTCODEHASH", Self::opcode_extcodehash;
-        0x40, "BLOCKHASH", Self::opcode_blockhash;
-        0x41, "COINBASE", Self::opcode_coinbase;
-        0x42, "TIMESTAMP", Self::opcode_timestamp;
-        0x43, "NUMBER", Self::opcode_number;
-        0x44, "PREVRANDAO", Self::opcode_difficulty;
-        0x45, "GASLIMIT", Self::opcode_gaslimit;
-        0x46, "CHAINID", Self::opcode_chainid;
-        0x47, "SELFBALANCE", Self::opcode_selfbalance;
-        0x48, "BASEFEE", Self::opcode_basefee;
+        0x30, ADDRESS, Self::opcode_address;
+        0x31, BALANCE, Self::opcode_balance;
+        0x32, ORIGIN, Self::opcode_origin;
+        0x33, CALLER, Self::opcode_caller;
+        0x34, CALLVALUE, Self::opcode_callvalue;
+        0x35, CALLDATALOAD, Self::opcode_calldataload;
+        0x36, CALLDATASIZE, Self::opcode_calldatasize;
+        0x37, CALLDATACOPY, Self::opcode_calldatacopy;
+        0x38, CODESIZE, Self::opcode_codesize;
+        0x39, CODECOPY, Self::opcode_codecopy;
+        0x3A, GASPRICE, Self::opcode_gasprice;
+        0x3B, EXTCODESIZE, Self::opcode_extcodesize;
+        0x3C, EXTCODECOPY, Self::opcode_extcodecopy;
+        0x3D, RETURNDATASIZE, Self::opcode_returndatasize;
+        0x3E, RETURNDATACOPY, Self::opcode_returndatacopy;
+        0x3F, EXTCODEHASH, Self::opcode_extcodehash;
+        0x40, BLOCKHASH, Self::opcode_blockhash;
+        0x41, COINBASE, Self::opcode_coinbase;
+        0x42, TIMESTAMP, Self::opcode_timestamp;
+        0x43, NUMBER, Self::opcode_number;
+        0x44, PREVRANDAO, Self::opcode_difficulty;
+        0x45, GASLIMIT, Self::opcode_gaslimit;
+        0x46, CHAINID, Self::opcode_chainid;
+        0x47, SELFBALANCE, Self::opcode_selfbalance;
+        0x48, BASEFEE, Self::opcode_basefee;
 
-        0x50, "POP", Self::opcode_pop;
-        0x51, "MLOAD", Self::opcode_mload;
-        0x52, "MSTORE", Self::opcode_mstore;
-        0x53, "MSTORE8", Self::opcode_mstore8;
-        0x54, "SLOAD", Self::opcode_sload;
-        0x55, "SSTORE", Self::opcode_sstore;
-        0x56, "JUMP", Self::opcode_jump;
-        0x57, "JUMPI", Self::opcode_jumpi;
-        0x58, "PC", Self::opcode_pc;
-        0x59, "MSIZE", Self::opcode_msize;
-        0x5A, "GAS", Self::opcode_gas;
-        0x5B, "JUMPDEST", Self::opcode_jumpdest;
+        0x50, POP, Self::opcode_pop;
+        0x51, MLOAD, Self::opcode_mload;
+        0x52, MSTORE, Self::opcode_mstore;
+        0x53, MSTORE8, Self::opcode_mstore8;
+        0x54, SLOAD, Self::opcode_sload;
+        0x55, SSTORE, Self::opcode_sstore;
+        0x56, JUMP, Self::opcode_jump;
+        0x57, JUMPI, Self::opcode_jumpi;
+        0x58, PC, Self::opcode_pc;
+        0x59, MSIZE, Self::opcode_msize;
+        0x5A, GAS, Self::opcode_gas;
+        0x5B, JUMPDEST, Self::opcode_jumpdest;
 
-        0x5F, "PUSH0", Self::opcode_push_0;
-        0x60, "PUSH1", Self::opcode_push_1;
-        0x61, "PUSH2", Self::opcode_push_2_31::<2>;
-        0x62, "PUSH3", Self::opcode_push_2_31::<3>;
-        0x63, "PUSH4", Self::opcode_push_2_31::<4>;
-        0x64, "PUSH5", Self::opcode_push_2_31::<5>;
-        0x65, "PUSH6", Self::opcode_push_2_31::<6>;
-        0x66, "PUSH7", Self::opcode_push_2_31::<7>;
-        0x67, "PUSH8", Self::opcode_push_2_31::<8>;
-        0x68, "PUSH9", Self::opcode_push_2_31::<9>;
-        0x69, "PUSH10", Self::opcode_push_2_31::<10>;
-        0x6A, "PUSH11", Self::opcode_push_2_31::<11>;
-        0x6B, "PUSH12", Self::opcode_push_2_31::<12>;
-        0x6C, "PUSH13", Self::opcode_push_2_31::<13>;
-        0x6D, "PUSH14", Self::opcode_push_2_31::<14>;
-        0x6E, "PUSH15", Self::opcode_push_2_31::<15>;
-        0x6F, "PUSH16", Self::opcode_push_2_31::<16>;
-        0x70, "PUSH17", Self::opcode_push_2_31::<17>;
-        0x71, "PUSH18", Self::opcode_push_2_31::<18>;
-        0x72, "PUSH19", Self::opcode_push_2_31::<19>;
-        0x73, "PUSH20", Self::opcode_push_2_31::<20>;
-        0x74, "PUSH21", Self::opcode_push_2_31::<21>;
-        0x75, "PUSH22", Self::opcode_push_2_31::<22>;
-        0x76, "PUSH23", Self::opcode_push_2_31::<23>;
-        0x77, "PUSH24", Self::opcode_push_2_31::<24>;
-        0x78, "PUSH25", Self::opcode_push_2_31::<25>;
-        0x79, "PUSH26", Self::opcode_push_2_31::<26>;
-        0x7A, "PUSH27", Self::opcode_push_2_31::<27>;
-        0x7B, "PUSH28", Self::opcode_push_2_31::<28>;
-        0x7C, "PUSH29", Self::opcode_push_2_31::<29>;
-        0x7D, "PUSH30", Self::opcode_push_2_31::<30>;
-        0x7E, "PUSH31", Self::opcode_push_2_31::<31>;
-        0x7F, "PUSH32", Self::opcode_push_32;
+        0x5F, PUSH0, Self::opcode_push_0;
+        0x60, PUSH1, Self::opcode_push_1;
+        0x61, PUSH2, Self::opcode_push_2_31::<2>;
+        0x62, PUSH3, Self::opcode_push_2_31::<3>;
+        0x63, PUSH4, Self::opcode_push_2_31::<4>;
+        0x64, PUSH5, Self::opcode_push_2_31::<5>;
+        0x65, PUSH6, Self::opcode_push_2_31::<6>;
+        0x66, PUSH7, Self::opcode_push_2_31::<7>;
+        0x67, PUSH8, Self::opcode_push_2_31::<8>;
+        0x68, PUSH9, Self::opcode_push_2_31::<9>;
+        0x69, PUSH10, Self::opcode_push_2_31::<10>;
+        0x6A, PUSH11, Self::opcode_push_2_31::<11>;
+        0x6B, PUSH12, Self::opcode_push_2_31::<12>;
+        0x6C, PUSH13, Self::opcode_push_2_31::<13>;
+        0x6D, PUSH14, Self::opcode_push_2_31::<14>;
+        0x6E, PUSH15, Self::opcode_push_2_31::<15>;
+        0x6F, PUSH16, Self::opcode_push_2_31::<16>;
+        0x70, PUSH17, Self::opcode_push_2_31::<17>;
+        0x71, PUSH18, Self::opcode_push_2_31::<18>;
+        0x72, PUSH19, Self::opcode_push_2_31::<19>;
+        0x73, PUSH20, Self::opcode_push_2_31::<20>;
+        0x74, PUSH21, Self::opcode_push_2_31::<21>;
+        0x75, PUSH22, Self::opcode_push_2_31::<22>;
+        0x76, PUSH23, Self::opcode_push_2_31::<23>;
+        0x77, PUSH24, Self::opcode_push_2_31::<24>;
+        0x78, PUSH25, Self::opcode_push_2_31::<25>;
+        0x79, PUSH26, Self::opcode_push_2_31::<26>;
+        0x7A, PUSH27, Self::opcode_push_2_31::<27>;
+        0x7B, PUSH28, Self::opcode_push_2_31::<28>;
+        0x7C, PUSH29, Self::opcode_push_2_31::<29>;
+        0x7D, PUSH30, Self::opcode_push_2_31::<30>;
+        0x7E, PUSH31, Self::opcode_push_2_31::<31>;
+        0x7F, PUSH32, Self::opcode_push_32;
 
-        0x80, "DUP1", Self::opcode_dup_1_16::<1>;
-        0x81, "DUP2", Self::opcode_dup_1_16::<2>;
-        0x82, "DUP3", Self::opcode_dup_1_16::<3>;
-        0x83, "DUP4", Self::opcode_dup_1_16::<4>;
-        0x84, "DUP5", Self::opcode_dup_1_16::<5>;
-        0x85, "DUP6", Self::opcode_dup_1_16::<6>;
-        0x86, "DUP7", Self::opcode_dup_1_16::<7>;
-        0x87, "DUP8", Self::opcode_dup_1_16::<8>;
-        0x88, "DUP9", Self::opcode_dup_1_16::<9>;
-        0x89, "DUP10", Self::opcode_dup_1_16::<10>;
-        0x8A, "DUP11", Self::opcode_dup_1_16::<11>;
-        0x8B, "DUP12", Self::opcode_dup_1_16::<12>;
-        0x8C, "DUP13", Self::opcode_dup_1_16::<13>;
-        0x8D, "DUP14", Self::opcode_dup_1_16::<14>;
-        0x8E, "DUP15", Self::opcode_dup_1_16::<15>;
-        0x8F, "DUP16", Self::opcode_dup_1_16::<16>;
+        0x80, DUP1, Self::opcode_dup_1_16::<1>;
+        0x81, DUP2, Self::opcode_dup_1_16::<2>;
+        0x82, DUP3, Self::opcode_dup_1_16::<3>;
+        0x83, DUP4, Self::opcode_dup_1_16::<4>;
+        0x84, DUP5, Self::opcode_dup_1_16::<5>;
+        0x85, DUP6, Self::opcode_dup_1_16::<6>;
+        0x86, DUP7, Self::opcode_dup_1_16::<7>;
+        0x87, DUP8, Self::opcode_dup_1_16::<8>;
+        0x88, DUP9, Self::opcode_dup_1_16::<9>;
+        0x89, DUP10, Self::opcode_dup_1_16::<10>;
+        0x8A, DUP11, Self::opcode_dup_1_16::<11>;
+        0x8B, DUP12, Self::opcode_dup_1_16::<12>;
+        0x8C, DUP13, Self::opcode_dup_1_16::<13>;
+        0x8D, DUP14, Self::opcode_dup_1_16::<14>;
+        0x8E, DUP15, Self::opcode_dup_1_16::<15>;
+        0x8F, DUP16, Self::opcode_dup_1_16::<16>;
 
-        0x90, "SWAP1", Self::opcode_swap_1_16::<1>;
-        0x91, "SWAP2", Self::opcode_swap_1_16::<2>;
-        0x92, "SWAP3", Self::opcode_swap_1_16::<3>;
-        0x93, "SWAP4", Self::opcode_swap_1_16::<4>;
-        0x94, "SWAP5", Self::opcode_swap_1_16::<5>;
-        0x95, "SWAP6", Self::opcode_swap_1_16::<6>;
-        0x96, "SWAP7", Self::opcode_swap_1_16::<7>;
-        0x97, "SWAP8", Self::opcode_swap_1_16::<8>;
-        0x98, "SWAP9", Self::opcode_swap_1_16::<9>;
-        0x99, "SWAP10", Self::opcode_swap_1_16::<10>;
-        0x9A, "SWAP11", Self::opcode_swap_1_16::<11>;
-        0x9B, "SWAP12", Self::opcode_swap_1_16::<12>;
-        0x9C, "SWAP13", Self::opcode_swap_1_16::<13>;
-        0x9D, "SWAP14", Self::opcode_swap_1_16::<14>;
-        0x9E, "SWAP15", Self::opcode_swap_1_16::<15>;
-        0x9F, "SWAP16", Self::opcode_swap_1_16::<16>;
+        0x90, SWAP1, Self::opcode_swap_1_16::<1>;
+        0x91, SWAP2, Self::opcode_swap_1_16::<2>;
+        0x92, SWAP3, Self::opcode_swap_1_16::<3>;
+        0x93, SWAP4, Self::opcode_swap_1_16::<4>;
+        0x94, SWAP5, Self::opcode_swap_1_16::<5>;
+        0x95, SWAP6, Self::opcode_swap_1_16::<6>;
+        0x96, SWAP7, Self::opcode_swap_1_16::<7>;
+        0x97, SWAP8, Self::opcode_swap_1_16::<8>;
+        0x98, SWAP9, Self::opcode_swap_1_16::<9>;
+        0x99, SWAP10, Self::opcode_swap_1_16::<10>;
+        0x9A, SWAP11, Self::opcode_swap_1_16::<11>;
+        0x9B, SWAP12, Self::opcode_swap_1_16::<12>;
+        0x9C, SWAP13, Self::opcode_swap_1_16::<13>;
+        0x9D, SWAP14, Self::opcode_swap_1_16::<14>;
+        0x9E, SWAP15, Self::opcode_swap_1_16::<15>;
+        0x9F, SWAP16, Self::opcode_swap_1_16::<16>;
 
-        0xA0, "LOG0", Self::opcode_log_0_4::<0>;
-        0xA1, "LOG1", Self::opcode_log_0_4::<1>;
-        0xA2, "LOG2", Self::opcode_log_0_4::<2>;
-        0xA3, "LOG3", Self::opcode_log_0_4::<3>;
-        0xA4, "LOG4", Self::opcode_log_0_4::<4>;
+        0xA0, LOG0, Self::opcode_log_0_4::<0>;
+        0xA1, LOG1, Self::opcode_log_0_4::<1>;
+        0xA2, LOG2, Self::opcode_log_0_4::<2>;
+        0xA3, LOG3, Self::opcode_log_0_4::<3>;
+        0xA4, LOG4, Self::opcode_log_0_4::<4>;
 
-        0xF0, "CREATE", Self::opcode_create;
-        0xF1, "CALL", Self::opcode_call;
-        0xF2, "CALLCODE", Self::opcode_callcode;
-        0xF3, "RETURN", Self::opcode_return;
-        0xF4, "DELEGATECALL", Self::opcode_delegatecall;
-        0xF5, "CREATE2", Self::opcode_create2;
+        0xF0, CREATE, Self::opcode_create;
+        0xF1, CALL, Self::opcode_call;
+        0xF2, CALLCODE, Self::opcode_callcode;
+        0xF3, RETURN, Self::opcode_return;
+        0xF4, DELEGATECALL, Self::opcode_delegatecall;
+        0xF5, CREATE2, Self::opcode_create2;
 
-        0xFA, "STATICCALL", Self::opcode_staticcall;
+        0xFA, STATICCALL, Self::opcode_staticcall;
 
-        0xFD, "REVERT", Self::opcode_revert;
-        0xFE, "INVALID", Self::opcode_invalid;
+        0xFD, REVERT, Self::opcode_revert;
+        0xFE, INVALID, Self::opcode_invalid;
 
-        0xFF, "SELFDESTRUCT", Self::opcode_selfdestruct;
+        0xFF, SELFDESTRUCT, Self::opcode_selfdestruct;
 ];

--- a/evm_loader/program/src/evm/tracing.rs
+++ b/evm_loader/program/src/evm/tracing.rs
@@ -1,38 +1,51 @@
+use maybe_async::maybe_async;
+
 use super::{Context, ExitStatus};
 use crate::evm::database::Database;
-use ethnum::U256;
+use crate::evm::opcode_table::Opcode;
 
 pub struct NoopEventListener;
 
+#[maybe_async(?Send)]
 pub trait EventListener {
-    fn event(&mut self, executor_state: &impl Database, event: Event);
+    async fn event(
+        &mut self,
+        executor_state: &impl Database,
+        event: Event,
+    ) -> crate::error::Result<()>;
 }
 
+#[maybe_async(?Send)]
 impl EventListener for NoopEventListener {
-    fn event(&mut self, _executor_state: &impl Database, _event: Event) {}
+    async fn event(
+        &mut self,
+        _executor_state: &impl Database,
+        _event: Event,
+    ) -> crate::error::Result<()> {
+        Ok(())
+    }
 }
 
 /// Trace event
 pub enum Event {
     BeginVM {
         context: Context,
-        code: Vec<u8>,
+        chain_id: u64,
+        input: Vec<u8>,
+        opcode: Opcode,
     },
     EndVM {
+        context: Context,
+        chain_id: u64,
         status: ExitStatus,
     },
     BeginStep {
-        opcode: u8,
+        context: Context,
+        chain_id: u64,
+        opcode: Opcode,
         pc: usize,
         stack: Vec<[u8; 32]>,
         memory: Vec<u8>,
-    },
-    EndStep {
-        gas_used: u64,
-        return_data: Option<Vec<u8>>,
-    },
-    StorageAccess {
-        index: U256,
-        value: [u8; 32],
+        return_data: Vec<u8>,
     },
 }


### PR DESCRIPTION
This PR fixes bugs related to the existing `struct_logger` tracer and implements 3 new tracers:
- [`debug_traceTransaction`](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debugtracetransaction)([`prestateTracer`](https://geth.ethereum.org/docs/developers/evm-tracing/built-in-tracers#prestate-tracer) with both `pre` and `diffMode` modes and [`call_tracer`](https://geth.ethereum.org/docs/developers/evm-tracing/built-in-tracers#call-tracer) with `withLog` and `onlyTopCall` options)
- [`trace_replayTransaction`](https://openethereum.github.io/JSONRPC-trace-module#trace_replaytransaction)(`stateDiff` tracer)