### PR TITLE
NDEV-3080 Neon-API Optimizations

### DIFF
--- a/evm_loader/lib/src/account_storage_tests.rs
+++ b/evm_loader/lib/src/account_storage_tests.rs
@@ -16,7 +16,6 @@ mod mock_rpc_client {
     use solana_client::rpc_response::{Response, RpcResponseContext, RpcResult};
     use solana_sdk::account::Account;
     use solana_sdk::clock::{Slot, UnixTimestamp};
-    use solana_sdk::commitment_config::CommitmentConfig;
     use solana_sdk::pubkey::Pubkey;
     use std::collections::HashMap;
 
@@ -45,14 +44,6 @@ mod mock_rpc_client {
             })
         }
 
-        async fn get_account_with_commitment(
-            &self,
-            key: &Pubkey,
-            _commitment: CommitmentConfig,
-        ) -> RpcResult<Option<Account>> {
-            self.get_account(key).await
-        }
-
         async fn get_multiple_accounts(
             &self,
             pubkeys: &[Pubkey],
@@ -70,6 +61,10 @@ mod mock_rpc_client {
 
         async fn get_slot(&self) -> ClientResult<Slot> {
             Ok(Slot::default())
+        }
+
+        async fn get_deactivated_solana_features(&self) -> ClientResult<Vec<Pubkey>> {
+            Ok(vec![])
         }
     }
 

--- a/evm_loader/lib/src/commands/collect_treasury.rs
+++ b/evm_loader/lib/src/commands/collect_treasury.rs
@@ -1,4 +1,4 @@
-use crate::rpc::{check_account_for_fee, CloneRpcClient, Rpc};
+use crate::rpc::{check_account_for_fee, CloneRpcClient};
 use crate::{
     commands::get_neon_elf::read_elf_parameters_from_account, errors::NeonError, Config, NeonResult,
 };

--- a/evm_loader/lib/src/commands/get_neon_elf.rs
+++ b/evm_loader/lib/src/commands/get_neon_elf.rs
@@ -168,7 +168,7 @@ pub async fn read_program_data_from_account(
     evm_loader: &Pubkey,
 ) -> Result<(Option<Pubkey>, Vec<u8>), NeonError> {
     let account = rpc
-        .get_account_with_commitment(evm_loader, config.commitment)
+        .get_account(evm_loader)
         .await?
         .value
         .ok_or(NeonError::AccountNotFound(*evm_loader))?;
@@ -180,14 +180,9 @@ pub async fn read_program_data_from_account(
             programdata_address,
         }) = account.state()
         {
-            let programdata_account = rpc
-                .get_account_with_commitment(&programdata_address, config.commitment)
-                .await?
-                .value
-                .ok_or(NeonError::AssociatedPdaNotFound(
-                    programdata_address,
-                    config.evm_loader,
-                ))?;
+            let programdata_account = rpc.get_account(&programdata_address).await?.value.ok_or(
+                NeonError::AssociatedPdaNotFound(programdata_address, config.evm_loader),
+            )?;
 
             if let Ok(UpgradeableLoaderState::ProgramData {
                 upgrade_authority_address,

--- a/evm_loader/lib/src/rpc/db_call_client.rs
+++ b/evm_loader/lib/src/rpc/db_call_client.rs
@@ -10,7 +10,6 @@ use solana_client::{
 use solana_sdk::{
     account::Account,
     clock::{Slot, UnixTimestamp},
-    commitment_config::CommitmentConfig,
     pubkey::Pubkey,
 };
 
@@ -65,14 +64,6 @@ impl Rpc for CallDbClient {
         self.get_account(key).await
     }
 
-    async fn get_account_with_commitment(
-        &self,
-        key: &Pubkey,
-        _: CommitmentConfig,
-    ) -> RpcResult<Option<Account>> {
-        self.get_account(key).await
-    }
-
     async fn get_multiple_accounts(
         &self,
         pubkeys: &[Pubkey],
@@ -93,5 +84,9 @@ impl Rpc for CallDbClient {
 
     async fn get_slot(&self) -> ClientResult<Slot> {
         Ok(self.slot)
+    }
+
+    async fn get_deactivated_solana_features(&self) -> ClientResult<Vec<Pubkey>> {
+        Ok(vec![]) // TODO
     }
 }

--- a/evm_loader/lib/src/rpc/emulator_client.rs
+++ b/evm_loader/lib/src/rpc/emulator_client.rs
@@ -1,0 +1,96 @@
+use async_trait::async_trait;
+use evm_loader::account_storage::AccountStorage;
+use solana_client::{
+    client_error::Result as ClientResult,
+    rpc_response::{Response, RpcResponseContext, RpcResult},
+};
+use solana_sdk::{
+    account::Account,
+    clock::{Slot, UnixTimestamp},
+    pubkey::Pubkey,
+};
+
+use crate::account_storage::{fake_operator, EmulatorAccountStorage};
+
+use super::Rpc;
+
+#[async_trait(?Send)]
+impl<'rpc, T: Rpc> Rpc for EmulatorAccountStorage<'rpc, T> {
+    async fn get_account(&self, key: &Pubkey) -> RpcResult<Option<Account>> {
+        let block_number = self.block_number().as_u64();
+        let context = RpcResponseContext::new(block_number);
+
+        if *key == self.operator() {
+            return Ok(Response {
+                context,
+                value: Some(fake_operator()),
+            });
+        }
+
+        if let Some(account_data) = self.accounts_get(key) {
+            return Ok(Response {
+                context,
+                value: Some(Account::from(&*account_data)),
+            });
+        }
+
+        let account = self._get_account_from_rpc(*key).await?.cloned();
+        Ok(Response {
+            context,
+            value: account,
+        })
+    }
+
+    async fn get_multiple_accounts(
+        &self,
+        pubkeys: &[Pubkey],
+    ) -> ClientResult<Vec<Option<Account>>> {
+        let mut accounts = vec![None; pubkeys.len()];
+
+        let mut exists = vec![true; pubkeys.len()];
+        let mut missing_keys = Vec::with_capacity(pubkeys.len());
+
+        for (i, pubkey) in pubkeys.iter().enumerate() {
+            if pubkey == &self.operator() {
+                accounts[i] = Some(fake_operator());
+                continue;
+            }
+
+            if let Some(account_data) = self.accounts_get(pubkey) {
+                accounts[i] = Some(Account::from(&*account_data));
+                continue;
+            }
+
+            exists[i] = false;
+            missing_keys.push(*pubkey);
+        }
+
+        let response = self._get_multiple_accounts_from_rpc(&missing_keys).await?;
+
+        let mut j = 0_usize;
+        for i in 0..pubkeys.len() {
+            if exists[i] {
+                continue;
+            }
+
+            assert_eq!(pubkeys[i], missing_keys[j]);
+            accounts[i] = response[j].cloned();
+
+            j += 1;
+        }
+
+        Ok(accounts)
+    }
+
+    async fn get_block_time(&self, _slot: Slot) -> ClientResult<UnixTimestamp> {
+        Ok(self.block_timestamp().as_i64())
+    }
+
+    async fn get_slot(&self) -> ClientResult<Slot> {
+        Ok(self.block_number().as_u64())
+    }
+
+    async fn get_deactivated_solana_features(&self) -> ClientResult<Vec<Pubkey>> {
+        self._get_deactivated_solana_features().await
+    }
+}

--- a/evm_loader/lib/src/rpc/mod.rs
+++ b/evm_loader/lib/src/rpc/mod.rs
@@ -1,4 +1,5 @@
 mod db_call_client;
+mod emulator_client;
 mod validator_client;
 
 pub use db_call_client::CallDbClient;
@@ -15,7 +16,6 @@ use solana_sdk::native_token::lamports_to_sol;
 use solana_sdk::{
     account::Account,
     clock::{Slot, UnixTimestamp},
-    commitment_config::CommitmentConfig,
     pubkey::Pubkey,
 };
 
@@ -23,15 +23,12 @@ use solana_sdk::{
 #[enum_dispatch]
 pub trait Rpc {
     async fn get_account(&self, key: &Pubkey) -> RpcResult<Option<Account>>;
-    async fn get_account_with_commitment(
-        &self,
-        key: &Pubkey,
-        commitment: CommitmentConfig,
-    ) -> RpcResult<Option<Account>>;
     async fn get_multiple_accounts(&self, pubkeys: &[Pubkey])
         -> ClientResult<Vec<Option<Account>>>;
     async fn get_block_time(&self, slot: Slot) -> ClientResult<UnixTimestamp>;
     async fn get_slot(&self) -> ClientResult<Slot>;
+
+    async fn get_deactivated_solana_features(&self) -> ClientResult<Vec<Pubkey>>;
 }
 
 #[enum_dispatch(BuildConfigSimulator, Rpc)]

--- a/evm_loader/lib/src/rpc/validator_client.rs
+++ b/evm_loader/lib/src/rpc/validator_client.rs
@@ -9,7 +9,6 @@ use solana_client::{
 use solana_sdk::{
     account::Account,
     clock::{Slot, UnixTimestamp},
-    commitment_config::CommitmentConfig,
     pubkey::Pubkey,
 };
 use std::ops::Deref;
@@ -63,14 +62,6 @@ impl Rpc for CloneRpcClient {
             .await
     }
 
-    async fn get_account_with_commitment(
-        &self,
-        key: &Pubkey,
-        commitment: CommitmentConfig,
-    ) -> RpcResult<Option<Account>> {
-        self.rpc.get_account_with_commitment(key, commitment).await
-    }
-
     async fn get_multiple_accounts(
         &self,
         pubkeys: &[Pubkey],
@@ -90,5 +81,51 @@ impl Rpc for CloneRpcClient {
 
     async fn get_slot(&self) -> ClientResult<Slot> {
         self.rpc.get_slot().await
+    }
+
+    async fn get_deactivated_solana_features(&self) -> ClientResult<Vec<Pubkey>> {
+        use std::time::{Duration, Instant};
+        use tokio::sync::Mutex;
+
+        struct Cache {
+            data: Vec<Pubkey>,
+            timestamp: Instant,
+        }
+
+        static CACHE: Mutex<Option<Cache>> = Mutex::const_new(None);
+        let mut cache = CACHE.lock().await;
+
+        if let Some(cache) = cache.as_ref() {
+            if cache.timestamp.elapsed() < Duration::from_secs(24 * 60 * 60) {
+                return Ok(cache.data.clone());
+            }
+        }
+
+        let feature_keys: Vec<Pubkey> = solana_sdk::feature_set::FEATURE_NAMES
+            .keys()
+            .copied()
+            .collect();
+
+        let features = Rpc::get_multiple_accounts(self, &feature_keys).await?;
+
+        let mut result = Vec::with_capacity(feature_keys.len());
+        for (pubkey, feature) in feature_keys.iter().zip(features) {
+            let is_activated = feature
+                .and_then(|a| solana_sdk::feature::from_account(&a))
+                .and_then(|f| f.activated_at)
+                .is_some();
+
+            if !is_activated {
+                result.push(*pubkey);
+            }
+        }
+
+        cache.replace(Cache {
+            data: result.clone(),
+            timestamp: Instant::now(),
+        });
+        drop(cache);
+
+        Ok(result)
     }
 }

--- a/evm_loader/lib/src/solana_simulator/utils.rs
+++ b/evm_loader/lib/src/solana_simulator/utils.rs
@@ -61,7 +61,7 @@ pub async fn genesis_config_info(
     );
 
     if sync == SyncState::Yes {
-        for feature in deactivated_features(rpc).await? {
+        for feature in rpc.get_deactivated_solana_features().await? {
             genesis_config.accounts.remove(&feature);
         }
     }
@@ -72,28 +72,6 @@ pub async fn genesis_config_info(
         voting_keypair,
         validator_pubkey,
     })
-}
-
-pub async fn deactivated_features(rpc: &impl Rpc) -> Result<Vec<Pubkey>, Error> {
-    let feature_keys: Vec<Pubkey> = solana_sdk::feature_set::FEATURE_NAMES
-        .keys()
-        .copied()
-        .collect();
-    let features = rpc.get_multiple_accounts(&feature_keys).await?;
-
-    let mut result = Vec::with_capacity(feature_keys.len());
-    for (pubkey, feature) in feature_keys.iter().zip(features) {
-        let is_activated = feature
-            .and_then(|a| solana_sdk::feature::from_account(&a))
-            .and_then(|f| f.activated_at)
-            .is_some();
-
-        if !is_activated {
-            result.push(*pubkey);
-        }
-    }
-
-    Ok(result)
 }
 
 pub async fn sync_sysvar_accounts(rpc: &impl Rpc, bank: &Bank) -> Result<(), Error> {


### PR DESCRIPTION
- Correctly implement `get_multiple_accounts` in the `EmulatorAccountStorage`
- Cache deactivated Solana features when requested from Solana RPC
- Do not request Solana features when working with Clickhouse. TODO: @s-medvedev fix this