### PR TITLE
NDEV-3096. Get Account State after emulation for debug_traceTransacti…

### DIFF
--- a/evm_loader/lib/src/account_data.rs
+++ b/evm_loader/lib/src/account_data.rs
@@ -11,13 +11,19 @@ use solana_sdk::{
 
 pub use evm_loader::account_storage::{AccountStorage, SyncedAccountStorage};
 use evm_loader::solana_program::debug_account_data::debug_account_data;
+use serde::{Deserialize, Serialize};
+use serde_with::hex::Hex;
+use serde_with::serde_as;
 
-#[derive(Clone)]
+#[allow(clippy::unsafe_derive_deserialize)]
+#[serde_as]
+#[derive(Clone, Serialize, Deserialize)]
 #[repr(C)]
 pub struct AccountData {
     original_length: u32,
     pub pubkey: Pubkey,
     pub lamports: u64,
+    #[serde_as(as = "Hex")]
     data: Vec<u8>,
     pub owner: Pubkey,
     pub executable: bool,

--- a/evm_loader/lib/src/commands/emulate.rs
+++ b/evm_loader/lib/src/commands/emulate.rs
@@ -1,3 +1,4 @@
+use crate::account_data::AccountData;
 use crate::commands::get_config::BuildConfigSimulator;
 use crate::rpc::Rpc;
 use crate::tracing::tracers::Tracer;
@@ -30,6 +31,7 @@ pub struct SolanaAccount {
     pub is_writable: bool,
     pub is_legacy: bool,
 }
+
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmulateResponse {
@@ -44,6 +46,7 @@ pub struct EmulateResponse {
     pub iterations: u64,
     pub solana_accounts: Vec<SolanaAccount>,
     pub logs: Vec<Log>,
+    pub accounts_data: Option<Vec<AccountData>>,
 }
 
 impl EmulateResponse {
@@ -64,6 +67,7 @@ impl EmulateResponse {
             iterations: 0,
             solana_accounts: vec![],
             logs: backend.backend().logs(),
+            accounts_data: None,
         }
     }
 }
@@ -104,7 +108,8 @@ pub async fn execute<T: Tracer>(
 
     let step_limit = emulate_request.step_limit.unwrap_or(100_000);
 
-    let result = emulate_trx(emulate_request.tx.clone(), &mut storage, step_limit, tracer).await?;
+    let mut result =
+        emulate_trx(emulate_request.tx.clone(), &mut storage, step_limit, tracer).await?;
 
     if storage.is_timestamp_used() {
         let mut storage2 =
@@ -134,13 +139,14 @@ pub async fn execute<T: Tracer>(
                 }
             });
 
-            let emul_response = EmulateResponse {
+            result.0 = EmulateResponse {
                 // We get the result from the first response (as it is executed on the current time)
                 result: response.result.clone(),
                 exit_status: response.exit_status.to_string(),
                 external_solana_call: response.external_solana_call,
                 reverts_before_solana_calls: response.reverts_before_solana_calls,
                 reverts_after_solana_calls: response.reverts_after_solana_calls,
+                accounts_data: None,
 
                 // ...and consumed resources from the both responses (because the real execution can occur in the future)
                 steps_executed: response.steps_executed.max(response2.steps_executed),
@@ -149,9 +155,11 @@ pub async fn execute<T: Tracer>(
                 solana_accounts: combined_solana_accounts,
                 logs: response.logs.clone(),
             };
-
-            return Ok((emul_response, result.1));
         }
+    }
+
+    if emulate_request.provide_account_info.unwrap_or(false) {
+        result.0.accounts_data = Some(provide_account_data(&storage, &result.0.solana_accounts));
     }
 
     Ok(result)
@@ -234,7 +242,22 @@ async fn emulate_trx<T: Tracer>(
             result: exit_status.into_result().unwrap_or_default(),
             iterations,
             logs,
+            accounts_data: None,
         },
         tracer.map(|tracer| tracer.into_traces(used_gas)),
     ))
+}
+
+fn provide_account_data(
+    storage: &EmulatorAccountStorage<impl Rpc>,
+    solana_accounts: &Vec<SolanaAccount>,
+) -> Vec<AccountData> {
+    let mut accounts_data = Vec::<AccountData>::new();
+    for account in solana_accounts {
+        if let Some(account_data) = storage.accounts_get(&account.pubkey) {
+            accounts_data.push(account_data.clone());
+        }
+    }
+
+    accounts_data
 }

--- a/evm_loader/lib/src/types/mod.rs
+++ b/evm_loader/lib/src/types/mod.rs
@@ -169,6 +169,7 @@ pub struct EmulateRequest {
     pub accounts: Vec<Pubkey>,
     #[serde_as(as = "Option<HashMap<DisplayFromStr,_>>")]
     pub solana_overrides: Option<HashMap<Pubkey, Option<SerializedAccount>>>,
+    pub provide_account_info: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/evm_loader/lib/src/types/mod.rs
+++ b/evm_loader/lib/src/types/mod.rs
@@ -159,6 +159,13 @@ impl From<&SerializedAccount> for Account {
 }
 
 #[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum AccountInfoLevel {
+    Changed,
+    All,
+}
+
+#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmulateRequest {
     pub tx: TxParams,
