### PR TITLE
NDEV-3025: state and stateDiff overrides require 32 byte hex values

### DIFF
--- a/evm_loader/lib/src/tracing/mod.rs
+++ b/evm_loader/lib/src/tracing/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use ethnum::U256;
 use serde_json::Value;
-use web3::types::Bytes;
+use web3::types::{Bytes, H256};
 
 use evm_loader::types::Address;
 
@@ -33,8 +33,8 @@ pub struct AccountOverride {
     pub nonce: Option<u64>,
     pub code: Option<Bytes>,
     pub balance: Option<U256>,
-    pub state: Option<HashMap<U256, U256>>,
-    pub state_diff: Option<HashMap<U256, U256>>,
+    pub state: Option<HashMap<H256, H256>>,
+    pub state_diff: Option<HashMap<H256, H256>>,
 }
 
 impl AccountOverride {
@@ -45,8 +45,14 @@ impl AccountOverride {
             (Some(_), Some(_)) => {
                 panic!("Account has both `state` and `stateDiff` overrides")
             }
-            (Some(state), None) => return state.get(&index).map(|value| value.to_be_bytes()),
-            (None, Some(state_diff)) => state_diff.get(&index).map(|v| v.to_be_bytes()),
+            (Some(state), None) => {
+                return state
+                    .get(&H256::from(index.to_be_bytes()))
+                    .map(|value| value.to_fixed_bytes())
+            }
+            (None, Some(state_diff)) => state_diff
+                .get(&H256::from(index.to_be_bytes()))
+                .map(|v| v.to_fixed_bytes()),
         }
     }
 }


### PR DESCRIPTION
Go Ethereum rejects requests like:

```bash
curl --location 'http://127.0.0.1:8545' \
--header 'Content-Type: application/json' \
--data '{
    "jsonrpc": "2.0",
    "method": "debug_traceCall",
    "params": [
        {
            "data": "0x2e64cec1",
            "from": "0x82211934c340b29561381392348d48413e15adc8",
            "gas": "0x7530",
            "gasPrice": "0x418d06a287",
            "to": "0x8DbEf2f213803d34953b0de6EA25F84B0cb4ad6a",
            "value": "0x0"
        },
        {
            "blockNumber": "latest"
        },
        {
            "stateOverrides": {
                "0xdf250f5303db9e6bc4ef037403be02bf6a3fa2e4": {
                    "stateDiff": {
                        "0x0000000000000000000000000000000000000000000000000000000000000000": "0x11",
                        "0x0000000000000000000000000000000000000000000000000000000000000001": "0x12"
                    }
                }
            },
            "tracer": "prestateTracer"
        }
    ],
    "id": 1234
}'
```

with the error: 
```json
{
    "jsonrpc": "2.0",
    "id": 1234,
    "error": {
        "code": -32602,
        "message": "invalid argument 2: hex string has length 2, want 64 for common.Hash"
    }
}
```

But neon-api accepts such requests and should not.