### PR TITLE
NDEV-3095: Compare status and logs between emulation and receipt

### DIFF
--- a/evm_loader/lib/src/abi/trace.rs
+++ b/evm_loader/lib/src/abi/trace.rs
@@ -1,6 +1,7 @@
 use serde_json::Value;
 
 use super::params_to_neon_error;
+use crate::commands::emulate::EmulateResponse;
 use crate::commands::get_config::BuildConfigSimulator;
 use crate::commands::trace::{self};
 use crate::config::APIOptions;
@@ -11,7 +12,7 @@ pub async fn execute(
     rpc: &(impl Rpc + BuildConfigSimulator),
     config: &APIOptions,
     params: &str,
-) -> NeonResult<Value> {
+) -> NeonResult<(EmulateResponse, Option<Value>)> {
     let params: EmulateApiRequest =
         serde_json::from_str(params).map_err(|_| params_to_neon_error(params))?;
 

--- a/evm_loader/lib/src/account_storage.rs
+++ b/evm_loader/lib/src/account_storage.rs
@@ -1,8 +1,11 @@
 use crate::account_data::AccountData;
+use crate::commands::get_config::{BuildConfigSimulator, ChainInfo};
+use crate::tracing::{AccountOverrides, BlockOverrides};
 use crate::{rpc::Rpc, solana_simulator::SolanaSimulator, NeonError, NeonResult};
 use async_trait::async_trait;
 use elsa::FrozenMap;
 use ethnum::U256;
+use evm_loader::account_storage::LogCollector;
 pub use evm_loader::account_storage::{AccountStorage, SyncedAccountStorage};
 use evm_loader::{
     account::{
@@ -35,9 +38,7 @@ use std::{
     convert::TryInto,
     rc::Rc,
 };
-
-use crate::commands::get_config::{BuildConfigSimulator, ChainInfo};
-use crate::tracing::{AccountOverrides, BlockOverrides};
+use web3::types::Log;
 
 const FAKE_OPERATOR: Pubkey = pubkey!("neonoperator1111111111111111111111111111111");
 
@@ -114,6 +115,8 @@ pub struct EmulatorAccountStorage<'rpc, T: Rpc> {
     accounts_cache: FrozenMap<Pubkey, Box<Option<Account>>>,
     used_accounts: FrozenMap<Pubkey, Box<RefCell<SolanaAccount>>>,
     return_data: RefCell<Option<TransactionReturnData>>,
+    logs: Vec<Log>,
+    logs_stack: Vec<usize>,
 }
 
 impl<'rpc, T: Rpc + BuildConfigSimulator> EmulatorAccountStorage<'rpc, T> {
@@ -175,6 +178,8 @@ impl<'rpc, T: Rpc + BuildConfigSimulator> EmulatorAccountStorage<'rpc, T> {
             accounts_cache,
             used_accounts: FrozenMap::new(),
             return_data: RefCell::new(None),
+            logs: vec![],
+            logs_stack: vec![],
         };
 
         let target_chain_id = tx_chain_id.unwrap_or_else(|| storage.default_chain_id());
@@ -207,6 +212,8 @@ impl<'rpc, T: Rpc + BuildConfigSimulator> EmulatorAccountStorage<'rpc, T> {
             accounts_cache: other.accounts_cache.clone(),
             used_accounts: other.used_accounts.clone(),
             return_data: RefCell::new(None),
+            logs: other.logs.clone(),
+            logs_stack: other.logs_stack.clone(),
         };
         let target_chain_id = tx_chain_id.unwrap_or_else(|| storage.default_chain_id());
         storage.apply_balance_overrides(target_chain_id).await?;
@@ -908,6 +915,33 @@ impl<'a, T: Rpc> EmulatorAccountStorage<'_, T> {
     pub fn is_timestamp_used(&self) -> bool {
         *self.timestamp_used.borrow()
     }
+
+    pub fn logs(&self) -> Vec<Log> {
+        self.logs.clone()
+    }
+}
+
+impl<T: Rpc> LogCollector for EmulatorAccountStorage<'_, T> {
+    fn collect_log<const N: usize>(
+        &mut self,
+        address: &[u8; 20],
+        topics: [[u8; 32]; N],
+        data: &[u8],
+    ) {
+        self.logs.push(Log {
+            address: address.into(),
+            topics: topics.iter().map(Into::into).collect(),
+            data: data.into(),
+            block_hash: None,
+            block_number: None,
+            transaction_hash: None,
+            transaction_index: None,
+            log_index: None,
+            transaction_log_index: None,
+            log_type: None,
+            removed: None,
+        });
+    }
 }
 
 #[async_trait(?Send)]
@@ -1400,6 +1434,7 @@ impl<T: Rpc> SyncedAccountStorage for EmulatorAccountStorage<'_, T> {
     fn snapshot(&mut self) {
         info!("snapshot");
         self.call_stack.push(self.accounts.clone());
+        self.logs_stack.push(self.logs.len());
     }
 
     fn revert_snapshot(&mut self) {
@@ -1411,10 +1446,25 @@ impl<T: Rpc> SyncedAccountStorage for EmulatorAccountStorage<'_, T> {
         } else {
             self.execute_status.reverts_before_solana_calls = true;
         }
+
+        let logs_stack_len = self
+            .logs_stack
+            .pop()
+            .expect("Fatal Error: Inconsistent EVM Logs Stack");
+
+        self.logs.truncate(logs_stack_len);
+
+        if self.logs_stack.is_empty() {
+            // sanity check
+            assert!(self.logs.is_empty());
+        }
     }
 
     fn commit_snapshot(&mut self) {
         self.call_stack.pop().expect("No snapshots to commit");
+        self.logs_stack
+            .pop()
+            .expect("Fatal Error: Inconsistent EVM Logs Stack");
     }
 }
 

