### PR TITLE
Support ALT in `simulate_solana` request

### DIFF
--- a/evm_loader/lib/src/types/mod.rs
+++ b/evm_loader/lib/src/types/mod.rs
@@ -239,6 +239,7 @@ pub struct GetHolderRequest {
 pub struct SimulateSolanaRequest {
     pub compute_units: Option<u64>,
     pub account_limit: Option<usize>,
+    pub verify: Option<bool>,
     #[serde_as(as = "Hex")]
     pub blockhash: [u8; 32],
     #[serde_as(as = "Vec<Hex>")]


### PR DESCRIPTION
- Support Legacy transactions.
- Support ALT, if it is already exists in the Solana.
- New flag - `verify`. `true` by default. If `false`, the transaction size and signature is not verified.