@@ -169,7 +176,7 @@ pub struct EmulateRequest {
     pub accounts: Vec<Pubkey>,
     #[serde_as(as = "Option<HashMap<DisplayFromStr,_>>")]
     pub solana_overrides: Option<HashMap<Pubkey, Option<SerializedAccount>>>,
-    pub provide_account_info: Option<bool>,
+    pub provide_account_info: Option<AccountInfoLevel>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -382,8 +389,9 @@ mod tests {
                     "rent_epoch": 0,
                     "data": "0102030405"
                 }
-            }
-        }        
+            },
+            "provide_account_info": null
+        }
         "#;
 
         let request: super::EmulateRequest = serde_json::from_str(txt).unwrap();

--- a/evm_loader/lib/src/types/tracer_ch_common.rs
+++ b/evm_loader/lib/src/types/tracer_ch_common.rs
@@ -8,6 +8,8 @@ use std::collections::BTreeMap;
 use std::time::Instant;
 use thiserror::Error;
 
+use crate::account_data::AccountData;
+
 pub const ROOT_BLOCK_DELAY: u8 = 100;
 
 #[derive(Error, Debug)]
@@ -65,6 +67,7 @@ pub struct RevisionRow {
 
 #[derive(Row, serde::Deserialize, Clone)]
 pub struct AccountRow {
+    pub pubkey: Vec<u8>,
     pub owner: Vec<u8>,
     pub lamports: u64,
     pub executable: bool,
@@ -78,6 +81,7 @@ impl fmt::Debug for AccountRow {
         let mut debug_struct = f.debug_struct("AccountRow");
 
         debug_struct
+            .field("pubkey", &bs58::encode(&self.pubkey).into_string())
             .field("owner", &bs58::encode(&self.owner).into_string())
             .field("lamports", &self.lamports)
             .field("executable", &self.executable)
@@ -101,16 +105,20 @@ impl fmt::Debug for AccountRow {
     }
 }
 
+fn pubkey_from(src: Vec<u8>) -> Result<Pubkey, String> {
+    Pubkey::try_from(src).map_err(|src| {
+        format!(
+            "Incorrect slice length ({}) while converting owner from: {src:?}",
+            src.len(),
+        )
+    })
+}
+
 impl TryInto<Account> for AccountRow {
     type Error = String;
 
     fn try_into(self) -> Result<Account, Self::Error> {
-        let owner = Pubkey::try_from(self.owner).map_err(|src| {
-            format!(
-                "Incorrect slice length ({}) while converting owner from: {src:?}",
-                src.len(),
-            )
-        })?;
+        let owner = pubkey_from(self.owner)?;
 
         Ok(Account {
             lamports: self.lamports,
@@ -119,6 +127,26 @@ impl TryInto<Account> for AccountRow {
             rent_epoch: self.rent_epoch,
             executable: self.executable,
         })
+    }
+}
+
+impl TryInto<AccountData> for AccountRow {
+    type Error = String;
+
+    fn try_into(self) -> Result<AccountData, Self::Error> {
+        let owner = pubkey_from(self.owner)?;
+        let pubkey = pubkey_from(self.pubkey)?;
+
+        Ok(AccountData::new_from_account(
+            pubkey,
+            &Account {
+                lamports: self.lamports,
+                data: self.data,
+                owner,
+                rent_epoch: self.rent_epoch,
+                executable: self.executable,
+            },
+        ))
     }
 }
 

--- a/evm_loader/program/src/account/mod.rs
+++ b/evm_loader/program/src/account/mod.rs
@@ -20,8 +20,8 @@ pub use treasury::{MainTreasury, Treasury};
 use self::program::System;
 
 mod ether_balance;
-mod ether_contract;
-mod ether_storage;
+pub mod ether_contract;
+pub mod ether_storage;
 mod holder;
 mod incinerator;
 pub mod legacy;

--- a/evm_loader/program/src/account/mod.rs
+++ b/evm_loader/program/src/account/mod.rs
@@ -8,7 +8,7 @@ pub use crate::{account_storage::FAKE_OPERATOR, config::ACCOUNT_SEED_VERSION};
 
 pub use ether_balance::{BalanceAccount, Header as BalanceHeader};
 pub use ether_contract::{AllocateResult, ContractAccount, Header as ContractHeader};
-pub use ether_storage::{Header as StorageCellHeader, StorageCell, StorageCellAddress};
+pub use ether_storage::{Cell, Header as StorageCellHeader, StorageCell, StorageCellAddress};
 pub use holder::{Header as HolderHeader, Holder};
 pub use incinerator::Incinerator;
 pub use operator::Operator;
@@ -20,8 +20,8 @@ pub use treasury::{MainTreasury, Treasury};
 use self::program::System;
 
 mod ether_balance;
-pub mod ether_contract;
-pub mod ether_storage;
+mod ether_contract;
+mod ether_storage;
 mod holder;
 mod incinerator;
 pub mod legacy;


### PR DESCRIPTION
Added flag to provide Account Data for tracer. In case of RPC `debug_traceTransaction` we should compare account after emulation and in tracer database 