### PR TITLE
NDEV-3080 Neon-API Optimizations, part 2

### DIFF
--- a/evm_loader/Cargo.lock
+++ b/evm_loader/Cargo.lock
@@ -3367,6 +3367,7 @@ dependencies = [
  "goblin 0.6.1",
  "hex",
  "hex-literal",
+ "hyper",
  "lazy_static",
  "log",
  "neon-lib-interface",

--- a/evm_loader/api/src/api_server/handlers/mod.rs
+++ b/evm_loader/api/src/api_server/handlers/mod.rs
@@ -67,6 +67,7 @@ fn process_error(status_code: StatusCode, e: &NeonError) -> (Json<Value>, Status
         Json(json!({
             "result": "error",
             "error": e.to_string(),
+            "error_code": e.error_code(),
         })),
         status_code,
     )

--- a/evm_loader/lib/Cargo.toml
+++ b/evm_loader/lib/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 thiserror = "1.0"
 anyhow = "1.0"
 bincode = "1.3.1"
+hyper = "0.14"
 evm-loader = { path = "../program", default-features = false, features = ["log", "async-trait"] }
 solana-sdk.workspace = true
 solana-client.workspace = true

--- a/evm_loader/lib/src/account_storage.rs
+++ b/evm_loader/lib/src/account_storage.rs
@@ -146,8 +146,8 @@ impl<'rpc, T: Rpc + BuildConfigSimulator> EmulatorAccountStorage<'rpc, T> {
         let rent_account = rpc
             .get_account(&solana_sdk::sysvar::rent::id())
             .await?
-            .value
             .ok_or(NeonError::AccountNotFound(solana_sdk::sysvar::rent::id()))?;
+
         let rent = bincode::deserialize::<Rent>(&rent_account.data)?;
         info!("Rent: {rent:?}");
 
@@ -299,7 +299,7 @@ impl<'a, T: Rpc> EmulatorAccountStorage<'_, T> {
         }
 
         let response = self.rpc.get_account(&pubkey).await?;
-        let account = self.accounts_cache.insert(pubkey, Box::new(response.value));
+        let account = self.accounts_cache.insert(pubkey, Box::new(response));
         Ok(account.as_ref())
     }
 

--- a/evm_loader/lib/src/account_storage_tests.rs
+++ b/evm_loader/lib/src/account_storage_tests.rs
@@ -13,7 +13,6 @@ mod mock_rpc_client {
     use crate::{commands::get_config::ConfigSimulator, rpc::Rpc};
     use async_trait::async_trait;
     use solana_client::client_error::Result as ClientResult;
-    use solana_client::rpc_response::{Response, RpcResponseContext, RpcResult};
     use solana_sdk::account::Account;
     use solana_sdk::clock::{Slot, UnixTimestamp};
     use solana_sdk::pubkey::Pubkey;
@@ -33,15 +32,9 @@ mod mock_rpc_client {
 
     #[async_trait(?Send)]
     impl Rpc for MockRpcClient {
-        async fn get_account(&self, key: &Pubkey) -> RpcResult<Option<Account>> {
+        async fn get_account(&self, key: &Pubkey) -> ClientResult<Option<Account>> {
             let result = self.accounts.get(key).cloned();
-            Ok(Response {
-                context: RpcResponseContext {
-                    slot: 0,
-                    api_version: None,
-                },
-                value: result,
-            })
+            Ok(result)
         }
 
         async fn get_multiple_accounts(

--- a/evm_loader/lib/src/commands/emulate.rs
+++ b/evm_loader/lib/src/commands/emulate.rs
@@ -174,7 +174,7 @@ async fn emulate_trx<T: Tracer>(
 
     let (exit_status, steps_executed, tracer) = evm.execute(step_limit, &mut backend).await?;
     if exit_status == ExitStatus::StepLimit {
-        return Err(NeonError::TooManySteps);
+        return Ok((EmulateResponse::revert(&NeonError::TooManySteps), None));
     }
 
     debug!("Execute done, result={exit_status:?}");

--- a/evm_loader/lib/src/commands/get_config.rs
+++ b/evm_loader/lib/src/commands/get_config.rs
@@ -299,6 +299,19 @@ pub async fn read_chains(
     Ok(chains)
 }
 
+pub async fn read_legacy_chain_id(
+    rpc: &impl BuildConfigSimulator,
+    program_id: Pubkey,
+) -> NeonResult<u64> {
+    for chain in read_chains(rpc, program_id).await? {
+        if chain.name == "neon" {
+            return Ok(chain.id);
+        }
+    }
+
+    unreachable!()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/evm_loader/lib/src/commands/get_holder.rs
+++ b/evm_loader/lib/src/commands/get_holder.rs
@@ -135,7 +135,7 @@ pub async fn execute(
     address: Pubkey,
 ) -> NeonResult<GetHolderResponse> {
     let response = rpc.get_account(&address).await?;
-    let Some(mut account) = response.value else {
+    let Some(mut account) = response else {
         return Ok(GetHolderResponse::empty());
     };
 

--- a/evm_loader/lib/src/commands/get_neon_elf.rs
+++ b/evm_loader/lib/src/commands/get_neon_elf.rs
@@ -170,7 +170,6 @@ pub async fn read_program_data_from_account(
     let account = rpc
         .get_account(evm_loader)
         .await?
-        .value
         .ok_or(NeonError::AccountNotFound(*evm_loader))?;
 
     if account.owner == bpf_loader::id() || account.owner == bpf_loader_deprecated::id() {
@@ -180,7 +179,7 @@ pub async fn read_program_data_from_account(
             programdata_address,
         }) = account.state()
         {
-            let programdata_account = rpc.get_account(&programdata_address).await?.value.ok_or(
+            let programdata_account = rpc.get_account(&programdata_address).await?.ok_or(
                 NeonError::AssociatedPdaNotFound(programdata_address, config.evm_loader),
             )?;
 

--- a/evm_loader/lib/src/config.rs
+++ b/evm_loader/lib/src/config.rs
@@ -20,7 +20,9 @@ pub struct Config {
 pub struct APIOptions {
     pub solana_cli_config_path: Option<String>,
     pub commitment: CommitmentConfig,
-    pub json_rpc_url: String,
+    pub solana_url: String,
+    pub solana_timeout: u64,
+    pub solana_max_retries: usize,
     pub evm_loader: Pubkey,
     pub key_for_config: Pubkey,
     pub db_config: ChDbConfig,
@@ -38,7 +40,17 @@ pub fn load_api_config_from_environment() -> APIOptions {
         .and_then(|s| CommitmentConfig::from_str(&s).ok())
         .unwrap_or(CommitmentConfig::confirmed());
 
-    let json_rpc_url = env::var("SOLANA_URL").expect("solana url variable must be set");
+    let solana_url = env::var("SOLANA_URL").expect("solana url variable must be set");
+
+    let solana_timeout = env::var("SOLANA_TIMEOUT").unwrap_or_else(|_| "30".to_string());
+    let solana_timeout = solana_timeout
+        .parse()
+        .expect("SOLANA_TIMEOUT variable must be a valid number");
+
+    let solana_max_retries = env::var("SOLANA_MAX_RETRIES").unwrap_or_else(|_| "10".to_string());
+    let solana_max_retries = solana_max_retries
+        .parse()
+        .expect("SOLANA_MAX_RETRIES variable must be a valid number");
 
     let evm_loader = env::var("EVM_LOADER")
         .ok()
@@ -55,7 +67,9 @@ pub fn load_api_config_from_environment() -> APIOptions {
     APIOptions {
         solana_cli_config_path,
         commitment,
-        json_rpc_url,
+        solana_url,
+        solana_timeout,
+        solana_max_retries,
         evm_loader,
         key_for_config,
         db_config,

--- a/evm_loader/lib/src/errors.rs
+++ b/evm_loader/lib/src/errors.rs
@@ -73,8 +73,7 @@ pub enum NeonError {
     InvalidAssociatedPda(Pubkey, Pubkey),
     #[error("")]
     InvalidChDbConfig,
-    /// too many steps
-    #[error("Too many steps")]
+    #[error("Out of Gas. Exceeded maximum number of EVM opcodes")]
     TooManySteps,
     #[error("Incorrect address {0:?}.")]
     IncorrectAddress(String),
@@ -84,8 +83,6 @@ pub enum NeonError {
     TxParametersParsingError(String),
     #[error("AddrParseError. {0:?}")]
     AddrParseError(#[from] AddrParseError),
-    #[error("SolanaClientError. {0:?}")]
-    SolanaClientError(solana_client::client_error::ClientError),
     /// Environment Error
     #[error("Environment error {0:?}")]
     EnvironmentError(#[from] EnvironmentError),
@@ -141,7 +138,6 @@ impl NeonError {
             NeonError::PubkeyError(_) => 116,
             NeonError::EvmError(_) => 117,
             NeonError::AddrParseError(_) => 118,
-            NeonError::SolanaClientError(_) => 120,
             NeonError::EvmLoaderNotSpecified => 201,
             NeonError::KeypairNotSpecified => 202,
             NeonError::IncorrectProgram(_) => 203,

--- a/evm_loader/lib/src/rpc/db_call_client.rs
+++ b/evm_loader/lib/src/rpc/db_call_client.rs
@@ -5,7 +5,6 @@ use async_trait::async_trait;
 use solana_client::{
     client_error::Result as ClientResult,
     client_error::{ClientError, ClientErrorKind},
-    rpc_response::{Response, RpcResponseContext, RpcResult},
 };
 use solana_sdk::{
     account::Account,
@@ -40,16 +39,6 @@ impl CallDbClient {
         })
     }
 
-    async fn get_account(&self, key: &Pubkey) -> RpcResult<Option<Account>> {
-        Ok(Response {
-            context: RpcResponseContext {
-                slot: self.slot,
-                api_version: None,
-            },
-            value: self.get_account_at(key).await?,
-        })
-    }
-
     async fn get_account_at(&self, key: &Pubkey) -> ClientResult<Option<Account>> {
         self.tracer_db
             .get_account_at(key, self.slot, self.tx_index_in_block)
@@ -60,8 +49,8 @@ impl CallDbClient {
 
 #[async_trait(?Send)]
 impl Rpc for CallDbClient {
-    async fn get_account(&self, key: &Pubkey) -> RpcResult<Option<Account>> {
-        self.get_account(key).await
+    async fn get_account(&self, key: &Pubkey) -> ClientResult<Option<Account>> {
+        self.get_account_at(key).await
     }
 
     async fn get_multiple_accounts(

--- a/evm_loader/lib/src/rpc/emulator_client.rs
+++ b/evm_loader/lib/src/rpc/emulator_client.rs
@@ -1,9 +1,6 @@
 use async_trait::async_trait;
 use evm_loader::account_storage::AccountStorage;
-use solana_client::{
-    client_error::Result as ClientResult,
-    rpc_response::{Response, RpcResponseContext, RpcResult},
-};
+use solana_client::client_error::Result as ClientResult;
 use solana_sdk::{
     account::Account,
     clock::{Slot, UnixTimestamp},
@@ -16,35 +13,27 @@ use super::Rpc;
 
 #[async_trait(?Send)]
 impl<'rpc, T: Rpc> Rpc for EmulatorAccountStorage<'rpc, T> {
-    async fn get_account(&self, key: &Pubkey) -> RpcResult<Option<Account>> {
-        let block_number = self.block_number().as_u64();
-        let context = RpcResponseContext::new(block_number);
-
+    async fn get_account(&self, key: &Pubkey) -> ClientResult<Option<Account>> {
         if *key == self.operator() {
-            return Ok(Response {
-                context,
-                value: Some(fake_operator()),
-            });
+            return Ok(Some(fake_operator()));
         }
 
         if let Some(account_data) = self.accounts_get(key) {
-            return Ok(Response {
-                context,
-                value: Some(Account::from(&*account_data)),
-            });
+            return Ok(Some(Account::from(&*account_data)));
         }
 
         let account = self._get_account_from_rpc(*key).await?.cloned();
-        Ok(Response {
-            context,
-            value: account,
-        })
+        Ok(account)
     }
 
     async fn get_multiple_accounts(
         &self,
         pubkeys: &[Pubkey],
     ) -> ClientResult<Vec<Option<Account>>> {
+        if pubkeys.is_empty() {
+            return Ok(Vec::new());
+        }
+
         let mut accounts = vec![None; pubkeys.len()];
 
         let mut exists = vec![true; pubkeys.len()];

--- a/evm_loader/lib/src/rpc/mod.rs
+++ b/evm_loader/lib/src/rpc/mod.rs
@@ -10,7 +10,7 @@ use crate::{NeonError, NeonResult};
 use async_trait::async_trait;
 use enum_dispatch::enum_dispatch;
 use solana_cli::cli::CliError;
-use solana_client::{client_error::Result as ClientResult, rpc_response::RpcResult};
+use solana_client::client_error::Result as ClientResult;
 use solana_sdk::message::Message;
 use solana_sdk::native_token::lamports_to_sol;
 use solana_sdk::{
@@ -22,7 +22,7 @@ use solana_sdk::{
 #[async_trait(?Send)]
 #[enum_dispatch]
 pub trait Rpc {
-    async fn get_account(&self, key: &Pubkey) -> RpcResult<Option<Account>>;
+    async fn get_account(&self, key: &Pubkey) -> ClientResult<Option<Account>>;
     async fn get_multiple_accounts(&self, pubkeys: &[Pubkey])
         -> ClientResult<Vec<Option<Account>>>;
     async fn get_block_time(&self, slot: Slot) -> ClientResult<UnixTimestamp>;

--- a/evm_loader/lib/src/rpc/validator_client.rs
+++ b/evm_loader/lib/src/rpc/validator_client.rs
@@ -3,21 +3,70 @@ use crate::{config::APIOptions, Config};
 use super::Rpc;
 use async_trait::async_trait;
 use solana_client::{
-    client_error::Result as ClientResult, nonblocking::rpc_client::RpcClient,
-    rpc_response::RpcResult,
+    client_error::{ClientError, ClientErrorKind, Result as ClientResult},
+    nonblocking::rpc_client::RpcClient,
 };
 use solana_sdk::{
     account::Account,
     clock::{Slot, UnixTimestamp},
     pubkey::Pubkey,
 };
-use std::ops::Deref;
-use std::sync::Arc;
+use std::{error::Error, ops::Deref, time::Duration};
+use std::{future::Future, sync::Arc};
+
+fn should_retry(e: &ClientError) -> bool {
+    let ClientErrorKind::Reqwest(reqwest_error) = e.kind() else {
+        return false;
+    };
+
+    let Some(source) = reqwest_error.source() else {
+        return false;
+    };
+
+    let Some(hyper_error) = source.downcast_ref::<hyper::Error>() else {
+        return false;
+    };
+
+    if hyper_error.is_incomplete_message() {
+        return true;
+    }
+
+    let Some(hyper_source) = hyper_error.source() else {
+        return false;
+    };
+
+    let Some(io_error) = hyper_source.downcast_ref::<std::io::Error>() else {
+        return false;
+    };
+
+    io_error.kind() == std::io::ErrorKind::ConnectionReset
+}
+
+async fn with_retries<F, Fut, R>(max_retries: usize, request: F) -> ClientResult<R>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = ClientResult<R>>,
+{
+    for _ in 0..max_retries {
+        match request().await {
+            Ok(result) => return Ok(result),
+            Err(error) if should_retry(&error) => {
+                log::warn!("{}", error);
+                log::warn!("Retrying...");
+                continue;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(ClientErrorKind::Custom("Max number of retries exceeded".to_string()).into())
+}
 
 #[derive(Clone)]
 pub struct CloneRpcClient {
     pub rpc: Arc<RpcClient>,
     pub key_for_config: Pubkey,
+    pub max_retries: usize,
 }
 
 impl CloneRpcClient {
@@ -30,18 +79,21 @@ impl CloneRpcClient {
         Self {
             rpc: Arc::new(rpc_client),
             key_for_config: config.key_for_config,
+            max_retries: 10,
         }
     }
 
     #[must_use]
     pub fn new_from_api_config(config: &APIOptions) -> Self {
-        let url = config.json_rpc_url.clone();
+        let url = config.solana_url.clone();
         let commitment = config.commitment;
+        let timeout = Duration::from_secs(config.solana_timeout);
 
-        let rpc_client = RpcClient::new_with_commitment(url, commitment);
+        let rpc_client = RpcClient::new_with_timeout_and_commitment(url, timeout, commitment);
         Self {
             rpc: Arc::new(rpc_client),
             key_for_config: config.key_for_config,
+            max_retries: config.solana_max_retries,
         }
     }
 }
@@ -56,19 +108,31 @@ impl Deref for CloneRpcClient {
 
 #[async_trait(?Send)]
 impl Rpc for CloneRpcClient {
-    async fn get_account(&self, key: &Pubkey) -> RpcResult<Option<Account>> {
-        self.rpc
-            .get_account_with_commitment(key, self.commitment())
+    async fn get_account(&self, key: &Pubkey) -> ClientResult<Option<Account>> {
+        let request = || self.get_account_with_commitment(key, self.commitment());
+        with_retries(self.max_retries, request)
             .await
+            .map(|r| r.value)
     }
 
     async fn get_multiple_accounts(
         &self,
         pubkeys: &[Pubkey],
     ) -> ClientResult<Vec<Option<Account>>> {
-        let mut result: Vec<Option<Account>> = Vec::new();
+        if pubkeys.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        if pubkeys.len() == 1 {
+            let account = Rpc::get_account(self, &pubkeys[0]).await?;
+            return Ok(vec![account]);
+        }
+
+        let mut result: Vec<Option<Account>> = Vec::with_capacity(pubkeys.len());
         for chunk in pubkeys.chunks(100) {
-            let mut accounts = self.rpc.get_multiple_accounts(chunk).await?;
+            let request = || self.rpc.get_multiple_accounts(chunk);
+
+            let mut accounts = with_retries(self.max_retries, request).await?;
             result.append(&mut accounts);
         }
 
@@ -76,11 +140,11 @@ impl Rpc for CloneRpcClient {
     }
 
     async fn get_block_time(&self, slot: Slot) -> ClientResult<UnixTimestamp> {
-        self.rpc.get_block_time(slot).await
+        with_retries(self.max_retries, || self.rpc.get_block_time(slot)).await
     }
 
     async fn get_slot(&self) -> ClientResult<Slot> {
-        self.rpc.get_slot().await
+        with_retries(self.max_retries, || self.rpc.get_slot()).await
     }
 
     async fn get_deactivated_solana_features(&self) -> ClientResult<Vec<Pubkey>> {

--- a/evm_loader/lib/src/types/mod.rs
+++ b/evm_loader/lib/src/types/mod.rs
@@ -161,7 +161,7 @@ pub struct EmulateApiRequest {
     pub tx_index_in_block: Option<u64>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Default)]
+#[derive(Deserialize, Serialize, Debug, Default, Copy, Clone, Eq, PartialEq)]
 pub struct BalanceAddress {
     pub address: Address,
     pub chain_id: u64,


### PR DESCRIPTION
- Repeat requests to Solana multiple times in case of recoverable errors
- New env variables `SOLANA_TIMEOUT` (default 30) and `SOLANA_MAX_RETRIES` (default 10)
- `get_balance` and `get_contract` will return empty accounts instead of errors