### PR TITLE
SLA-109 Use special constant for operator account inside the action list

### DIFF
--- a/evm_loader/lib/src/account_storage.rs
+++ b/evm_loader/lib/src/account_storage.rs
@@ -9,7 +9,7 @@ use evm_loader::{
         legacy::{LegacyEtherData, LegacyStorageData},
         BalanceAccount, ContractAccount, StorageCell, StorageCellAddress,
     },
-    account_storage::find_slot_hash,
+    account_storage::{find_slot_hash, FAKE_OPERATOR},
     config::STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT,
     error::Error as EvmLoaderError,
     executor::OwnedAccountInfo,
@@ -22,7 +22,6 @@ use solana_sdk::{
     clock::Clock,
     instruction::Instruction,
     program_error::ProgramError,
-    pubkey,
     pubkey::{Pubkey, PubkeyError},
     rent::Rent,
     system_program,
@@ -38,8 +37,6 @@ use std::{
 
 use crate::commands::get_config::{BuildConfigSimulator, ChainInfo};
 use crate::tracing::{AccountOverrides, BlockOverrides};
-
-const FAKE_OPERATOR: Pubkey = pubkey!("neonoperator1111111111111111111111111111111");
 
 #[derive(Default, Clone, Copy)]
 pub struct ExecuteStatus {
@@ -1333,7 +1330,7 @@ impl<T: Rpc> SyncedAccountStorage for EmulatorAccountStorage<'_, T> {
         self.mark_account(instruction.program_id, false);
 
         for meta in &instruction.accounts {
-            if meta.pubkey != self.operator {
+            if meta.pubkey != FAKE_OPERATOR {
                 self.use_account(meta.pubkey, meta.is_writable)
                     .await
                     .map_err(map_neon_error)?;

--- a/evm_loader/lib/src/account_storage.rs
+++ b/evm_loader/lib/src/account_storage.rs
@@ -1363,7 +1363,7 @@ impl<T: Rpc> SyncedAccountStorage for EmulatorAccountStorage<'_, T> {
         self.mark_account(instruction.program_id, false);
 
         for meta in &instruction.accounts {
-            if meta.pubkey != FAKE_OPERATOR {
+            if meta.pubkey != self.operator {
                 self.use_account(meta.pubkey, meta.is_writable)
                     .await
                     .map_err(map_neon_error)?;

--- a/evm_loader/program/src/account/mod.rs
+++ b/evm_loader/program/src/account/mod.rs
@@ -4,7 +4,7 @@ use solana_program::pubkey::Pubkey;
 use solana_program::rent::Rent;
 use std::cell::{Ref, RefMut};
 
-pub use crate::config::ACCOUNT_SEED_VERSION;
+pub use crate::{account_storage::FAKE_OPERATOR, config::ACCOUNT_SEED_VERSION};
 
 pub use ether_balance::{BalanceAccount, Header as BalanceHeader};
 pub use ether_contract::{AllocateResult, ContractAccount, Header as ContractHeader};
@@ -272,6 +272,9 @@ impl<'a> AccountsDB<'a> {
 
     #[must_use]
     pub fn get(&self, pubkey: &Pubkey) -> &AccountInfo<'a> {
+        if pubkey == &FAKE_OPERATOR || pubkey == self.operator.key {
+            return self.operator_info();
+        }
         let index = self
             .sorted_accounts
             .binary_search_by_key(&pubkey, |a| a.key)

--- a/evm_loader/program/src/account_storage/apply.rs
+++ b/evm_loader/program/src/account_storage/apply.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use ethnum::U256;
-use solana_program::instruction::{AccountMeta, Instruction};
+use solana_program::instruction::Instruction;
 use solana_program::program::{invoke_signed_unchecked, invoke_unchecked};
 use solana_program::system_program;
 
@@ -131,7 +131,7 @@ impl<'a> ProgramAccountStorage<'a> {
                 }
                 Action::ExternalInstruction {
                     program_id,
-                    accounts,
+                    mut accounts,
                     data,
                     seeds,
                     ..
@@ -143,30 +143,21 @@ impl<'a> ProgramAccountStorage<'a> {
                     let seeds = seeds.iter().map(|s| s.as_slice()).collect::<Vec<_>>();
 
                     let mut accounts_info = Vec::with_capacity(accounts.len() + 1);
-                    let mut accounts_changed = Vec::with_capacity(accounts.len());
 
                     let program = self.accounts.get(&program_id).clone();
                     accounts_info.push(program);
 
-                    for meta in &accounts {
-                        let (account, meta) = if meta.pubkey == FAKE_OPERATOR {
-                            (
-                                self.accounts.operator_info().clone(),
-                                AccountMeta {
-                                    pubkey: self.accounts.operator_key(),
-                                    ..meta.clone()
-                                },
-                            )
-                        } else {
-                            (self.accounts.get(&meta.pubkey).clone(), meta.clone())
-                        };
+                    for meta in &mut accounts {
+                        if meta.pubkey == FAKE_OPERATOR {
+                            meta.pubkey = self.accounts.operator_key();
+                        }
+                        let account = self.accounts.get(&meta.pubkey).clone();
                         accounts_info.push(account);
-                        accounts_changed.push(meta);
                     }
 
                     let instruction = Instruction {
                         program_id,
-                        accounts: accounts_changed,
+                        accounts,
                         data,
                     };
 

--- a/evm_loader/program/src/account_storage/apply.rs
+++ b/evm_loader/program/src/account_storage/apply.rs
@@ -149,12 +149,11 @@ impl<'a> ProgramAccountStorage<'a> {
                     accounts_info.push(program);
 
                     for meta in &accounts {
-                        let account: AccountInfo<'a> =
-                            if meta.pubkey == self.accounts.operator_key() {
-                                self.accounts.operator_info().clone()
-                            } else {
-                                self.accounts.get(&meta.pubkey).clone()
-                            };
+                        let account: AccountInfo<'a> = if meta.pubkey == FAKE_OPERATOR {
+                            self.accounts.operator_info().clone()
+                        } else {
+                            self.accounts.get(&meta.pubkey).clone()
+                        };
                         accounts_info.push(account);
                     }
 

--- a/evm_loader/program/src/account_storage/apply.rs
+++ b/evm_loader/program/src/account_storage/apply.rs
@@ -7,7 +7,7 @@ use solana_program::program::{invoke_signed_unchecked, invoke_unchecked};
 use solana_program::system_program;
 
 use crate::account::{AllocateResult, BalanceAccount, ContractAccount, StorageCell};
-use crate::account_storage::ProgramAccountStorage;
+use crate::account_storage::{ProgramAccountStorage, FAKE_OPERATOR};
 use crate::config::{
     ACCOUNT_SEED_VERSION, PAYMENT_TO_TREASURE, STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT,
 };

--- a/evm_loader/program/src/account_storage/backend.rs
+++ b/evm_loader/program/src/account_storage/backend.rs
@@ -1,4 +1,4 @@
-use crate::account_storage::{AccountStorage, LogCollector, ProgramAccountStorage, FAKE_OPERATOR};
+use crate::account_storage::{AccountStorage, LogCollector, ProgramAccountStorage};
 use crate::config::STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT;
 use crate::error::Result;
 use crate::executor::OwnedAccountInfo;
@@ -164,12 +164,7 @@ impl<'a> AccountStorage for ProgramAccountStorage<'a> {
     fn clone_solana_account(&self, address: &Pubkey) -> OwnedAccountInfo {
         // This is used to emulate external instruction
         // One of instruction accounts can be operator
-        let info = if address == &FAKE_OPERATOR || address == &self.accounts.operator_key() {
-            self.accounts.operator_info()
-        } else {
-            self.accounts.get(address)
-        };
-
+        let info = self.accounts.get(address);
         OwnedAccountInfo::from_account_info(self.program_id(), info)
     }
 

--- a/evm_loader/program/src/account_storage/backend.rs
+++ b/evm_loader/program/src/account_storage/backend.rs
@@ -1,4 +1,4 @@
-use crate::account_storage::{AccountStorage, ProgramAccountStorage};
+use crate::account_storage::{AccountStorage, ProgramAccountStorage, FAKE_OPERATOR};
 use crate::config::STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT;
 use crate::error::Result;
 use crate::executor::OwnedAccountInfo;
@@ -127,7 +127,7 @@ impl<'a> AccountStorage for ProgramAccountStorage<'a> {
     fn clone_solana_account(&self, address: &Pubkey) -> OwnedAccountInfo {
         // This is used to emulate external instruction
         // One of instruction accounts can be operator
-        let info = if address == &self.accounts.operator_key() {
+        let info = if address == &FAKE_OPERATOR || address == &self.accounts.operator_key() {
             self.accounts.operator_info()
         } else {
             self.accounts.get(address)

--- a/evm_loader/program/src/account_storage/mod.rs
+++ b/evm_loader/program/src/account_storage/mod.rs
@@ -4,7 +4,7 @@ use crate::types::Address;
 use ethnum::U256;
 use maybe_async::maybe_async;
 use solana_program::{
-    account_info::AccountInfo, instruction::Instruction, pubkey::Pubkey, rent::Rent,
+    account_info::AccountInfo, instruction::Instruction, pubkey, pubkey::Pubkey, rent::Rent,
 };
 #[cfg(target_os = "solana")]
 use {crate::account::AccountsDB, solana_program::clock::Clock};
@@ -32,6 +32,8 @@ pub struct ProgramAccountStorage<'a> {
     keys: keys_cache::KeysCache,
     synced_modified_contracts: std::collections::HashSet<Pubkey>,
 }
+
+pub const FAKE_OPERATOR: Pubkey = pubkey!("neonoperator1111111111111111111111111111111");
 
 /// Account storage
 /// Trait to access account info

--- a/evm_loader/program/src/account_storage/synced.rs
+++ b/evm_loader/program/src/account_storage/synced.rs
@@ -5,7 +5,7 @@ use solana_program::program::{invoke_signed_unchecked, invoke_unchecked};
 use solana_program::system_program;
 
 use crate::account::{AllocateResult, ContractAccount, StorageCell};
-use crate::account_storage::SyncedAccountStorage;
+use crate::account_storage::{SyncedAccountStorage, FAKE_OPERATOR};
 use crate::config::{ACCOUNT_SEED_VERSION, STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT};
 use crate::error::Result;
 use crate::types::Address;

--- a/evm_loader/program/src/account_storage/synced.rs
+++ b/evm_loader/program/src/account_storage/synced.rs
@@ -119,7 +119,7 @@ impl<'a> SyncedAccountStorage for crate::account_storage::ProgramAccountStorage<
         accounts_info.push(program);
 
         for meta in &instruction.accounts {
-            let account: AccountInfo<'a> = if meta.pubkey == self.accounts.operator_key() {
+            let account: AccountInfo<'a> = if meta.pubkey == FAKE_OPERATOR {
                 self.accounts.operator_info().clone()
             } else {
                 self.accounts.get(&meta.pubkey).clone()

--- a/evm_loader/program/src/executor/precompile_extension/call_solana.rs
+++ b/evm_loader/program/src/executor/precompile_extension/call_solana.rs
@@ -1,4 +1,5 @@
 use crate::{
+    account_storage::FAKE_OPERATOR,
     config::ACCOUNT_SEED_VERSION,
     error::{Error, Result},
     evm::database::Database,
@@ -321,7 +322,10 @@ async fn execute_external_instruction<State: Database>(
     }
 
     for meta in &instruction.accounts {
-        if meta.pubkey == state.operator() || meta.pubkey == *state.program_id() {
+        if meta.pubkey == FAKE_OPERATOR
+            || meta.pubkey == state.operator()
+            || meta.pubkey == *state.program_id()
+        {
             return Err(Error::InvalidAccountForCall(meta.pubkey));
         }
     }
@@ -345,7 +349,7 @@ async fn execute_external_instruction<State: Database>(
         let payer = state.external_account(payer_pubkey).await?;
         if payer.lamports < required_lamports {
             let transfer_instruction = solana_program::system_instruction::transfer(
-                &state.operator(),
+                &FAKE_OPERATOR,
                 &payer_pubkey,
                 required_lamports - payer.lamports,
             );
@@ -367,7 +371,7 @@ async fn execute_external_instruction<State: Database>(
         if payer.lamports > 0 {
             let transfer_instruction = solana_program::system_instruction::transfer(
                 &payer_pubkey,
-                &state.operator(),
+                &FAKE_OPERATOR,
                 payer.lamports,
             );
             state

--- a/evm_loader/program/src/executor/precompile_extension/metaplex.rs
+++ b/evm_loader/program/src/executor/precompile_extension/metaplex.rs
@@ -14,6 +14,7 @@ use solana_program::pubkey::Pubkey;
 
 use crate::{
     account::ACCOUNT_SEED_VERSION,
+    account_storage::FAKE_OPERATOR,
     error::{Error, Result},
     evm::database::Database,
     types::Address,
@@ -201,7 +202,7 @@ async fn create_metadata<State: Database>(
         .mint(mint)
         .mint_authority(signer_pubkey)
         .update_authority(signer_pubkey, true)
-        .payer(state.operator())
+        .payer(FAKE_OPERATOR)
         .is_mutable(true)
         .data(DataV2 {
             name,
@@ -259,7 +260,7 @@ async fn create_master_edition<State: Database>(
         .mint(mint)
         .mint_authority(signer_pubkey)
         .update_authority(signer_pubkey)
-        .payer(state.operator());
+        .payer(FAKE_OPERATOR);
 
     if let Some(max_supply) = max_supply {
         instruction_builder.max_supply(max_supply);

--- a/evm_loader/program/src/executor/precompile_extension/mod.rs
+++ b/evm_loader/program/src/executor/precompile_extension/mod.rs
@@ -1,4 +1,5 @@
 use crate::{
+    account_storage::FAKE_OPERATOR,
     error::Result,
     evm::{database::Database, Context},
     types::Address,
@@ -89,7 +90,7 @@ pub async fn create_account<State: Database>(
 
     if required_lamports > 0 {
         let transfer =
-            system_instruction::transfer(&state.operator(), &account.key, required_lamports);
+            system_instruction::transfer(&FAKE_OPERATOR, &account.key, required_lamports);
         state
             .queue_external_instruction(transfer, vec![], required_lamports, true)
             .await?;

--- a/evm_loader/program/src/executor/precompile_extension/neon_token.rs
+++ b/evm_loader/program/src/executor/precompile_extension/neon_token.rs
@@ -8,6 +8,7 @@ use spl_associated_token_account::get_associated_token_address;
 
 use crate::{
     account::token,
+    account_storage::FAKE_OPERATOR,
     error::{Error, Result},
     evm::database::Database,
     types::Address,
@@ -107,12 +108,8 @@ async fn withdraw<State: Database>(
     if !spl_token::check_id(&account.owner) {
         use spl_associated_token_account::instruction::create_associated_token_account;
 
-        let create_associated = create_associated_token_account(
-            &state.operator(),
-            &target,
-            &mint_address,
-            &spl_token::ID,
-        );
+        let create_associated =
+            create_associated_token_account(&FAKE_OPERATOR, &target, &mint_address, &spl_token::ID);
 
         let fee = state.rent().minimum_balance(spl_token::state::Account::LEN);
         state

--- a/evm_loader/program/src/executor/precompile_extension/spl_token.rs
+++ b/evm_loader/program/src/executor/precompile_extension/spl_token.rs
@@ -9,6 +9,7 @@ use solana_program::{
 use super::create_account;
 use crate::{
     account::ACCOUNT_SEED_VERSION,
+    account_storage::FAKE_OPERATOR,
     error::{Error, Result},
     evm::database::Database,
     types::Address,
@@ -389,7 +390,7 @@ async fn close_account<State: Database>(
     let close_account = spl_token::instruction::close_account(
         &spl_token::ID,
         &account,
-        &state.operator(),
+        &FAKE_OPERATOR,
         &signer_pubkey,
         &[],
     )?;

--- a/evm_loader/program/src/executor/state.rs
+++ b/evm_loader/program/src/executor/state.rs
@@ -446,7 +446,7 @@ impl<'a, B: AccountStorage> Database for ExecutorState<'a, B> {
             self.touch_solana(m.pubkey);
 
             let account = self.backend.clone_solana_account(&m.pubkey).await;
-            accounts.insert(account.key, account);
+            accounts.insert(m.pubkey, account);
         }
 
         for action in &self.actions {


### PR DESCRIPTION
NeonEVM puts `Action::ExternalInstriction` with the current operator on each iteration. If different operators executed iterations it leads to a problem, because on the final iteration, we have an action with the previous operator.

Solution: we put a special constant to the action list and change this constant with the real operator in the final iteration.