### PR TITLE
NDEV-3379. Fix executed steps when step limit happens

### DIFF
--- a/evm_loader/program/src/evm/mod.rs
+++ b/evm_loader/program/src/evm/mod.rs
@@ -374,10 +374,10 @@ impl<B: Database, T: EventListener> Machine<B, T> {
             ExitStatus::Return(value)
         } else {
             loop {
-                step += 1;
-                if step > step_limit {
+                if step >= step_limit {
                     break ExitStatus::StepLimit;
                 }
+                step += 1;
 
                 let opcode = self.execution_code.get_or_default(self.pc);
 


### PR DESCRIPTION
If step limit was 500 and step limit happens than we will write 501 steps into transaction logs. We will read 501 steps in proxy and give incorrect number of EVM steps in neon_getTransactionReceipt with solanaTransactionList parameter