### PR TITLE
NDEV-3007: Update Solana dependencies to 1.17.33

### DIFF
--- a/.github/workflows/deploy.py
+++ b/.github/workflows/deploy.py
@@ -32,8 +32,8 @@ DOCKER_PASSWORD = os.environ.get("DHUBP")
 IMAGE_NAME = os.environ.get("IMAGE_NAME")
 RUN_LINK_REPO = os.environ.get("RUN_LINK_REPO")
 DOCKERHUB_ORG_NAME = os.environ.get("DOCKERHUB_ORG_NAME")
-SOLANA_NODE_VERSION = 'v1.17.31'
-SOLANA_BPF_VERSION = 'v1.17.31'
+SOLANA_NODE_VERSION = 'v1.17.33'
+SOLANA_BPF_VERSION = 'v1.17.33'
 
 VERSION_BRANCH_TEMPLATE = r"[vt]{1}\d{1,2}\.\d{1,2}\.x.*"
 docker_client = docker.APIClient()

--- a/evm_loader/Cargo.lock
+++ b/evm_loader/Cargo.lock
@@ -4941,9 +4941,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e29f060cabd0e1bd90a63f8e1517ddd3365d3dc2eaa05f9a9fa542f4adeaaa"
+checksum = "ed136199e67867bea960ab65895e150b0f767b1f6d9e7093a62a875f7f33d207"
 dependencies = [
  "Inflector",
  "base64 0.21.7",
@@ -4966,9 +4966,9 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e32ca00e7785d0fde702aa6c9fa749d33d1c275980baee85de0543357cae28"
+checksum = "bbb104530ea601d2dad1232449589c6198e26e70c1c9d0be1fb0ba1a40a546df"
 dependencies = [
  "arrayref",
  "bincode",
@@ -5025,9 +5025,9 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a93d1c1a0c13de20e13a0c9bd7275b00bb901b8b7c55424fea98f71cb37778"
+checksum = "5152bcbdcd1dd698cd3182ce4e810f6f4ff18ce3260e934005dba4c5d53293db"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -5046,9 +5046,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a396f4190c9bc81ec2d697673a571d7f064634916105fdf9efecb6fa5bec818"
+checksum = "60bdb8a5c42a514b00605ec184870aee7230a0610b46d56aa19e8a77928a0d80"
 dependencies = [
  "bincode",
  "byteorder",
@@ -5065,9 +5065,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4efb7bc86741650dc2a942d23e7e714d41bbc46eff5555784ec87ee7a591615"
+checksum = "4bee6b54dc14d1cdf80334934745ae5011dda936cdcd5316b9d393a912dc2132"
 dependencies = [
  "bv",
  "bytemuck",
@@ -5083,9 +5083,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e5cdc0ae0c8ae79c39a4a362066d0d61764bc7ea7e033961fd7510fd24da2a"
+checksum = "ae9cafd23f6641f118dd11148f950309139849b74b28ec9dfafbfa00457761b9"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -5100,9 +5100,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "599b8cac742270ddc097458623d9688b3ad03e6adb19987e993f47ec51b330eb"
+checksum = "598d94119670b731a168e72f343260e37e38d221a116db974a6553d4da1be74a"
 dependencies = [
  "bincode",
  "bs58 0.4.0",
@@ -5151,9 +5151,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6de25e2f3e00901ffbe09e625303fdda62baaa584992027bdc92fc3fca04e1a"
+checksum = "632f34d4a96028066250b48f4255fa53ab561dab145cc0c2db8f1e403c48e33b"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -5167,9 +5167,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b3aca5a25e1ca04b5b1107bcdc26fcc69d167df0f617dbca5967df62e0d42"
+checksum = "4c20066a01daa20b7b31d44318558517ed9e7da1c7e4e017210d2b659fce255f"
 dependencies = [
  "Inflector",
  "base64 0.21.7",
@@ -5194,9 +5194,9 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e2301c2af7e5a1dba0855f710329a2bb993829ed9fdf8f6207d02ee6fc54a4"
+checksum = "d221979e0ee0f8133e9a02a6a9d54a004c59a6857e9b245e4cb4a7541826a662"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5227,9 +5227,9 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773ae3c4d99f9ed06d9dc5c6541df1db16bc42d77f91c46b9c9b117fc5e129b3"
+checksum = "e7056e3d37696525e1257090ec9af4ee8667aac3fbda313f801b712b3b5bce11"
 dependencies = [
  "solana-program-runtime",
  "solana-sdk",
@@ -5237,9 +5237,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595118948b966b110aad3f9d8d8464958abe379ecfa7a813b4fc82659c8259bc"
+checksum = "e66d677aafa8822aae006cebe3b55587b610541e4f8f4e34987463d0640d05ad"
 dependencies = [
  "bincode",
  "chrono",
@@ -5251,9 +5251,9 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d363d6bb43e618b6010b47c2eb0579777ce4ed388ca15b84a610a738edf0b97e"
+checksum = "716f64f1c9ed455729a8de412b7b3ad200b47997b4f68408a1bb65c2a61ccf80"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5273,9 +5273,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1e8673cd74543895f310eb2dfd497c7ffc970a799923bd0f8fd6e0320e14ab"
+checksum = "47c669f8432952cfe1fa50a6e26827a4b99a3fdfdff229b218f4882668ea89f0"
 dependencies = [
  "lazy_static",
  "log",
@@ -5297,9 +5297,9 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad19317b6d6302967fe8946a27eb95ba9df67167a7ddf5f538ede312d899471"
+checksum = "c7b988b2989fa6c0c0ff9feafa0f1e4b2571fb1953e88fcb109112219e5edf4b"
 dependencies = [
  "bincode",
  "byteorder",
@@ -5321,9 +5321,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96734b05823c8b515f8e3cc02641a27aee2c9760b1a43c74cb20f2a1ab0ab76c"
+checksum = "ef1d4f626d41690e30273990808709fa189f32d2ab55724870e9dbf03107b8a7"
 dependencies = [
  "ahash 0.8.5",
  "blake3",
@@ -5351,9 +5351,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0f1291a464fd046135d019d57a81be165ee3d23aa7df880b47dac683a0582a"
+checksum = "b82e46dc5348003a010c8b05b494d800a7cfd5793b3dd843a4d664306fce2edc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5363,9 +5363,9 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a437265099d9782e1f95eee2feb3b9b4f0247a177d0c0646148da738ae3b1f"
+checksum = "331541db807a0a2bfd29fbc39b2c5f17779d3cc9bc29ea70fe0a719689a2c580"
 dependencies = [
  "log",
  "solana-measure",
@@ -5376,9 +5376,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5977c8f24b83cf50e7139ffdb25d70bad6a177f18ccc79ca2293d6a987fa81c"
+checksum = "be76f972b4863c350a408f112979ee607950640d58c164b3c3437c0fbc347867"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -5387,9 +5387,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a39ef01b2c65552d05013b2642ffd73258f2c80e3a59e44c499762047df9456"
+checksum = "abd540426200a9bb393de5640ae91c2d39909cefca902e529e6fe20709526cf5"
 dependencies = [
  "log",
  "solana-sdk",
@@ -5397,9 +5397,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad30ff3775412f2929d440446aef8b070676920bc5df495ea6398a8f28ce91f"
+checksum = "aa7fe468cdc1113b181f5958414c897593f484e9feaef35c96f8c26c9d39bbdd"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -5412,9 +5412,9 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafd5178a38a039e12c14780f1b6a74f1e672d62357343e0aee6d0fc7e5bd18"
+checksum = "8508f0496a42a469c9ffa9b4e9e81a40bc71b93248a8fa759f27b3e9865208bd"
 dependencies = [
  "bincode",
  "clap 3.2.23",
@@ -5434,9 +5434,9 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d6293cddcc98ae092d00f43f741405da30aa083acb96666606130810b064f3"
+checksum = "1b80387cc3b7e2b0c26c67cdd67e08bc461fccb3f62a363e8e1fc32e8270f64d"
 dependencies = [
  "ahash 0.8.5",
  "bincode",
@@ -5463,9 +5463,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6412447793f8a3ef7526655906728325093b472e481791ac5c584e8d272166dc"
+checksum = "85f79df075d0cf539285c529a683bb0a8cfe819b9ccefad0c9eb6fe567b3528a"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -5517,9 +5517,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1977e741a6793fca27413507457d797df0f41bc0ae634247d112bc77ab2b0325"
+checksum = "be80e2669f3659165f389d1049c5f4ca7305be44cd743ef7c79a5aed09635058"
 dependencies = [
  "base64 0.21.7",
  "bincode",
@@ -5545,9 +5545,9 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad21dd5d6fe09116dbc29aec279b7cf08d250b564899dc87437bd780ed26290"
+checksum = "df12f8912a05adb1672de27d4509e35389bc29a46cf2253ecaf6e3ce76fba09c"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -5570,9 +5570,9 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6201869768fe133ce9b8088e4f718f53ff164b8e5df3d0d46a6563a22545924f"
+checksum = "e0b3cc12f0dce18f7c020363d876aa9258aa403404afcac29d7cf498c2d0d653"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -5597,9 +5597,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f100d0c3214d67bb847a1eefc7079f6bb755534266423f4c994ad3b40c685ed"
+checksum = "c5d3a9d5f8e6d4c35f1833c61c3afbe138dded89dc91842176f4734f5e56ee66"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -5607,9 +5607,9 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3328c891079086b408a04e701470a346d517c9c51c0a96f2f166f616a3e1c3c8"
+checksum = "7ecaac75eae288354b765125238ce6ecc46b405de2dd8e851e389e2b0c7fa9d2"
 dependencies = [
  "console",
  "dialoguer",
@@ -5627,9 +5627,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfacf1163a375d98c29779a03ba278b2ef43494f77e33826a33f9460563c0887"
+checksum = "cde5066e74eff9a714122012683f82ea8bf630b0112b9e83104d5685a9f2bf1b"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -5653,9 +5653,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fab293a88113511e66607d76bd027edfe0b1372b467fd76bbb5af03448539a2"
+checksum = "9f6ebb85cdcdb7c4f20806b29023c4ee5c7cacc0124478a3d309af52997a4773"
 dependencies = [
  "base64 0.21.7",
  "bs58 0.4.0",
@@ -5675,9 +5675,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e43cb51374a6ec8fd401b3387334ef93e04f6d8ae87bbb29892aff42aeb1061"
+checksum = "20426894bebb53f7b32dc5cf871e58ba381433c2858cb6338d00d4beb68f6cd6"
 dependencies = [
  "clap 2.34.0",
  "solana-clap-utils",
@@ -5688,9 +5688,9 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c00486a8cc4fd4beddc5e22fdb1836c38a1280b6c708329bcfdfc61be39e377"
+checksum = "e3790ebeb675aec5576251a7a71b0ab23e3aaa138d24bef0e83e13e8d64ee3a8"
 dependencies = [
  "arrayref",
  "base64 0.21.7",
@@ -5765,9 +5765,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de1ce8848de4198f9bc7e4574252be02b1ed86ecbc2fff506780d5f8d6e4c4a8"
+checksum = "9e2722c05330a72ba707715861e365d6b38e8bae0c6dc481032bc53b370469b5"
 dependencies = [
  "assert_matches",
  "base64 0.21.7",
@@ -5819,9 +5819,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cc46bbda0a5472d8d0a4c846b22941436ac45c31456d3e885a387a5f264f7"
+checksum = "ae8907d340ee8f10d6c9e9530db93ead2a82c8e21da95d8f96e0298071faffea"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2",
@@ -5838,9 +5838,9 @@ checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
 name = "solana-stake-program"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d94e05db9762c5fc6114e788570c4645dbe7e7ea5da2e39269128944b3a200"
+checksum = "c574ada0989783887f963d68a4889774d6b5397551c87030eee555a324c5859c"
 dependencies = [
  "bincode",
  "log",
@@ -5853,9 +5853,9 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f02b475fc20c55ebbcfa5638ff93f9b780414cc6185e3a6d0992bca0ae81ee"
+checksum = "b08adda24e6b06d6848bf0376f0641725b29d8c2710d980506c18190299a5b04"
 dependencies = [
  "async-channel",
  "bytes",
@@ -5886,9 +5886,9 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eec04b67da2f353fe18dcf7e8bcdd6d8ddcece8598de55a6a7671fd01e9188f"
+checksum = "a98b513f36cbc7a0ee120280b968010a958ef4e04e1e282b711a4d117d217c12"
 dependencies = [
  "bincode",
  "log",
@@ -5900,9 +5900,9 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6ce2304764b8bb699db734fde9cd19ace038d3895d828a557ea0ec2a9e0ecd"
+checksum = "f878baf1685d7bf4ccd9edf53a863bde06ece1bb08c8306a3f623c84ee1be951"
 dependencies = [
  "bincode",
  "log",
@@ -5915,9 +5915,9 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa3e2351625e26f55e5e08f8e5aadaa2380fd0649f25641d6ba3f3848dbe5c9a"
+checksum = "66a0f44fcaf0fef6f077b03386242d60dad64a861e3dee3d3312f19f194cfb03"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5939,9 +5939,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0841bbd1845c87043e4184961e45cc7c08b36d96d0d146256b26ea5c74630a0f"
+checksum = "cb26713d10ecdd8b2524e227736b3a80d2b8105afc17890b2592eaa83005b253"
 dependencies = [
  "Inflector",
  "base64 0.21.7",
@@ -5964,9 +5964,9 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae54a100f0b0b5be065f5d05f2259f6d4a7b39f5866d579927f3ca35a01773b"
+checksum = "0035cd922f58537b4754867ad3f9b0f5428815f4e1835a90b73e89cf17209fe5"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -5979,9 +5979,9 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f69945e38d7440221e2fac0aaa57a9d72adb329b0de705ca5bd9ba981aedc16"
+checksum = "4f5f943a8bf30efba1fea89a157eaabd6753d6afa8d595b7b1449526a221f8ea"
 dependencies = [
  "log",
  "rustc_version",
@@ -5995,9 +5995,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0122b117497cac299cd52bbfcb9f3732d882833f5c87ee87d2d3541ba77057"
+checksum = "14e09c7281abdba4a8cab1f413feaafaa8599a5d4eafa6c37790214f1531c11a"
 dependencies = [
  "crossbeam-channel",
  "itertools 0.10.5",
@@ -6014,9 +6014,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e574aafc3c5adc7106ab4605d8ad378c9a12f2cf1dec2e8ba1aa6fd97a5d5490"
+checksum = "d235dd88b21d78bf5a341c7a80a0730ca078bece366305f53fad9dbd7e72c116"
 dependencies = [
  "bincode",
  "log",
@@ -6036,9 +6036,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de791a3bb992976029ead33017d4d994614b10d3028c7598632019fdb432dcad"
+checksum = "02967e947d0f17d10cc037fdb5e9ffbac90cd1e390270f765e93dabf82f46b38"
 dependencies = [
  "bytemuck",
  "num-derive 0.3.3",
@@ -6050,9 +6050,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.17.31"
+version = "1.17.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597dddc8ab46852dea7fc3d22e031fa4ffdb1b2291ac24d960605424a510a5f5"
+checksum = "229fbe8647285712f672ff6f61b32d04158a216c45d9094acecd07446665e791"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.21.7",

--- a/evm_loader/Cargo.toml
+++ b/evm_loader/Cargo.toml
@@ -12,12 +12,12 @@ members = [
 ]
 
 [workspace.dependencies]
-solana-clap-utils = "=1.17.31"
-solana-cli = "=1.17.31"
-solana-cli-config = "=1.17.31"
-solana-client = "=1.17.31"
-solana-program = { version = "=1.17.31", default-features = false }
-solana-sdk = "=1.17.31"
-solana-program-runtime = "=1.17.31"
-solana-runtime = "=1.17.31"
-solana-accounts-db = "=1.17.31"
+solana-clap-utils = "=1.17.33"
+solana-cli = "=1.17.33"
+solana-cli-config = "=1.17.33"
+solana-client = "=1.17.33"
+solana-program = { version = "=1.17.33", default-features = false }
+solana-sdk = "=1.17.33"
+solana-program-runtime = "=1.17.33"
+solana-runtime = "=1.17.33"
+solana-accounts-db = "=1.17.33"

--- a/evm_loader/program-macro/Cargo.toml
+++ b/evm_loader/program-macro/Cargo.toml
@@ -15,4 +15,4 @@ quote = "1"
 itertools = "0.12"
 bs58 = "0.5"
 serde = { version = "1.0", features = [ "derive" ] }
-toml = "0.8"
+toml = "=0.8.2"

--- a/evm_loader/rpc-client/Cargo.toml
+++ b/evm_loader/rpc-client/Cargo.toml
@@ -11,8 +11,8 @@ serde_json = "1.0.115"
 neon-lib = { path = "../lib" }
 thiserror = "1.0.58"
 async-trait = "0.1.79"
-jsonrpsee-core = "0.22.3"
-jsonrpsee-http-client = "0.22.3"
-jsonrpsee-types = "0.22.3"
+jsonrpsee-core = "=0.22.3"
+jsonrpsee-http-client = "=0.22.3"
+jsonrpsee-types = "=0.22.3"
 tokio = { version = "1", features = ["full"] }
 build-info = { version = "0.0.31", features = ["serde"] }


### PR DESCRIPTION
The v1.17.33 release is now recommended for general use by MainnetBeta validators. 