--- a/evm_loader/lib/src/commands/trace.rs
+++ b/evm_loader/lib/src/commands/trace.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::missing_errors_doc)]
 
+use crate::commands::emulate::EmulateResponse;
 use serde_json::Value;
 use solana_sdk::pubkey::Pubkey;
 
@@ -13,7 +14,7 @@ pub async fn trace_transaction(
     rpc: &(impl Rpc + BuildConfigSimulator),
     program_id: Pubkey,
     emulate_request: EmulateRequest,
-) -> Result<Value, NeonError> {
+) -> Result<(EmulateResponse, Option<Value>), NeonError> {
     let trace_config = emulate_request
         .trace_config
         .as_ref()
@@ -22,8 +23,5 @@ pub async fn trace_transaction(
 
     let tracer = new_tracer(&emulate_request.tx, trace_config)?;
 
-    let (_, emulated_traces) =
-        super::emulate::execute(rpc, program_id, emulate_request, Some(tracer)).await?;
-
-    Ok(emulated_traces.expect("traces should not be None"))
+    super::emulate::execute(rpc, program_id, emulate_request, Some(tracer)).await
 }

--- a/evm_loader/program/src/account_storage/backend.rs
+++ b/evm_loader/program/src/account_storage/backend.rs
@@ -73,7 +73,7 @@ impl<'a> AccountStorage for ProgramAccountStorage<'a> {
         solana_program::program::get_return_data()
     }
 
-    fn set_return_data(&self, data: &[u8]) {
+    fn set_return_data(&mut self, data: &[u8]) {
         solana_program::program::set_return_data(data);
     }
 

--- a/evm_loader/program/src/account_storage/backend.rs
+++ b/evm_loader/program/src/account_storage/backend.rs
@@ -1,4 +1,4 @@
-use crate::account_storage::{AccountStorage, ProgramAccountStorage};
+use crate::account_storage::{AccountStorage, LogCollector, ProgramAccountStorage};
 use crate::config::STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT;
 use crate::error::Result;
 use crate::executor::OwnedAccountInfo;
@@ -7,6 +7,43 @@ use ethnum::U256;
 use solana_program::account_info::AccountInfo;
 use solana_program::{pubkey::Pubkey, rent::Rent, sysvar::slot_hashes};
 use std::convert::TryInto;
+
+use crate::debug::log_data;
+
+impl LogCollector for ProgramAccountStorage<'_> {
+    fn collect_log<const N: usize>(
+        &mut self,
+        address: &[u8; 20],
+        topics: [[u8; 32]; N],
+        data: &[u8],
+    ) {
+        match N {
+            0 => log_data(&[b"LOG0", address, &[0], data]),
+            1 => log_data(&[b"LOG1", address, &[1], &topics[0], data]),
+            2 => log_data(&[b"LOG2", address, &[2], &topics[0], &topics[1], data]),
+            3 => log_data(&[
+                b"LOG3",
+                address,
+                &[3],
+                &topics[0],
+                &topics[1],
+                &topics[2],
+                data,
+            ]),
+            4 => log_data(&[
+                b"LOG4",
+                address,
+                &[4],
+                &topics[0],
+                &topics[1],
+                &topics[2],
+                &topics[3],
+                data,
+            ]),
+            _ => unreachable!(),
+        }
+    }
+}
 
 impl<'a> AccountStorage for ProgramAccountStorage<'a> {
     fn program_id(&self) -> &Pubkey {

--- a/evm_loader/program/src/account_storage/mod.rs
+++ b/evm_loader/program/src/account_storage/mod.rs
@@ -56,7 +56,7 @@ pub trait AccountStorage: LogCollector {
     fn return_data(&self) -> Option<(Pubkey, Vec<u8>)>;
 
     /// Set return data to Solana
-    fn set_return_data(&self, data: &[u8]);
+    fn set_return_data(&mut self, data: &[u8]);
 
     /// Get account nonce
     async fn nonce(&self, address: Address, chain_id: u64) -> u64;

--- a/evm_loader/program/src/account_storage/mod.rs
+++ b/evm_loader/program/src/account_storage/mod.rs
@@ -36,7 +36,7 @@ pub struct ProgramAccountStorage<'a> {
 /// Account storage
 /// Trait to access account info
 #[maybe_async(?Send)]
-pub trait AccountStorage {
+pub trait AccountStorage: LogCollector {
     /// Get `NeonEVM` program id
     fn program_id(&self) -> &Pubkey;
     /// Get operator pubkey
@@ -95,7 +95,7 @@ pub trait AccountStorage {
 }
 
 #[maybe_async(?Send)]
-pub trait SyncedAccountStorage {
+pub trait SyncedAccountStorage: AccountStorage {
     async fn set_code(&mut self, address: Address, chain_id: u64, code: Vec<u8>) -> Result<()>;
     async fn set_storage(&mut self, address: Address, index: U256, value: [u8; 32]) -> Result<()>;
     async fn increment_nonce(&mut self, address: Address, chain_id: u64) -> Result<()>;
@@ -118,4 +118,13 @@ pub trait SyncedAccountStorage {
     fn snapshot(&mut self);
     fn revert_snapshot(&mut self);
     fn commit_snapshot(&mut self);
+}
+
+pub trait LogCollector {
+    fn collect_log<const N: usize>(
+        &mut self,
+        address: &[u8; 20],
+        topics: [[u8; 32]; N],
+        data: &[u8],
+    );
 }

--- a/evm_loader/program/src/evm/database.rs
+++ b/evm_loader/program/src/evm/database.rs
@@ -1,4 +1,5 @@
 use super::{Buffer, Context};
+use crate::account_storage::LogCollector;
 use crate::{error::Result, executor::OwnedAccountInfo, types::Address};
 use ethnum::U256;
 use maybe_async::maybe_async;
@@ -7,7 +8,7 @@ use solana_program::{
 };
 
 #[maybe_async(?Send)]
-pub trait Database {
+pub trait Database: LogCollector {
     fn program_id(&self) -> &Pubkey;
     fn operator(&self) -> Pubkey;
     fn chain_id_to_token(&self, chain_id: u64) -> Pubkey;

--- a/evm_loader/program/src/instruction/transaction_execute.rs
+++ b/evm_loader/program/src/instruction/transaction_execute.rs
@@ -26,7 +26,7 @@ pub fn execute(
     account_storage.origin(origin, &trx)?.increment_nonce()?;
 
     let (exit_reason, apply_state, steps_executed) = {
-        let mut backend = ExecutorState::new(&account_storage);
+        let mut backend = ExecutorState::new(&mut account_storage);
 
         let mut evm = Machine::new(&trx, origin, &mut backend, None::<NoopEventListener>)?;
         let (result, steps_executed, _) = evm.execute(u64::MAX, &mut backend)?;


### PR DESCRIPTION
Updated neon-api emulation process to also return the Ethereum logs generated, taking into account reverts too.