### PR TITLE
NDEV-2841: Extract pda_seeds module

### DIFF
--- a/evm_loader/lib/src/commands/init_environment.rs
+++ b/evm_loader/lib/src/commands/init_environment.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::NeonResult;
 
 use crate::rpc::CloneRpcClient;
+use evm_loader::pda_seeds::AUTHORITY_SEEDS;
 use {
     crate::{
         commands::{
@@ -202,7 +203,7 @@ pub async fn execute(
     executor.checkpoint(config.commitment).await?;
 
     //====================== Create 'Deposit' NEON-token balance ======================================================
-    let (deposit_authority, _) = Pubkey::find_program_address(&[b"Deposit"], &config.evm_loader);
+    let (deposit_authority, _) = Pubkey::find_program_address(AUTHORITY_SEEDS, &config.evm_loader);
     let chains = super::get_config::read_chains(client, config.evm_loader).await?;
     for chain in chains {
         let pool = get_associated_token_address(&deposit_authority, &chain.token);

--- a/evm_loader/program/src/account/ether_contract.rs
+++ b/evm_loader/program/src/account/ether_contract.rs
@@ -1,3 +1,4 @@
+use crate::pda_seeds::contract_account_seeds;
 use crate::{
     account::TAG_EMPTY,
     account_storage::KeysCache,
@@ -15,9 +16,7 @@ use std::{
 
 use crate::config::STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT;
 
-use super::{
-    AccountHeader, AccountsDB, ACCOUNT_PREFIX_LEN, ACCOUNT_SEED_VERSION, TAG_ACCOUNT_CONTRACT,
-};
+use super::{AccountHeader, AccountsDB, ACCOUNT_PREFIX_LEN, TAG_ACCOUNT_CONTRACT};
 
 #[derive(Eq, PartialEq)]
 pub enum AllocateResult {
@@ -103,9 +102,15 @@ impl<'a> ContractAccount<'a> {
         let operator = accounts.operator();
 
         if system_program::check_id(info.owner) {
-            let seeds: &[&[u8]] = &[&[ACCOUNT_SEED_VERSION], address.as_bytes(), &[bump_seed]];
             let space = required_size.min(MAX_PERMITTED_DATA_INCREASE);
-            system.create_pda_account(&crate::ID, operator, info, seeds, space, rent)?;
+            system.create_pda_account(
+                &crate::ID,
+                operator,
+                info,
+                &contract_account_seeds(&address, &[bump_seed]),
+                space,
+                rent,
+            )?;
         } else if crate::check_id(info.owner) {
             super::validate_tag(&crate::ID, info, TAG_EMPTY)?;
 

--- a/evm_loader/program/src/account/treasury.rs
+++ b/evm_loader/program/src/account/treasury.rs
@@ -1,5 +1,6 @@
-use crate::config::TREASURY_POOL_SEED;
 use crate::error::{Error, Result};
+use crate::pda_seeds::main_treasury_seeds;
+use crate::pda_seeds::with_treasury_seeds;
 use solana_program::{account_info::AccountInfo, program_pack::Pack, pubkey::Pubkey};
 use std::ops::Deref;
 
@@ -29,10 +30,9 @@ impl<'a> Treasury<'a> {
 
     #[must_use]
     pub fn address(program_id: &Pubkey, index: u32) -> (Pubkey, u8) {
-        Pubkey::find_program_address(
-            &[TREASURY_POOL_SEED.as_bytes(), &index.to_le_bytes()],
-            program_id,
-        )
+        with_treasury_seeds(index, &[], |seeds| {
+            Pubkey::find_program_address(seeds, program_id)
+        })
     }
 
     #[must_use]
@@ -73,7 +73,7 @@ impl<'a> MainTreasury<'a> {
 
     #[must_use]
     pub fn address(program_id: &Pubkey) -> (Pubkey, u8) {
-        Pubkey::find_program_address(&[TREASURY_POOL_SEED.as_bytes()], program_id)
+        Pubkey::find_program_address(&main_treasury_seeds(&[]), program_id)
     }
 
     #[must_use]

--- a/evm_loader/program/src/account_storage/apply.rs
+++ b/evm_loader/program/src/account_storage/apply.rs
@@ -3,15 +3,15 @@ use std::collections::HashMap;
 use ethnum::U256;
 use solana_program::instruction::Instruction;
 use solana_program::program::{invoke_signed_unchecked, invoke_unchecked};
+use solana_program::program_error::ProgramError;
 use solana_program::system_program;
 
 use crate::account::{AllocateResult, BalanceAccount, ContractAccount, StorageCell};
 use crate::account_storage::{ProgramAccountStorage, FAKE_OPERATOR};
-use crate::config::{
-    ACCOUNT_SEED_VERSION, PAYMENT_TO_TREASURE, STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT,
-};
+use crate::config::{PAYMENT_TO_TREASURE, STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT};
 use crate::error::Result;
 use crate::executor::Action;
+use crate::pda_seeds::{contract_account_seeds, with_slice_of_slice_of_slice};
 use crate::types::Address;
 
 impl<'a> ProgramAccountStorage<'a> {
@@ -136,12 +136,6 @@ impl<'a> ProgramAccountStorage<'a> {
                     seeds,
                     ..
                 } => {
-                    let seeds = seeds
-                        .iter()
-                        .map(|s| s.iter().map(|s| s.as_slice()).collect::<Vec<_>>())
-                        .collect::<Vec<_>>();
-                    let seeds = seeds.iter().map(|s| s.as_slice()).collect::<Vec<_>>();
-
                     let mut accounts_info = Vec::with_capacity(accounts.len() + 1);
 
                     let program = self.accounts.get(&program_id).clone();
@@ -161,11 +155,14 @@ impl<'a> ProgramAccountStorage<'a> {
                         data,
                     };
 
-                    if !seeds.is_empty() {
-                        invoke_signed_unchecked(&instruction, &accounts_info, &seeds)?;
-                    } else {
-                        invoke_unchecked(&instruction, &accounts_info)?;
-                    }
+                    with_slice_of_slice_of_slice(&seeds, |seeds| {
+                        if !seeds.is_empty() {
+                            invoke_signed_unchecked(&instruction, &accounts_info, &seeds)?;
+                        } else {
+                            invoke_unchecked(&instruction, &accounts_info)?;
+                        }
+                        Ok::<(), ProgramError>(())
+                    })?;
                 }
             }
         }
@@ -219,11 +216,15 @@ impl<'a> ProgramAccountStorage<'a> {
 
                 if system_program::check_id(account.owner) {
                     let (_, bump) = self.keys.contract_with_bump_seed(&crate::ID, address);
-                    let sign: &[&[u8]] = &[&[ACCOUNT_SEED_VERSION], address.as_bytes(), &[bump]];
 
                     let len = values.len();
-                    let mut storage =
-                        StorageCell::create(cell_address, len, &self.accounts, sign, &self.rent)?;
+                    let mut storage = StorageCell::create(
+                        cell_address,
+                        len,
+                        &self.accounts,
+                        &contract_account_seeds(&address, &[bump]),
+                        &self.rent,
+                    )?;
                     let mut cells = storage.cells_mut();
 
                     assert_eq!(cells.len(), len);

--- a/evm_loader/program/src/executor/precompile_extension/metaplex.rs
+++ b/evm_loader/program/src/executor/precompile_extension/metaplex.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unnecessary_wraps)]
+use crate::pda_seeds::contract_account_seeds_vec;
 use std::convert::{Into, TryInto};
 
 use ethnum::U256;
@@ -13,7 +14,6 @@ use mpl_token_metadata::{
 use solana_program::pubkey::Pubkey;
 
 use crate::{
-    account::ACCOUNT_SEED_VERSION,
     account_storage::FAKE_OPERATOR,
     error::{Error, Result},
     evm::database::Database,
@@ -189,12 +189,6 @@ async fn create_metadata<State: Database>(
     let signer = context.caller;
     let (signer_pubkey, bump_seed) = state.contract_pubkey(signer);
 
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        signer.as_bytes().to_vec(),
-        vec![bump_seed],
-    ];
-
     let (metadata_pubkey, _) = Metadata::find_pda(&mint);
 
     let instruction = CreateMetadataAccountV3Builder::new()
@@ -228,7 +222,12 @@ async fn create_metadata<State: Database>(
 
     let fee = state.rent().minimum_balance(MAX_METADATA_LEN) + CREATE_FEE;
     state
-        .queue_external_instruction(instruction, vec![seeds], fee, true)
+        .queue_external_instruction(
+            instruction,
+            vec![contract_account_seeds_vec(&signer, bump_seed)],
+            fee,
+            true,
+        )
         .await?;
 
     Ok(metadata_pubkey.to_bytes().to_vec())
@@ -243,12 +242,6 @@ async fn create_master_edition<State: Database>(
 ) -> Result<Vec<u8>> {
     let signer = context.caller;
     let (signer_pubkey, bump_seed) = state.contract_pubkey(signer);
-
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        signer.as_bytes().to_vec(),
-        vec![bump_seed],
-    ];
 
     let (metadata_pubkey, _) = Metadata::find_pda(&mint);
     let (edition_pubkey, _) = MasterEdition::find_pda(&mint);
@@ -270,7 +263,12 @@ async fn create_master_edition<State: Database>(
 
     let fee = state.rent().minimum_balance(MAX_MASTER_EDITION_LEN) + CREATE_FEE;
     state
-        .queue_external_instruction(instruction, vec![seeds], fee, true)
+        .queue_external_instruction(
+            instruction,
+            vec![contract_account_seeds_vec(&signer, bump_seed)],
+            fee,
+            true,
+        )
         .await?;
 
     Ok(edition_pubkey.to_bytes().to_vec())

--- a/evm_loader/program/src/executor/precompile_extension/neon_token.rs
+++ b/evm_loader/program/src/executor/precompile_extension/neon_token.rs
@@ -6,6 +6,7 @@ use maybe_async::maybe_async;
 use solana_program::{account_info::IntoAccountInfo, program_pack::Pack, pubkey::Pubkey};
 use spl_associated_token_account::get_associated_token_address;
 
+use crate::pda_seeds::{PubkeyExt, AUTHORITY_SEEDS};
 use crate::{
     account::token,
     account_storage::FAKE_OPERATOR,
@@ -117,7 +118,8 @@ async fn withdraw<State: Database>(
             .await?;
     }
 
-    let (authority, bump_seed) = Pubkey::find_program_address(&[b"Deposit"], state.program_id());
+    let (authority, transfer_seeds) =
+        Pubkey::find_program_address_with_seeds(AUTHORITY_SEEDS, state.program_id());
     let pool = get_associated_token_address(&authority, &mint_address);
 
     let transfer = spl_token::instruction::transfer_checked(
@@ -130,7 +132,6 @@ async fn withdraw<State: Database>(
         spl_amount.as_u64(),
         mint_data.decimals,
     )?;
-    let transfer_seeds = vec![b"Deposit".to_vec(), vec![bump_seed]];
 
     state.burn(source, chain_id, value).await?;
     state

--- a/evm_loader/program/src/executor/precompile_extension/spl_token.rs
+++ b/evm_loader/program/src/executor/precompile_extension/spl_token.rs
@@ -1,5 +1,6 @@
 use std::convert::{Into, TryInto};
 
+use crate::pda_seeds::external_authority_seeds;
 use ethnum::U256;
 use maybe_async::maybe_async;
 use solana_program::{
@@ -7,8 +8,10 @@ use solana_program::{
 };
 
 use super::create_account;
+use crate::pda_seeds::contract_account_seeds_vec;
+use crate::pda_seeds::spl_token_seeds;
+use crate::pda_seeds::PubkeyExt;
 use crate::{
-    account::ACCOUNT_SEED_VERSION,
     account_storage::FAKE_OPERATOR,
     error::{Error, Result},
     evm::database::Database,
@@ -270,13 +273,8 @@ async fn initialize_mint<State: Database>(
     let signer = context.caller;
     let (signer_pubkey, _) = state.contract_pubkey(signer);
 
-    let (mint_key, bump_seed) = Pubkey::find_program_address(
-        &[
-            &[ACCOUNT_SEED_VERSION],
-            b"ContractData",
-            signer.as_bytes(),
-            seed,
-        ],
+    let (mint_key, seeds) = Pubkey::find_program_address_with_seeds(
+        &spl_token_seeds(&signer, seed),
         state.program_id(),
     );
 
@@ -284,14 +282,6 @@ async fn initialize_mint<State: Database>(
     if !system_program::check_id(&account.owner) {
         return Err(Error::AccountInvalidOwner(mint_key, system_program::ID));
     }
-
-    let seeds: Vec<Vec<u8>> = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        b"ContractData".to_vec(),
-        signer.as_bytes().to_vec(),
-        seed.to_vec(),
-        vec![bump_seed],
-    ];
 
     create_account(
         state,
@@ -327,13 +317,8 @@ async fn initialize_account<State: Database>(
     let signer = context.caller;
     let (signer_pubkey, _) = state.contract_pubkey(signer);
 
-    let (account_key, bump_seed) = Pubkey::find_program_address(
-        &[
-            &[ACCOUNT_SEED_VERSION],
-            b"ContractData",
-            signer.as_bytes(),
-            seed,
-        ],
+    let (account_key, seeds) = Pubkey::find_program_address_with_seeds(
+        &spl_token_seeds(&signer, seed),
         state.program_id(),
     );
 
@@ -341,14 +326,6 @@ async fn initialize_account<State: Database>(
     if !system_program::check_id(&account.owner) {
         return Err(Error::AccountInvalidOwner(account_key, system_program::ID));
     }
-
-    let seeds: Vec<Vec<u8>> = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        b"ContractData".to_vec(),
-        signer.as_bytes().to_vec(),
-        seed.to_vec(),
-        vec![bump_seed],
-    ];
 
     create_account(
         state,
@@ -381,12 +358,6 @@ async fn close_account<State: Database>(
     let signer = context.caller;
     let (signer_pubkey, bump_seed) = state.contract_pubkey(signer);
 
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        signer.as_bytes().to_vec(),
-        vec![bump_seed],
-    ];
-
     let close_account = spl_token::instruction::close_account(
         &spl_token::ID,
         &account,
@@ -395,7 +366,12 @@ async fn close_account<State: Database>(
         &[],
     )?;
     state
-        .queue_external_instruction(close_account, vec![seeds], 0, true)
+        .queue_external_instruction(
+            close_account,
+            vec![contract_account_seeds_vec(&signer, bump_seed)],
+            0,
+            true,
+        )
         .await?;
 
     Ok(vec![])
@@ -412,12 +388,6 @@ async fn approve<State: Database>(
     let signer = context.caller;
     let (signer_pubkey, bump_seed) = state.contract_pubkey(signer);
 
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        signer.as_bytes().to_vec(),
-        vec![bump_seed],
-    ];
-
     let approve = spl_token::instruction::approve(
         &spl_token::ID,
         &source,
@@ -427,7 +397,12 @@ async fn approve<State: Database>(
         amount,
     )?;
     state
-        .queue_external_instruction(approve, vec![seeds], 0, true)
+        .queue_external_instruction(
+            approve,
+            vec![contract_account_seeds_vec(&signer, bump_seed)],
+            0,
+            true,
+        )
         .await?;
 
     Ok(vec![])
@@ -442,15 +417,14 @@ async fn revoke<State: Database>(
     let signer = context.caller;
     let (signer_pubkey, bump_seed) = state.contract_pubkey(signer);
 
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        signer.as_bytes().to_vec(),
-        vec![bump_seed],
-    ];
-
     let revoke = spl_token::instruction::revoke(&spl_token::ID, &account, &signer_pubkey, &[])?;
     state
-        .queue_external_instruction(revoke, vec![seeds], 0, true)
+        .queue_external_instruction(
+            revoke,
+            vec![contract_account_seeds_vec(&signer, bump_seed)],
+            0,
+            true,
+        )
         .await?;
 
     Ok(vec![])
@@ -471,12 +445,6 @@ async fn transfer<State: Database>(
     let signer = context.caller;
     let (signer_pubkey, bump_seed) = state.contract_pubkey(signer);
 
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        signer.as_bytes().to_vec(),
-        vec![bump_seed],
-    ];
-
     let transfer = spl_token::instruction::transfer(
         &spl_token::ID,
         &source,
@@ -486,7 +454,12 @@ async fn transfer<State: Database>(
         amount,
     )?;
     state
-        .queue_external_instruction(transfer, vec![seeds], 0, true)
+        .queue_external_instruction(
+            transfer,
+            vec![contract_account_seeds_vec(&signer, bump_seed)],
+            0,
+            true,
+        )
         .await?;
 
     Ok(vec![])
@@ -505,21 +478,10 @@ async fn transfer_with_seed<State: Database>(
         return Ok(vec![]);
     }
 
-    let seeds: &[&[u8]] = &[
-        &[ACCOUNT_SEED_VERSION],
-        b"AUTH",
-        context.caller.as_bytes(),
-        seed,
-    ];
-    let (signer_pubkey, signer_seed) = Pubkey::find_program_address(seeds, state.program_id());
-
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        b"AUTH".to_vec(),
-        context.caller.as_bytes().to_vec(),
-        seed.to_vec(),
-        vec![signer_seed],
-    ];
+    let (signer_pubkey, seeds) = Pubkey::find_program_address_with_seeds(
+        &external_authority_seeds(&context.caller, seed),
+        state.program_id(),
+    );
 
     let transfer = spl_token::instruction::transfer(
         &spl_token::ID,
@@ -551,12 +513,6 @@ async fn mint_to<State: Database>(
     let signer = context.caller;
     let (signer_pubkey, bump_seed) = state.contract_pubkey(signer);
 
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        signer.as_bytes().to_vec(),
-        vec![bump_seed],
-    ];
-
     let mint_to = spl_token::instruction::mint_to(
         &spl_token::ID,
         &mint,
@@ -566,7 +522,12 @@ async fn mint_to<State: Database>(
         amount,
     )?;
     state
-        .queue_external_instruction(mint_to, vec![seeds], 0, true)
+        .queue_external_instruction(
+            mint_to,
+            vec![contract_account_seeds_vec(&signer, bump_seed)],
+            0,
+            true,
+        )
         .await?;
 
     Ok(vec![])
@@ -587,23 +548,15 @@ async fn burn<State: Database>(
     let signer = context.caller;
     let (signer_pubkey, bump_seed) = state.contract_pubkey(signer);
 
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        signer.as_bytes().to_vec(),
-        vec![bump_seed],
-    ];
-
-    #[rustfmt::skip]
-    let burn = spl_token::instruction::burn(
-        &spl_token::ID,
-        &source,
-        &mint,
-        &signer_pubkey,
-        &[],
-        amount
-    )?;
+    let burn =
+        spl_token::instruction::burn(&spl_token::ID, &source, &mint, &signer_pubkey, &[], amount)?;
     state
-        .queue_external_instruction(burn, vec![seeds], 0, true)
+        .queue_external_instruction(
+            burn,
+            vec![contract_account_seeds_vec(&signer, bump_seed)],
+            0,
+            true,
+        )
         .await?;
 
     Ok(vec![])
@@ -619,12 +572,6 @@ async fn freeze<State: Database>(
     let signer = context.caller;
     let (signer_pubkey, bump_seed) = state.contract_pubkey(signer);
 
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        signer.as_bytes().to_vec(),
-        vec![bump_seed],
-    ];
-
     let freeze = spl_token::instruction::freeze_account(
         &spl_token::ID,
         &target,
@@ -633,7 +580,12 @@ async fn freeze<State: Database>(
         &[],
     )?;
     state
-        .queue_external_instruction(freeze, vec![seeds], 0, true)
+        .queue_external_instruction(
+            freeze,
+            vec![contract_account_seeds_vec(&signer, bump_seed)],
+            0,
+            true,
+        )
         .await?;
 
     Ok(vec![])
@@ -649,22 +601,15 @@ async fn thaw<State: Database>(
     let signer = context.caller;
     let (signer_pubkey, bump_seed) = state.contract_pubkey(signer);
 
-    let seeds = vec![
-        vec![ACCOUNT_SEED_VERSION],
-        signer.as_bytes().to_vec(),
-        vec![bump_seed],
-    ];
-
-    #[rustfmt::skip]
-    let thaw = spl_token::instruction::thaw_account(
-        &spl_token::ID,
-        &target,
-        &mint,
-        &signer_pubkey,
-        &[]
-    )?;
+    let thaw =
+        spl_token::instruction::thaw_account(&spl_token::ID, &target, &mint, &signer_pubkey, &[])?;
     state
-        .queue_external_instruction(thaw, vec![seeds], 0, true)
+        .queue_external_instruction(
+            thaw,
+            vec![contract_account_seeds_vec(&signer, bump_seed)],
+            0,
+            true,
+        )
         .await?;
 
     Ok(vec![])
@@ -678,15 +623,8 @@ fn find_account<State: Database>(
 ) -> Result<Vec<u8>> {
     let signer = context.caller;
 
-    let (account_key, _) = Pubkey::find_program_address(
-        &[
-            &[ACCOUNT_SEED_VERSION],
-            b"ContractData",
-            signer.as_bytes(),
-            seed,
-        ],
-        state.program_id(),
-    );
+    let (account_key, _) =
+        Pubkey::find_program_address(&spl_token_seeds(&signer, seed), state.program_id());
 
     Ok(account_key.to_bytes().to_vec())
 }

--- a/evm_loader/program/src/instruction/collect_treasury.rs
+++ b/evm_loader/program/src/instruction/collect_treasury.rs
@@ -1,7 +1,5 @@
-use crate::{
-    account::{program::System, MainTreasury, Treasury},
-    config::TREASURY_POOL_SEED,
-};
+use crate::account::{program::System, MainTreasury, Treasury};
+use crate::pda_seeds::with_treasury_seeds;
 use arrayref::array_ref;
 use solana_program::{
     account_info::AccountInfo, entrypoint::ProgramResult, program::invoke_signed, pubkey::Pubkey,
@@ -28,15 +26,13 @@ pub fn process<'a>(
         .saturating_sub(minimal_balance_for_rent_exempt);
 
     if available_lamports > 0 {
-        invoke_signed(
-            &system_instruction::transfer(treasury.key, main_treasury.key, available_lamports),
-            &[treasury.clone(), main_treasury.clone(), system.clone()],
-            &[&[
-                TREASURY_POOL_SEED.as_bytes(),
-                &treasury_index.to_le_bytes(),
-                &[treasury.get_bump_seed()],
-            ]],
-        )?;
+        with_treasury_seeds(treasury_index, &[treasury.get_bump_seed()], |seeds| {
+            invoke_signed(
+                &system_instruction::transfer(treasury.key, main_treasury.key, available_lamports),
+                &[treasury.clone(), main_treasury.clone(), system.clone()],
+                &[seeds],
+            )
+        })?;
     };
 
     Ok(())

--- a/evm_loader/program/src/instruction/create_main_treasury.rs
+++ b/evm_loader/program/src/instruction/create_main_treasury.rs
@@ -1,6 +1,6 @@
+use crate::pda_seeds::main_treasury_seeds;
 use crate::{
     account::{program::System, program::Token, MainTreasury, Operator},
-    config::TREASURY_POOL_SEED,
     error::{Error, Result},
 };
 use solana_program::{
@@ -119,7 +119,7 @@ pub fn process<'a>(
         &spl_token::id(),
         &accounts.payer,
         accounts.main_treasury,
-        &[TREASURY_POOL_SEED.as_bytes(), &[bump_seed]],
+        &main_treasury_seeds(&[bump_seed]),
         spl_token::state::Account::LEN,
         &Rent::get()?,
     )?;

--- a/evm_loader/program/src/lib.rs
+++ b/evm_loader/program/src/lib.rs
@@ -29,6 +29,7 @@ pub mod external_programs;
 pub mod gasometer;
 #[cfg(target_os = "solana")]
 pub mod instruction;
+pub mod pda_seeds;
 pub mod types;
 
 // Export current solana-sdk types for downstream users who may also be building with a different

--- a/evm_loader/program/src/pda_seeds.rs
+++ b/evm_loader/program/src/pda_seeds.rs
@@ -1,0 +1,196 @@
+use crate::account::Operator;
+use crate::types::Address;
+use ethnum::U256;
+use solana_program::pubkey::Pubkey;
+
+pub const AUTHORITY_SEEDS: &[&[u8]] = &[b"Deposit"];
+
+const ACCOUNT_SEED_VERSION_SLICE: &[u8] = &[crate::config::ACCOUNT_SEED_VERSION];
+
+#[must_use]
+pub fn with_balance_account_seeds<R>(
+    address: &Address,
+    chain_id: u64,
+    bump_seed: &[u8],
+    f: impl Fn(&[&[u8]]) -> R,
+) -> R {
+    f(&[
+        ACCOUNT_SEED_VERSION_SLICE,
+        address.as_bytes(),
+        &U256::from(chain_id).to_be_bytes(),
+        bump_seed,
+    ])
+}
+
+#[must_use]
+pub fn contract_account_seeds<'a>(address: &'a Address, bump_seed: &'a [u8]) -> [&'a [u8]; 3] {
+    [ACCOUNT_SEED_VERSION_SLICE, address.as_bytes(), bump_seed]
+}
+
+fn to_vec_vec(seeds: &[&[u8]]) -> Vec<Vec<u8>> {
+    seeds.iter().map(|v| v.to_vec()).collect()
+}
+
+#[must_use]
+pub fn contract_account_seeds_vec(address: &Address, bump_seed: u8) -> Vec<Vec<u8>> {
+    to_vec_vec(&contract_account_seeds(address, &[bump_seed]))
+}
+
+#[must_use]
+pub fn spl_token_seeds<'a>(address: &'a Address, seed: &'a [u8]) -> [&'a [u8]; 4] {
+    [
+        ACCOUNT_SEED_VERSION_SLICE,
+        b"ContractData",
+        address.as_bytes(),
+        seed,
+    ]
+}
+
+#[must_use]
+pub fn external_authority_seeds<'a>(address: &'a Address, seed: &'a [u8]) -> [&'a [u8]; 4] {
+    [
+        ACCOUNT_SEED_VERSION_SLICE,
+        b"AUTH",
+        address.as_bytes(),
+        seed,
+    ]
+}
+
+#[must_use]
+pub fn with_treasury_seeds<R>(index: u32, bump_seed: &[u8], f: impl Fn(&[&[u8]]) -> R) -> R {
+    f(&[
+        crate::config::TREASURY_POOL_SEED.as_bytes(),
+        &index.to_le_bytes(),
+        bump_seed,
+    ])
+}
+
+#[must_use]
+pub fn main_treasury_seeds(bump_seed: &[u8]) -> [&[u8]; 2] {
+    [crate::config::TREASURY_POOL_SEED.as_bytes(), bump_seed]
+}
+
+#[must_use]
+pub fn with_operator_seeds<R>(
+    operator: &Operator<'_>,
+    address: &Address,
+    chain_id: u64,
+    bump_seed: &[u8],
+    f: impl Fn(&[&[u8]]) -> R,
+) -> R {
+    f(&[
+        ACCOUNT_SEED_VERSION_SLICE,
+        operator.key.as_ref(),
+        address.as_bytes(),
+        &U256::from(chain_id).to_be_bytes(),
+        bump_seed,
+    ])
+}
+
+#[must_use]
+pub fn payer_seeds<'a>(address: &'a Address, bump_seed: &'a [u8]) -> [&'a [u8]; 4] {
+    [
+        ACCOUNT_SEED_VERSION_SLICE,
+        b"PAYER",
+        address.as_bytes(),
+        bump_seed,
+    ]
+}
+
+#[must_use]
+pub fn payer_seeds_vec(address: &Address, bump_seed: u8) -> Vec<Vec<u8>> {
+    to_vec_vec(&payer_seeds(address, &[bump_seed]))
+}
+
+fn iter_map_collect<T>(seeds: &[Vec<T>]) -> Vec<&[T]> {
+    seeds.iter().map(Vec::as_slice).collect::<Vec<_>>()
+}
+
+pub fn with_slice_of_slice_of_slice<R>(seeds: &[Vec<Vec<u8>>], f: impl Fn(&[&[&[u8]]]) -> R) -> R {
+    f(&iter_map_collect(
+        &seeds
+            .iter()
+            .map(|s| iter_map_collect(s))
+            .collect::<Vec<_>>(),
+    ))
+}
+
+pub trait PubkeyExt {
+    fn find_program_address_with_seeds(
+        seeds: &[&[u8]],
+        program_id: &Pubkey,
+    ) -> (Pubkey, Vec<Vec<u8>>);
+}
+
+impl PubkeyExt for Pubkey {
+    fn find_program_address_with_seeds(
+        seeds: &[&[u8]],
+        program_id: &Pubkey,
+    ) -> (Pubkey, Vec<Vec<u8>>) {
+        let (pubkey, bump_seed) = Pubkey::find_program_address(seeds, program_id);
+
+        let mut seeds: Vec<_> = seeds.iter().map(|v| v.to_vec()).collect();
+        seeds.push(vec![bump_seed]);
+
+        (pubkey, seeds)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Address;
+    use hex::FromHex;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_authority_pubkey_mainnet() {
+        let neon_evm = Pubkey::from_str("NeonVMyRX5GbCrsAHnUwx1nYYoJAtskU1bWUo6JGNyG").unwrap();
+
+        let (pubkey, _) = Pubkey::find_program_address(AUTHORITY_SEEDS, &neon_evm);
+
+        assert_eq!(
+            pubkey.to_string(),
+            "CUU8HLwbSc2zFEDenmauiEJbCGCNy4eAHAmznZcjB6Nn"
+        );
+    }
+
+    #[test]
+    fn test_usdt_pubkey_mainnet() {
+        let neon_evm = Pubkey::from_str("NeonVMyRX5GbCrsAHnUwx1nYYoJAtskU1bWUo6JGNyG").unwrap();
+
+        // Neon USDT token: https://neonscan.org/token/0x5f0155d08ef4aae2b500aefb64a3419da8bb611a
+        let usdt_address = Address::from_hex("0x5f0155d08eF4aaE2B500AefB64A3419dA8bB611a").unwrap();
+
+        let (usdt_pubkey, _) =
+            Pubkey::find_program_address(&contract_account_seeds(&usdt_address, &[]), &neon_evm);
+
+        assert_eq!(
+            usdt_pubkey.to_string(),
+            "GHuABgXXF37MqV9WyqJXwvzA2eLkcxKf2t8WbiVzBLnU"
+        );
+    }
+
+    // Neon tx: https://neonscan.org/tx/0x0729687b2f56398652a6593b87b9932f3fe2f2e0c778eb4841a4e17d961a2a11
+    #[test]
+    fn test_token_account_pubkey_mainnet() {
+        let neon_evm = Pubkey::from_str("NeonVMyRX5GbCrsAHnUwx1nYYoJAtskU1bWUo6JGNyG").unwrap();
+
+        // Neon USDT token: https://neonscan.org/token/0x5f0155d08ef4aae2b500aefb64a3419da8bb611a
+        let usdt_address = Address::from_hex("0x5f0155d08eF4aaE2B500AefB64A3419dA8bB611a").unwrap();
+
+        // Neon tx.from address: https://neonscan.org/address/0x35b6c40e3873f361c43c073154bf8b37c1f34cd7
+        let address = <[u8; 32]>::from_hex(
+            "00000000000000000000000035B6C40e3873F361c43c073154BF8b37C1f34Cd7",
+        )
+        .unwrap();
+
+        let (pubkey, _) =
+            Pubkey::find_program_address(&spl_token_seeds(&usdt_address, &address), &neon_evm);
+
+        assert_eq!(
+            pubkey.to_string(),
+            "12HWB2U31J5AMgDTaaXBdNGN8jAeJNiwpgkewCNVNKyU"
+        );
+    }
+}


### PR DESCRIPTION
Centralized all PDA seeds logic in one module for easier understanding of NeonEVM account model.

Isolated an endianness inconsistency across seeds logic. Balance account chain_id is serialized using big endian, while treasury index is serialized using little endian. Avoiding code duplication around critical code like seed computations is critical to avoid inconsistencies like this one in the future.