### PR TITLE
NDEV-2899: Make PrestateTracerDiffModeResult public

### DIFF
--- a/evm_loader/lib/src/tracing/tracers/prestate_tracer/mod.rs
+++ b/evm_loader/lib/src/tracing/tracers/prestate_tracer/mod.rs
@@ -1,2 +1,4 @@
 mod state_diff;
 pub mod tracer;
+
+pub use state_diff::{PrestateTracerAccount, PrestateTracerDiffModeResult, PrestateTracerState};

--- a/evm_loader/lib/src/tracing/tracers/prestate_tracer/state_diff.rs
+++ b/evm_loader/lib/src/tracing/tracers/prestate_tracer/state_diff.rs
@@ -7,7 +7,7 @@ use crate::tracing::tracers::state_diff::StateMap;
 use evm_loader::types::Address;
 
 /// See <https://github.com/ethereum/go-ethereum/blob/master/eth/tracers/native/prestate.go#L39>
-type PrestateTracerState = BTreeMap<Address, PrestateTracerAccount>;
+pub type PrestateTracerState = BTreeMap<Address, PrestateTracerAccount>;
 
 /// See <https://github.com/ethereum/go-ethereum/blob/master/eth/tracers/native/prestate.go#L41>
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -18,6 +18,7 @@ pub struct PrestateTracerAccount {
     pub code: Option<Bytes>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nonce: Option<u64>,
+    #[serde(default)]
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub storage: BTreeMap<H256, H256>,
 }


### PR DESCRIPTION
This is needed to improve implementation of `debug_getModifiedAccountsByHash` and `debug_getModifiedAccountsByNumber` methods because the previous implementation was forced to duplicated the response definition. See https://github.com/neonlabsorg/tracer-api/pull/153 for more details.