### PR TITLE
Ndev 3112 optimize getting deactivated features

### DIFF
--- a/evm_loader/Cargo.lock
+++ b/evm_loader/Cargo.lock
@@ -3694,6 +3694,7 @@ dependencies = [
  "lazy_static",
  "log",
  "neon-lib-interface",
+ "once_cell",
  "rand 0.8.5",
  "scroll 0.12.0",
  "serde",

--- a/evm_loader/api/src/main.rs
+++ b/evm_loader/api/src/main.rs
@@ -14,6 +14,7 @@ pub use neon_lib::commands;
 pub use neon_lib::config;
 pub use neon_lib::errors;
 pub use neon_lib::types;
+pub use neon_lib::types::deactivated_features::set_deactivated_features_rpc;
 use tracing_appender::non_blocking::NonBlockingBuilder;
 
 use actix_request_identifier::RequestIdentifier;
@@ -57,6 +58,8 @@ async fn main() -> NeonApiResult<()> {
 
     let api_config = config::load_api_config_from_environment();
     let state: NeonApiState = Data::new(State::new(api_config).await);
+
+    set_deactivated_features_rpc(state.rpc_client.clone()).await;
 
     let listener_addr = options
         .value_of("host")

--- a/evm_loader/cli/src/main.rs
+++ b/evm_loader/cli/src/main.rs
@@ -14,7 +14,7 @@ use neon_lib::{
         get_storage_at, init_environment, trace,
     },
     rpc::CloneRpcClient,
-    types::{BalanceAddress, EmulateRequest},
+    types::{deactivated_features::set_deactivated_features_rpc, BalanceAddress, EmulateRequest},
     Config,
 };
 
@@ -42,10 +42,15 @@ type NeonCliResult = Result<serde_json::Value, NeonError>;
 async fn run(options: &ArgMatches<'_>) -> NeonCliResult {
     let config = &config::create(options)?;
 
+    let rpc = build_rpc(options, config).await?;
+
+    set_deactivated_features_rpc(RpcEnum::CloneRpcClient(CloneRpcClient::new_from_config(
+        config,
+    )))
+    .await;
+
     match options.subcommand() {
         ("emulate", Some(_)) => {
-            let rpc = build_rpc(options, config).await?;
-
             let request = read_tx_from_stdin()?;
             emulate::execute(
                 &rpc,
@@ -58,16 +63,12 @@ async fn run(options: &ArgMatches<'_>) -> NeonCliResult {
             .map(|(result, _)| json!(result))
         }
         ("trace", Some(_)) => {
-            let rpc = build_rpc(options, config).await?;
-
             let request = read_tx_from_stdin()?;
             trace::trace_transaction(&rpc, &config.db_config, &config.evm_loader, request)
                 .await
                 .map(|trace| json!(trace))
         }
         ("get-ether-account-data", Some(params)) => {
-            let rpc = build_rpc(options, config).await?;
-
             let address = address_of(params, "ether").unwrap();
             let chain_id = value_of(params, "chain_id").unwrap();
 
@@ -79,8 +80,6 @@ async fn run(options: &ArgMatches<'_>) -> NeonCliResult {
                 .map(|result| json!(result))
         }
         ("get-contract-account-data", Some(params)) => {
-            let rpc = build_rpc(options, config).await?;
-
             let account = address_of(params, "address").unwrap();
             let accounts = std::slice::from_ref(&account);
 
@@ -89,8 +88,6 @@ async fn run(options: &ArgMatches<'_>) -> NeonCliResult {
                 .map(|result| json!(result))
         }
         ("get-holder-account-data", Some(params)) => {
-            let rpc = build_rpc(options, config).await?;
-
             let account = pubkey_of(params, "account").unwrap();
 
             get_holder::execute(&rpc, &config.evm_loader, account)
@@ -98,8 +95,6 @@ async fn run(options: &ArgMatches<'_>) -> NeonCliResult {
                 .map(|result| json!(result))
         }
         ("neon-elf-params", Some(params)) => {
-            let rpc = build_rpc(options, config).await?;
-
             let program_location = params.value_of("program_location");
             get_neon_elf::execute(config, &rpc, program_location)
                 .await
@@ -135,8 +130,6 @@ async fn run(options: &ArgMatches<'_>) -> NeonCliResult {
             .map(|result| json!(result))
         }
         ("get-storage-at", Some(params)) => {
-            let rpc = build_rpc(options, config).await?;
-
             let contract_id = address_of(params, "contract_id").expect("contract_it parse error");
             let index = u256_of(params, "index").expect("index parse error");
 
@@ -144,13 +137,9 @@ async fn run(options: &ArgMatches<'_>) -> NeonCliResult {
                 .await
                 .map(|hash| json!(hex::encode(hash.0)))
         }
-        ("config", Some(_)) => {
-            let rpc = build_rpc(options, config).await?;
-
-            get_config::execute(&rpc, config.evm_loader)
-                .await
-                .map(|result| json!(result))
-        }
+        ("config", Some(_)) => get_config::execute(&rpc, config.evm_loader)
+            .await
+            .map(|result| json!(result)),
         _ => unreachable!(),
     }
 }

--- a/evm_loader/lib/Cargo.toml
+++ b/evm_loader/lib/Cargo.toml
@@ -55,6 +55,7 @@ lazy_static = "1.5.0"
 elsa = "1.10.0"
 arrayref = "0.3.8"
 futures = "0.3.30"
+once_cell = "1.19.0"
 
 [dev-dependencies]
 hex-literal = "0.4.1"

--- a/evm_loader/lib/src/account_storage.rs
+++ b/evm_loader/lib/src/account_storage.rs
@@ -19,6 +19,7 @@ use evm_loader::{
     types::{vector::VectorVecExt, Address, Vector},
 };
 use log::{debug, info, trace};
+use solana_sdk::sysvar::{Sysvar, SysvarId};
 use solana_sdk::{
     account::Account,
     account_info::{AccountInfo, IntoAccountInfo},
@@ -114,6 +115,19 @@ pub struct EmulatorAccountStorage<'rpc, T: Rpc> {
     logs_stack: Vec<usize>,
 }
 
+async fn get_sysvar<T>(rpc: &dyn Rpc) -> NeonResult<T>
+where
+    T: Sysvar + SysvarId,
+{
+    let account = rpc
+        .get_account(&T::id())
+        .await?
+        .ok_or(NeonError::AccountNotFound(T::id()))?;
+
+    let sysvar = bincode::deserialize::<T>(&account.data)?;
+    Ok(sysvar)
+}
+
 impl<'rpc, T: BuildConfigSimulator> EmulatorAccountStorage<'rpc, T> {
     pub async fn new(
         rpc: &'rpc T,
@@ -126,8 +140,8 @@ impl<'rpc, T: BuildConfigSimulator> EmulatorAccountStorage<'rpc, T> {
     ) -> Result<EmulatorAccountStorage<T>, NeonError> {
         trace!("backend::new");
 
-        let clock: Clock = rpc.get_sysvar().await?;
-        let rent: Rent = rpc.get_sysvar().await?;
+        let clock = get_sysvar::<Clock>(rpc).await?;
+        let rent = get_sysvar::<Rent>(rpc).await?;
 
         let (block_number, block_timestamp) = block_overrides
             .map(|o| (o.number, o.time))

--- a/evm_loader/lib/src/account_storage.rs
+++ b/evm_loader/lib/src/account_storage.rs
@@ -115,7 +115,7 @@ pub struct EmulatorAccountStorage<'rpc, T: Rpc> {
     logs_stack: Vec<usize>,
 }
 
-async fn get_sysvar<T>(rpc: &dyn Rpc) -> NeonResult<T>
+async fn get_sysvar<T>(rpc: &impl Rpc) -> NeonResult<T>
 where
     T: Sysvar + SysvarId,
 {

--- a/evm_loader/lib/src/account_storage.rs
+++ b/evm_loader/lib/src/account_storage.rs
@@ -1,5 +1,6 @@
 use crate::account_data::AccountData;
 use crate::commands::get_config::{BuildConfigSimulator, ChainInfo};
+use crate::sysvar::get_sysvar;
 use crate::tracing::{AccountOverrides, BlockOverrides};
 use crate::{rpc::Rpc, solana_simulator::SolanaSimulator, NeonError, NeonResult};
 use async_trait::async_trait;
@@ -18,8 +19,8 @@ use evm_loader::{
     executor::OwnedAccountInfo,
     types::{vector::VectorVecExt, Address, Vector},
 };
+
 use log::{debug, info, trace};
-use solana_sdk::sysvar::{Sysvar, SysvarId};
 use solana_sdk::{
     account::Account,
     account_info::{AccountInfo, IntoAccountInfo},
@@ -113,19 +114,6 @@ pub struct EmulatorAccountStorage<'rpc, T: Rpc> {
     return_data: Option<TransactionReturnData>,
     logs: Vec<Log>,
     logs_stack: Vec<usize>,
-}
-
-async fn get_sysvar<T>(rpc: &impl Rpc) -> NeonResult<T>
-where
-    T: Sysvar + SysvarId,
-{
-    let account = rpc
-        .get_account(&T::id())
-        .await?
-        .ok_or(NeonError::AccountNotFound(T::id()))?;
-
-    let sysvar = bincode::deserialize::<T>(&account.data)?;
-    Ok(sysvar)
 }
 
 impl<'rpc, T: BuildConfigSimulator> EmulatorAccountStorage<'rpc, T> {

--- a/evm_loader/lib/src/commands/emulate.rs
+++ b/evm_loader/lib/src/commands/emulate.rs
@@ -5,6 +5,7 @@ use crate::commands::get_config::BuildConfigSimulator;
 use crate::config::DbConfig;
 use crate::rpc::Rpc;
 use crate::rpc::{CallDbClient, RpcEnum};
+use crate::sysvar::get_sysvar;
 use crate::tracing::tracers::Tracer;
 use crate::tracing::{AccountOverride, BlockOverrides};
 use crate::types::FromAddress;
@@ -394,7 +395,7 @@ async fn emulate_trx_multiple_steps<'rpc, T: Tracer>(
 
     let mut rpc = create_rpc(db_config, block, index).await?;
 
-    let clock: Clock = rpc.get_sysvar().await?;
+    let clock = get_sysvar::<Clock>(&rpc).await?;
 
     let mut overrides = init_overrides(emulate_request);
 

--- a/evm_loader/lib/src/deactivated_features_tests.rs
+++ b/evm_loader/lib/src/deactivated_features_tests.rs
@@ -6,7 +6,6 @@ mod deactivated_features_tests {
     use solana_client::client_error::Result as ClientResult;
     use solana_sdk::{
         account::{Account, AccountSharedData},
-        clock::{Slot, UnixTimestamp},
         feature::Feature,
         feature_set,
         pubkey::Pubkey,
@@ -80,14 +79,6 @@ mod deactivated_features_tests {
             }
 
             Ok(result)
-        }
-
-        async fn get_block_time(&self, _slot: Slot) -> ClientResult<UnixTimestamp> {
-            todo!()
-        }
-
-        async fn get_slot(&self) -> ClientResult<Slot> {
-            todo!()
         }
 
         async fn get_deactivated_solana_features(&self) -> ClientResult<Vec<Pubkey>> {

--- a/evm_loader/lib/src/deactivated_features_tests.rs
+++ b/evm_loader/lib/src/deactivated_features_tests.rs
@@ -1,0 +1,130 @@
+mod deactivated_features_tests {
+    use std::collections::HashMap;
+
+    use async_trait::async_trait;
+    use solana_account_decoder::UiDataSliceConfig as SliceConfig;
+    use solana_client::client_error::Result as ClientResult;
+    use solana_sdk::{
+        account::{Account, AccountSharedData},
+        clock::{Slot, UnixTimestamp},
+        feature::Feature,
+        feature_set,
+        pubkey::Pubkey,
+    };
+
+    use crate::{
+        rpc::Rpc,
+        types::deactivated_features::{
+            get_deactivated_features_at_slot, set_deactivated_features_rpc,
+        },
+    };
+
+    #[derive(Clone)]
+    struct RpcMockFeatures {
+        pub features: HashMap<Pubkey, Option<u64>>,
+    }
+
+    impl Default for RpcMockFeatures {
+        fn default() -> Self {
+            let accounts: Vec<_> = feature_set::FEATURE_NAMES.keys().copied().collect();
+
+            let mut features = HashMap::<Pubkey, Option<u64>>::new();
+
+            for (slot, account) in accounts.iter().enumerate() {
+                let slot = if slot == 0 { None } else { Some(slot as u64) };
+                features.insert(*account, slot);
+            }
+
+            Self { features }
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl Rpc for RpcMockFeatures {
+        async fn get_account_slice(
+            &self,
+            _key: &Pubkey,
+            _slice: Option<SliceConfig>,
+        ) -> ClientResult<Option<Account>> {
+            todo!()
+        }
+
+        async fn get_multiple_accounts(
+            &self,
+            pubkeys: &[Pubkey],
+        ) -> ClientResult<Vec<Option<Account>>> {
+            let mut result: Vec<Option<Account>> = vec![];
+
+            for pubkey in pubkeys.iter() {
+                let feature = self.features.get(pubkey);
+
+                match feature {
+                    Some(slot) => {
+                        let mut data =
+                            AccountSharedData::new(1_000_000_000, 100, &solana_sdk::feature::ID);
+                        if solana_sdk::feature::to_account(
+                            &Feature {
+                                activated_at: *slot,
+                            },
+                            &mut data,
+                        )
+                        .is_some()
+                        {
+                            result.push(Some(data.into()));
+                        } else {
+                            result.push(None)
+                        }
+                    }
+                    None => result.push(None),
+                }
+            }
+
+            Ok(result)
+        }
+
+        async fn get_block_time(&self, _slot: Slot) -> ClientResult<UnixTimestamp> {
+            todo!()
+        }
+
+        async fn get_slot(&self) -> ClientResult<Slot> {
+            todo!()
+        }
+
+        async fn get_deactivated_solana_features(&self) -> ClientResult<Vec<Pubkey>> {
+            todo!()
+        }
+    }
+
+    async fn get_deactivated_features_and_wait(slot: Option<u64>) -> Vec<Pubkey> {
+        get_deactivated_features_at_slot(slot)
+            .await
+            .expect("get deactivated features failed at slot unexpectedly")
+    }
+
+    // by default? mock rpc contains vector of features: RpcMockFeatures::features
+    // features[0] is not activated
+    // features[1] is activated at slot 1
+    // features[i] is activated at slot i
+    // let we have N features overall, then...
+    // only 1 feature will be deactivated on slot N (features[0])
+    // only 2 features will be deactivated on slot N-1 (features[0], features[n-1] (last one) which should be activated at slot N)
+    // ...
+    // all features will be deactivated on slot 0
+    #[tokio::test]
+    async fn test_deactivated_features_cache() {
+        let rpc = RpcMockFeatures::default();
+        let features_cnt = rpc.features.len() as u64;
+        set_deactivated_features_rpc(rpc.clone()).await;
+
+        for i in 0..features_cnt {
+            let features = get_deactivated_features_and_wait(Some(i)).await;
+
+            assert_eq!(features_cnt - i, features.len() as u64);
+        }
+        {
+            // current slot
+            let features = get_deactivated_features_and_wait(None).await;
+            assert_eq!(features.len(), 1);
+        }
+    }
+}

--- a/evm_loader/lib/src/lib.rs
+++ b/evm_loader/lib/src/lib.rs
@@ -17,6 +17,7 @@ pub mod commands;
 pub mod config;
 pub mod errors;
 pub mod rpc;
+pub mod sysvar;
 
 pub mod solana_simulator;
 pub mod tracing;

--- a/evm_loader/lib/src/rpc/db_call_client.rs
+++ b/evm_loader/lib/src/rpc/db_call_client.rs
@@ -1,5 +1,5 @@
 use super::{e, Rpc, SliceConfig};
-use crate::types::deactivated_features::get_deactivated_features;
+use crate::types::deactivated_features::get_deactivated_features_at_slot;
 use crate::types::{TracerDb, TracerDbTrait};
 use crate::NeonError;
 use crate::NeonError::RocksDb;
@@ -74,6 +74,6 @@ impl Rpc for CallDbClient {
     }
 
     async fn get_deactivated_solana_features(&self) -> ClientResult<Vec<Pubkey>> {
-        get_deactivated_features(self, Some(self.slot)).await
+        get_deactivated_features_at_slot(Some(self.slot)).await
     }
 }

--- a/evm_loader/lib/src/rpc/db_call_client.rs
+++ b/evm_loader/lib/src/rpc/db_call_client.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use super::{e, Rpc, SliceConfig};
 use crate::types::{TracerDb, TracerDbTrait};
 use crate::NeonError;
@@ -73,6 +75,68 @@ impl Rpc for CallDbClient {
     }
 
     async fn get_deactivated_solana_features(&self) -> ClientResult<Vec<Pubkey>> {
-        Ok(vec![]) // TODO
+        use std::time::{Duration, Instant};
+        use tokio::sync::Mutex;
+
+        struct Cache {
+            // feature to slot when activated, if not then None
+            data: HashMap<Pubkey, Option<u64>>,
+            timestamp: Instant,
+        }
+
+        static CACHE: Mutex<Option<Cache>> = Mutex::const_new(None);
+        let mut cache = CACHE.lock().await;
+
+        if let Some(cache) = cache.as_ref() {
+            if cache.timestamp.elapsed() < Duration::from_secs(24 * 60 * 60) {
+                let mut keys: Vec<Pubkey> = cache.data.keys().copied().collect();
+
+                keys.retain(|pubkey| {
+                    let value = cache.data.get(pubkey);
+
+                    if let Some(Some(slot)) = value {
+                        if slot <= &self.slot {
+                            return false;
+                        }
+                    }
+
+                    true
+                });
+
+                return Ok(keys);
+            }
+        }
+
+        let feature_keys: Vec<Pubkey> = solana_sdk::feature_set::FEATURE_NAMES
+            .keys()
+            .copied()
+            .collect();
+
+        let features = Rpc::get_multiple_accounts(self, &feature_keys).await?;
+
+        let mut result = HashMap::<Pubkey, Option<u64>>::new();
+        for (pubkey, feature) in feature_keys.iter().zip(features) {
+            let slot = feature
+                .and_then(|a| solana_sdk::feature::from_account(&a))
+                .and_then(|f| f.activated_at);
+
+            result.insert(*pubkey, slot);
+        }
+
+        cache.replace(Cache {
+            data: result.clone(),
+            timestamp: Instant::now(),
+        });
+        drop(cache);
+
+        Ok(result
+            .into_iter()
+            .filter_map(|(pubkey, slot)| {
+                if slot.is_none() {
+                    return Some(pubkey);
+                }
+                None
+            })
+            .collect())
     }
 }

--- a/evm_loader/lib/src/rpc/db_call_client.rs
+++ b/evm_loader/lib/src/rpc/db_call_client.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
-
 use super::{e, Rpc, SliceConfig};
+use crate::types::deactivated_features::get_deactivated_features;
 use crate::types::{TracerDb, TracerDbTrait};
 use crate::NeonError;
 use crate::NeonError::RocksDb;
@@ -75,80 +74,6 @@ impl Rpc for CallDbClient {
     }
 
     async fn get_deactivated_solana_features(&self) -> ClientResult<Vec<Pubkey>> {
-        use std::time::{Duration, Instant};
-        use tokio::sync::Mutex;
-
-        struct Cache {
-            // feature to slot when activated, if not then None
-            data: HashMap<Pubkey, Option<u64>>,
-            timestamp: Instant,
-        }
-
-        static CACHE: Mutex<Option<Cache>> = Mutex::const_new(None);
-        let mut cache = CACHE.lock().await;
-
-        if let Some(cache) = cache.as_ref() {
-            if cache.timestamp.elapsed() < Duration::from_secs(24 * 60 * 60) {
-                let mut keys: Vec<Pubkey> = cache.data.keys().copied().collect();
-
-                keys.retain(|pubkey| {
-                    let value = cache.data.get(pubkey);
-
-                    if let Some(Some(slot)) = value {
-                        if slot <= &self.slot {
-                            return false;
-                        }
-                    }
-
-                    true
-                });
-
-                return Ok(keys);
-            }
-        }
-
-        let feature_keys: Vec<Pubkey> = solana_sdk::feature_set::FEATURE_NAMES
-            .keys()
-            .copied()
-            .collect();
-
-        let tracer_db = self.tracer_db.clone();
-        let slot = tracer_db
-            .get_latest_block()
-            .await
-            .map_err(|e| e!("get_latest_block error", e))?;
-
-        let self_rpc: Self = Self {
-            tracer_db,
-            slot,
-            tx_index_in_block: None,
-        };
-
-        let features = Rpc::get_multiple_accounts(&self_rpc, &feature_keys).await?;
-
-        let mut result = HashMap::<Pubkey, Option<u64>>::new();
-        for (pubkey, feature) in feature_keys.iter().zip(features) {
-            let slot = feature
-                .and_then(|a| solana_sdk::feature::from_account(&a))
-                .and_then(|f| f.activated_at);
-
-            result.insert(*pubkey, slot);
-        }
-
-        cache.replace(Cache {
-            data: result.clone(),
-            timestamp: Instant::now(),
-        });
-        drop(cache);
-
-        Ok(result
-            .into_iter()
-            .filter_map(|(pubkey, slot)| {
-                if slot.is_none() {
-                    return Some(pubkey);
-                }
-                None
-            })
-            .collect())
+        get_deactivated_features(self, Some(self.slot)).await
     }
 }

--- a/evm_loader/lib/src/rpc/db_call_client.rs
+++ b/evm_loader/lib/src/rpc/db_call_client.rs
@@ -112,7 +112,19 @@ impl Rpc for CallDbClient {
             .copied()
             .collect();
 
-        let features = Rpc::get_multiple_accounts(self, &feature_keys).await?;
+        let tracer_db = self.tracer_db.clone();
+        let slot = tracer_db
+            .get_latest_block()
+            .await
+            .map_err(|e| e!("get_latest_block error", e))?;
+
+        let self_rpc: Self = Self {
+            tracer_db,
+            slot,
+            tx_index_in_block: None,
+        };
+
+        let features = Rpc::get_multiple_accounts(&self_rpc, &feature_keys).await?;
 
         let mut result = HashMap::<Pubkey, Option<u64>>::new();
         for (pubkey, feature) in feature_keys.iter().zip(features) {

--- a/evm_loader/lib/src/rpc/mod.rs
+++ b/evm_loader/lib/src/rpc/mod.rs
@@ -4,7 +4,6 @@ mod validator_client;
 use crate::commands::get_config::GetConfigResponse;
 
 pub use db_call_client::CallDbClient;
-use solana_sdk::sysvar::{Sysvar, SysvarId};
 pub use validator_client::CloneRpcClient;
 
 use crate::commands::get_config::{BuildConfigSimulator, ConfigSimulator};
@@ -47,19 +46,6 @@ pub trait Rpc {
 
     async fn get_multiple_accounts(&self, pubkeys: &[Pubkey])
         -> ClientResult<Vec<Option<Account>>>;
-
-    async fn get_sysvar<T>(&self) -> NeonResult<T>
-    where
-        T: Sysvar + SysvarId,
-    {
-        let account = self
-            .get_account(&T::id())
-            .await?
-            .ok_or(NeonError::AccountNotFound(T::id()))?;
-
-        let sysvar = bincode::deserialize::<T>(&account.data)?;
-        Ok(sysvar)
-    }
 
     async fn get_deactivated_solana_features(&self) -> ClientResult<Vec<Pubkey>>;
 }

--- a/evm_loader/lib/src/rpc/validator_client.rs
+++ b/evm_loader/lib/src/rpc/validator_client.rs
@@ -1,4 +1,6 @@
-use crate::{config::APIOptions, types::deactivated_features::get_deactivated_features, Config};
+use crate::{
+    config::APIOptions, types::deactivated_features::get_deactivated_features_at_slot, Config,
+};
 
 use super::{Rpc, SliceConfig};
 use async_trait::async_trait;
@@ -167,6 +169,6 @@ impl Rpc for CloneRpcClient {
     }
 
     async fn get_deactivated_solana_features(&self) -> ClientResult<Vec<Pubkey>> {
-        get_deactivated_features(self, None).await
+        get_deactivated_features_at_slot(None).await
     }
 }

--- a/evm_loader/lib/src/rpc/validator_client.rs
+++ b/evm_loader/lib/src/rpc/validator_client.rs
@@ -1,4 +1,4 @@
-use crate::{config::APIOptions, Config};
+use crate::{config::APIOptions, types::deactivated_features::get_deactivated_features, Config};
 
 use super::{Rpc, SliceConfig};
 use async_trait::async_trait;
@@ -167,52 +167,6 @@ impl Rpc for CloneRpcClient {
     }
 
     async fn get_deactivated_solana_features(&self) -> ClientResult<Vec<Pubkey>> {
-        use std::time::{Duration, Instant};
-        use tokio::sync::Mutex;
-
-        struct Cache {
-            data: Vec<Pubkey>,
-            timestamp: Instant,
-        }
-
-        static CACHE: Mutex<Option<Cache>> = Mutex::const_new(None);
-        let mut cache = CACHE.lock().await;
-
-        if let Some(cache) = cache.as_ref() {
-            if cache.timestamp.elapsed() < Duration::from_secs(24 * 60 * 60) {
-                return Ok(cache.data.clone());
-            }
-        }
-
-        let feature_keys: Vec<Pubkey> = solana_sdk::feature_set::FEATURE_NAMES
-            .keys()
-            .copied()
-            .collect();
-
-        let features = Rpc::get_multiple_accounts(self, &feature_keys).await?;
-
-        let mut result = Vec::with_capacity(feature_keys.len());
-        for (pubkey, feature) in feature_keys.iter().zip(features) {
-            let is_activated = feature
-                .and_then(|a| solana_sdk::feature::from_account(&a))
-                .and_then(|f| f.activated_at)
-                .is_some();
-
-            if !is_activated {
-                result.push(*pubkey);
-            }
-        }
-
-        for feature in &result {
-            debug!("Deactivated feature: {}", feature);
-        }
-
-        cache.replace(Cache {
-            data: result.clone(),
-            timestamp: Instant::now(),
-        });
-        drop(cache);
-
-        Ok(result)
+        get_deactivated_features(self, None).await
     }
 }

--- a/evm_loader/lib/src/sysvar.rs
+++ b/evm_loader/lib/src/sysvar.rs
@@ -1,0 +1,15 @@
+use crate::{rpc::Rpc, NeonError, NeonResult};
+use solana_sdk::sysvar::{Sysvar, SysvarId};
+
+pub async fn get_sysvar<T>(rpc: &impl Rpc) -> NeonResult<T>
+where
+    T: Sysvar + SysvarId,
+{
+    let account = rpc
+        .get_account(&T::id())
+        .await?
+        .ok_or(NeonError::AccountNotFound(T::id()))?;
+
+    let sysvar = bincode::deserialize::<T>(&account.data)?;
+    Ok(sysvar)
+}

--- a/evm_loader/lib/src/types/deactivated_features.rs
+++ b/evm_loader/lib/src/types/deactivated_features.rs
@@ -1,4 +1,3 @@
-// use crate::tracing::tracers::state_diff::Account;
 use crate::rpc::Rpc;
 use once_cell::sync::Lazy;
 use solana_client::client_error::Result as ClientResult;

--- a/evm_loader/lib/src/types/deactivated_features.rs
+++ b/evm_loader/lib/src/types/deactivated_features.rs
@@ -5,27 +5,60 @@ use solana_client::client_error::Result as ClientResult;
 use solana_sdk::pubkey::Pubkey;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 
-static DEACTIVATED_FEATURES_UPDATE_SLOTS: u64 = 24 * 60 * 60; // approximately each 12h
+static DEACTIVATED_FEATURES_PERIOD: Duration = Duration::from_secs(60 * 60); // 1 hour
 
-#[derive(Debug, Eq, PartialEq, Clone, Default)]
+pub trait BoxRpc: Rpc + Sync + Send {}
+impl<T: Rpc + Sync + Send> BoxRpc for T {}
+
 struct DeactivatedFeaturesCache {
     // feature to slot when activated, if not then None
     pub data: HashMap<Pubkey, Option<u64>>,
-    pub last_slot: u64,
+    pub last_update: Instant,
+    pub rpc: Option<Box<dyn BoxRpc>>,
+}
+
+impl Default for DeactivatedFeaturesCache {
+    fn default() -> Self {
+        Self {
+            data: HashMap::new(),
+            last_update: Instant::now()
+                .checked_sub(DEACTIVATED_FEATURES_PERIOD)
+                .unwrap(),
+            rpc: None,
+        }
+    }
 }
 
 impl DeactivatedFeaturesCache {
-    fn should_update(&self, slot: u64) -> bool {
-        self.last_slot >= DEACTIVATED_FEATURES_UPDATE_SLOTS + slot
+    pub fn should_update(&mut self) -> bool {
+        if self.rpc.is_some() {
+            self.last_update + DEACTIVATED_FEATURES_PERIOD <= Instant::now()
+        } else {
+            false
+        }
+    }
+
+    pub fn set_deactivated_features_rpc(&mut self, rpc: impl BoxRpc + 'static) {
+        self.rpc = Some(Box::new(rpc));
+    }
+
+    pub async fn update(&mut self) -> ClientResult<()> {
+        if let Some(ref rpc) = self.rpc {
+            self.last_update = Instant::now();
+            self.data = get_multiple_features(rpc.as_ref()).await?;
+        }
+
+        Ok(())
     }
 }
 
 static DEACTIVATED_FEATURES: Lazy<Arc<Mutex<DeactivatedFeaturesCache>>> =
     Lazy::new(|| Arc::new(Mutex::new(DeactivatedFeaturesCache::default())));
 
-async fn get_multiple_features(rpc: &dyn Rpc) -> ClientResult<HashMap<Pubkey, Option<u64>>> {
+async fn get_multiple_features(rpc: &dyn BoxRpc) -> ClientResult<HashMap<Pubkey, Option<u64>>> {
     let feature_keys: Vec<Pubkey> = solana_sdk::feature_set::FEATURE_NAMES
         .keys()
         .copied()
@@ -45,28 +78,20 @@ async fn get_multiple_features(rpc: &dyn Rpc) -> ClientResult<HashMap<Pubkey, Op
     Ok(result)
 }
 
-async fn deactivated_features_get_instance(
-    rpc: &dyn Rpc,
-) -> ClientResult<DeactivatedFeaturesCache> {
+async fn get_deactivated_features() -> ClientResult<HashMap<Pubkey, Option<u64>>> {
     let mut cache = DEACTIVATED_FEATURES.lock().await;
 
-    let rpc_slot = rpc.get_slot().await?;
-    if cache.should_update(rpc_slot) {
-        cache.last_slot = rpc_slot;
-        cache.data = get_multiple_features(rpc).await?;
-    }
+    if cache.should_update() {
+        cache.update().await?;
+    };
 
-    Ok((*cache).clone())
+    Ok(cache.data.clone())
 }
 
-pub async fn get_deactivated_features(
-    rpc: &dyn Rpc,
-    slot: Option<u64>,
-) -> ClientResult<Vec<Pubkey>> {
-    let features = deactivated_features_get_instance(rpc).await?;
+pub async fn get_deactivated_features_at_slot(slot: Option<u64>) -> ClientResult<Vec<Pubkey>> {
+    let features = get_deactivated_features().await?;
 
     Ok(features
-        .data
         .into_iter()
         .filter_map(|(pubkey, activated_at)| match (slot, activated_at) {
             (_, None) => Some(pubkey),
@@ -80,3 +105,12 @@ pub async fn get_deactivated_features(
         })
         .collect())
 }
+
+pub async fn set_deactivated_features_rpc(rpc: impl BoxRpc + 'static) {
+    let mut cache = DEACTIVATED_FEATURES.lock().await;
+    cache.set_deactivated_features_rpc(rpc);
+}
+
+#[cfg(test)]
+#[path = "../deactivated_features_tests.rs"]
+mod deactivated_features_tests;

--- a/evm_loader/lib/src/types/deactivated_features.rs
+++ b/evm_loader/lib/src/types/deactivated_features.rs
@@ -1,0 +1,82 @@
+// use crate::tracing::tracers::state_diff::Account;
+use crate::rpc::Rpc;
+use once_cell::sync::Lazy;
+use solana_client::client_error::Result as ClientResult;
+use solana_sdk::pubkey::Pubkey;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+static DEACTIVATED_FEATURES_UPDATE_SLOTS: u64 = 24 * 60 * 60; // approximately each 12h
+
+#[derive(Debug, Eq, PartialEq, Clone, Default)]
+struct DeactivatedFeaturesCache {
+    // feature to slot when activated, if not then None
+    pub data: HashMap<Pubkey, Option<u64>>,
+    pub last_slot: u64,
+}
+
+impl DeactivatedFeaturesCache {
+    fn should_update(&self, slot: u64) -> bool {
+        self.last_slot >= DEACTIVATED_FEATURES_UPDATE_SLOTS + slot
+    }
+}
+
+static DEACTIVATED_FEATURES: Lazy<Arc<Mutex<DeactivatedFeaturesCache>>> =
+    Lazy::new(|| Arc::new(Mutex::new(DeactivatedFeaturesCache::default())));
+
+async fn get_multiple_features(rpc: &dyn Rpc) -> ClientResult<HashMap<Pubkey, Option<u64>>> {
+    let feature_keys: Vec<Pubkey> = solana_sdk::feature_set::FEATURE_NAMES
+        .keys()
+        .copied()
+        .collect();
+
+    let features = Rpc::get_multiple_accounts(rpc, &feature_keys).await?;
+
+    let mut result = HashMap::<Pubkey, Option<u64>>::new();
+    for (pubkey, feature) in feature_keys.iter().zip(features) {
+        let slot = feature
+            .and_then(|a| solana_sdk::feature::from_account(&a))
+            .and_then(|f| f.activated_at);
+
+        result.insert(*pubkey, slot);
+    }
+
+    Ok(result)
+}
+
+async fn deactivated_features_get_instance(
+    rpc: &dyn Rpc,
+) -> ClientResult<DeactivatedFeaturesCache> {
+    let mut cache = DEACTIVATED_FEATURES.lock().await;
+
+    let rpc_slot = rpc.get_slot().await?;
+    if cache.should_update(rpc_slot) {
+        cache.last_slot = rpc_slot;
+        cache.data = get_multiple_features(rpc).await?;
+    }
+
+    Ok((*cache).clone())
+}
+
+pub async fn get_deactivated_features(
+    rpc: &dyn Rpc,
+    slot: Option<u64>,
+) -> ClientResult<Vec<Pubkey>> {
+    let features = deactivated_features_get_instance(rpc).await?;
+
+    Ok(features
+        .data
+        .into_iter()
+        .filter_map(|(pubkey, activated_at)| match (slot, activated_at) {
+            (_, None) => Some(pubkey),
+            (Some(slot), Some(activated_at)) => {
+                if activated_at > slot {
+                    return Some(pubkey);
+                }
+                None
+            }
+            (None, Some(_)) => None,
+        })
+        .collect())
+}

--- a/evm_loader/lib/src/types/mod.rs
+++ b/evm_loader/lib/src/types/mod.rs
@@ -1,6 +1,6 @@
-pub mod tracer_ch_common;
-
+pub mod deactivated_features;
 pub mod programs_cache;
+pub mod tracer_ch_common;
 pub(crate) mod tracer_ch_db;
 pub mod tracer_rocks_db;
 


### PR DESCRIPTION
I haven't changed anything except moving ```get_sysvar``` method from Rpc trait to standalone function. It's used only in ```EmulatorAccountStorage```. The rest is the same.

The problem was about creating cache (```DeactivatedFeaturesCache```) with generic method inside of Rpc trait that it should implement. We also don't know the exact type of Rpc because it might be ```RpcMockFeatures``` created for tests.

I wasn't able to find the solution leaving ```get_sysvar``` method in Rpc trait. 