### PR TITLE
SLA-119: Fix DELEGATECALL "to" address in callTracer

### DIFF
--- a/evm_loader/lib/src/tracing/tracers/call_tracer.rs
+++ b/evm_loader/lib/src/tracing/tracers/call_tracer.rs
@@ -246,7 +246,7 @@ impl CallTracer {
         if self.depth == 1 {
             let call_frame = &mut self.call_stack[0];
             call_frame.from = context.caller;
-            call_frame.to = Some(context.contract);
+            call_frame.to = context.code_address.or(Some(context.contract));
             call_frame.input = input.into();
             call_frame.value = Some(to_web3_u256(context.value));
             call_frame.type_string = opcode;
@@ -259,7 +259,7 @@ impl CallTracer {
 
         self.call_stack.push(CallFrame {
             from: context.caller,
-            to: Some(context.contract),
+            to: context.code_address.or(Some(context.contract)),
             input: input.into(),
             value: Some(to_web3_u256(context.value)),
             type_string: opcode,


### PR DESCRIPTION
In case of `DELEGATECALL` opcode, `"to"` address in a `CallFrame` of `callTracer` needs to be the address of the delegate contract, as in [Go Ethereum](https://github.com/ethereum/go-ethereum/blob/master/core/vm/evm.go#L336).