### PR TITLE
Fix CALLCODE context

### DIFF
--- a/evm_loader/program/src/evm/opcode.rs
+++ b/evm_loader/program/src/evm/opcode.rs
@@ -1171,6 +1171,7 @@ impl<B: Database, T: EventListener> Machine<B, T> {
         let context = Context {
             value,
             code_address: Some(address),
+            caller: self.context.contract,
             ..self.context
         };
 


### PR DESCRIPTION
The `msg.sender` property should be set to the contract that calls via CALLCODE. 
This is missing in the current CALLCODE implementation.