### PR TITLE
NDEV-2894: Apply code and storage overridings

### DIFF
--- a/evm_loader/lib/src/account_storage.rs
+++ b/evm_loader/lib/src/account_storage.rs
@@ -239,7 +239,7 @@ impl<'rpc, T: Rpc + BuildConfigSimulator> EmulatorAccountStorage<'rpc, T> {
             return_data: RefCell::new(None),
         };
         storage
-            .apply_state_overrides(tx_chain_id.unwrap_or(storage.default_chain_id()))
+            .apply_state_overrides(tx_chain_id.unwrap_or_else(|| storage.default_chain_id()))
             .await?;
         Ok(storage)
     }
@@ -270,7 +270,7 @@ impl<'rpc, T: Rpc + BuildConfigSimulator> EmulatorAccountStorage<'rpc, T> {
             return_data: RefCell::new(None),
         };
         storage
-            .apply_state_overrides(tx_chain_id.unwrap_or(storage.default_chain_id()))
+            .apply_state_overrides(tx_chain_id.unwrap_or_else(|| storage.default_chain_id()))
             .await?;
         Ok(storage)
     }
@@ -360,7 +360,7 @@ impl<'a, T: Rpc> EmulatorAccountStorage<'_, T> {
             .state_overrides
             .as_ref()
             .unwrap()
-            .into_iter()
+            .iter()
             .filter(|(_, account)| {
                 account.code.is_some() || account.state_diff.is_some() || account.state.is_some()
             })
@@ -376,7 +376,7 @@ impl<'a, T: Rpc> EmulatorAccountStorage<'_, T> {
                         U256::from_be_bytes(index.to_fixed_bytes()),
                         value.to_fixed_bytes(),
                     )
-                    .await?
+                    .await?;
                 }
             // state and stateDiff can't be specified at the same time.
             // If state is set, message execution will only use the data in
@@ -390,7 +390,7 @@ impl<'a, T: Rpc> EmulatorAccountStorage<'_, T> {
                         U256::from_be_bytes(index.to_fixed_bytes()),
                         value.to_fixed_bytes(),
                     )
