### PR TITLE
NDEV-2750 Print information about completed EVM steps

### DIFF
--- a/evm_loader/lib/src/commands/get_holder.rs
+++ b/evm_loader/lib/src/commands/get_holder.rs
@@ -46,6 +46,8 @@ pub struct GetHolderResponse {
 
     #[serde_as(as = "Option<Vec<DisplayFromStr>>")]
     pub accounts: Option<Vec<Pubkey>>,
+
+    pub steps_executed: u64,
 }
 
 impl GetHolderResponse {
@@ -119,6 +121,7 @@ pub fn read_holder(program_id: &Pubkey, info: AccountInfo) -> NeonResult<GetHold
                 tx: Some(state.trx().hash()),
                 chain_id: state.trx().chain_id(),
                 accounts: Some(accounts),
+                steps_executed: state.steps_executed(),
             })
         }
         _ => Err(ProgramError::InvalidAccountData.into()),

--- a/evm_loader/program/src/instruction/transaction_step.rs
+++ b/evm_loader/program/src/instruction/transaction_step.rs
@@ -62,6 +62,8 @@ pub fn do_continue<'a>(
 
     let account_storage = ProgramAccountStorage::new(accounts)?;
     let (mut backend, mut evm) = if reset {
+        storage.reset_steps_executed();
+
         let mut backend = ExecutorState::new(&account_storage);
         let evm = Machine::new(storage.trx(), storage.trx_origin(), &mut backend, None)?;
         (backend, evm)
@@ -97,6 +99,13 @@ fn finalize<'a>(
     mut gasometer: Gasometer,
 ) -> Result<()> {
     debug_print!("finalize");
+
+    storage.increment_steps_executed(steps_executed)?;
+    log_data(&[
+        b"STEPS",
+        &steps_executed.to_le_bytes(),
+        &storage.steps_executed().to_le_bytes(),
+    ]);
 
     if steps_executed > 0 {
         accounts.transfer_treasury_payment()?;


### PR DESCRIPTION
Add a new message to the Solana logs: `["STEPS", steps_in_current_iteration, steps_total]`
Add the value `steps_executed` to the `get_holder` API response.