-                    .await?
+                    .await?;
                 }
             }
             if let Some(code) = account.code {

--- a/evm_loader/lib/src/account_storage.rs
+++ b/evm_loader/lib/src/account_storage.rs
@@ -439,15 +439,11 @@ impl<'a, T: Rpc> EmulatorAccountStorage<'_, T> {
         Ok(())
     }
 
-    fn is_storage_overriden(&self, pubkey: Pubkey) -> bool {
+    fn has_storage_override(&self, address: &Address) -> bool {
         self.state_overrides.as_ref().map_or(false, |overrides| {
             overrides
                 .iter()
-                .filter(|(address, _)| {
-                    let (overridden_pubkey, _) = address.find_solana_address(&self.program_id);
-                    overridden_pubkey == pubkey
-                })
-                .any(|(_, overrides)| overrides.state.is_some())
+                .any(|(item, override_)| *item == *address && override_.state.is_some())
         })
     }
 
@@ -751,7 +747,7 @@ impl<'a, T: Rpc> EmulatorAccountStorage<'_, T> {
             return Ok(account);
         }
 
-        if self.is_storage_overriden(pubkey) {
+        if self.has_storage_override(&address) {
             // In case of emulated state overrides full storage we should not
             // go to the node and return empty account here to fill it by
             // overriden data.

--- a/evm_loader/lib/src/account_storage.rs
+++ b/evm_loader/lib/src/account_storage.rs
@@ -219,7 +219,7 @@ impl<'rpc, T: Rpc + BuildConfigSimulator> EmulatorAccountStorage<'rpc, T> {
                 accounts_cache.insert(pubkey, Box::new(account));
             }
         }
-        let storage = Self {
+        let mut storage = Self {
             accounts: FrozenMap::new(),
             call_stack: vec![],
             program_id,
@@ -238,10 +238,9 @@ impl<'rpc, T: Rpc + BuildConfigSimulator> EmulatorAccountStorage<'rpc, T> {
             used_accounts: FrozenMap::new(),
             return_data: RefCell::new(None),
         };
-
-        let target_chain_id = tx_chain_id.unwrap_or_else(|| storage.default_chain_id());
-        storage.apply_balance_overrides(target_chain_id).await?;
-
+        storage
+            .apply_state_overrides(tx_chain_id.unwrap_or(storage.default_chain_id()))
+            .await?;
         Ok(storage)
     }
 
@@ -251,7 +250,7 @@ impl<'rpc, T: Rpc + BuildConfigSimulator> EmulatorAccountStorage<'rpc, T> {
         timestamp_shift: i64,
         tx_chain_id: Option<u64>,
     ) -> Result<EmulatorAccountStorage<'rpc, T>, NeonError> {
-        let storage = Self {
+        let mut storage = Self {
             accounts: FrozenMap::new(),
             call_stack: vec![],
             program_id: other.program_id,
@@ -270,8 +269,9 @@ impl<'rpc, T: Rpc + BuildConfigSimulator> EmulatorAccountStorage<'rpc, T> {
             used_accounts: other.used_accounts.clone(),
             return_data: RefCell::new(None),
         };
-        let target_chain_id = tx_chain_id.unwrap_or_else(|| storage.default_chain_id());
-        storage.apply_balance_overrides(target_chain_id).await?;
+        storage
+            .apply_state_overrides(tx_chain_id.unwrap_or(storage.default_chain_id()))
+            .await?;
         Ok(storage)
     }
 
@@ -304,6 +304,73 @@ impl<'rpc, T: Rpc + BuildConfigSimulator> EmulatorAccountStorage<'rpc, T> {
 }
 
 impl<'a, T: Rpc> EmulatorAccountStorage<'_, T> {
+    async fn apply_state_overrides(&mut self, target_chain_id: u64) -> NeonResult<()> {
+        self.apply_balance_overrides(target_chain_id).await?;
+        self.apply_contract_overrides(target_chain_id).await?;
+        Ok(())
+    }
+    /// Overrides existing code for a contract, used in emulations only.
+    async fn override_code_by(
+        &mut self,
+        address: Address,
+        chain_id: u64,
+        code: Vec<u8>,
+    ) -> evm_loader::error::Result<()> {
+        info!("override_code_by {address} -> {} bytes", code.len());
+        {
+            let mut account_data = self
+                .get_contract_account(address)
+                .await
+                .map_err(map_neon_error)?
+                .borrow_mut();
+            let pubkey = account_data.pubkey;
+
+            if account_data.is_empty() {
+                self.create_ethereum_contract(&mut account_data, address, chain_id, 0, &code)?;
+            } else {
+                let contract = ContractAccount::from_account(
+                    self.program_id(),
+                    account_data.into_account_info(),
+                )?;
+                let new_account_data = RefCell::new(AccountData::new(pubkey));
+                {
+                    let mut new_account = new_account_data.borrow_mut();
+                    let mut new_contract = self.create_ethereum_contract(
+                        &mut new_account,
+                        address,
+                        chain_id,
+                        contract.generation(),
+                        &code,
+                    )?;
+                    let storage = *contract.storage();
+                    new_contract.set_storage_multiple_values(0, &storage);
+                }
+                *account_data = new_account_data.replace_with(|_| AccountData::new(pubkey));
+            }
+        }
+
+        Ok(())
+    }
+    async fn apply_contract_overrides(&mut self, target_chain_id: u64) -> NeonResult<()> {
+        if self.state_overrides.is_none() {
+            return Ok(());
+        }
+        let codes_for_overriding: HashMap<Address, Bytes> = self
+            .state_overrides
+            .as_ref()
+            .unwrap()
+            .into_iter()
+            .filter(|(_, account)| account.code.is_some())
+            .map(|(&address, account)| (address, account.code.clone().unwrap()))
+            .collect();
+
+        for (address, code) in codes_for_overriding {
+            self.override_code_by(address, target_chain_id, code.0)
+                .await?;
+        }
+        Ok(())
+    }
+
     async fn apply_balance_overrides(&self, target_chain_id: u64) -> NeonResult<()> {
         if let Some(state_overrides) = self.state_overrides.as_ref() {
             for (address, overrides) in state_overrides {
@@ -1058,12 +1125,6 @@ impl<T: Rpc> AccountStorage for EmulatorAccountStorage<'_, T> {
         use evm_loader::evm::Buffer;
 
         info!("code {address}");
-
-        // TODO: move to reading data from Solana node
-        // let code_override = self.account_override(address, |a| a.code.clone());
-        // if let Some(code_override) = code_override {
-        //     return Buffer::from_vec(code_override.0);
-        // }
 
         let code = self
             .ethereum_contract_map_or(address, Vec::default(), |c| c.code().to_vec())

--- a/evm_loader/lib/src/account_storage.rs
+++ b/evm_loader/lib/src/account_storage.rs
@@ -772,7 +772,12 @@ impl<'a, T: Rpc> EmulatorAccountStorage<'_, T> {
         if let Some(account) = self.accounts.get(&cell_pubkey) {
             return Ok(account);
         }
-
+        if self.has_storage_override(&address) {
+            // In case of emulated state overrides full storage we should not
+            // go to the node and return empty account here to fill it by
+            // overriden data.
+            return Ok(self.add_empty_account(cell_pubkey));
+        }
         match self._get_account_from_rpc(cell_pubkey).await? {
             Some(account) => self.add_account(cell_pubkey, account).await,
             None => Ok(self.add_empty_account(cell_pubkey)),


### PR DESCRIPTION
The second step for https://neonlabs.atlassian.net/browse/NDEV-2894
- Applying overrides for code
- Applying overrides for state and stateDiff

First part in https://github.com/neonlabsorg/neon-evm/pull/400