### PR TITLE
Update Solana SDK to v2.3.1

### DIFF
--- a/.github/workflows/deploy.py
+++ b/.github/workflows/deploy.py
@@ -47,7 +47,6 @@ docker_client = docker.APIClient()
 NEON_TEST_IMAGE_NAME = "neon_tests"
 
 PROXY_ENDPOINT = os.environ.get("PROXY_ENDPOINT")
-NEON_TESTS_ENDPOINT = os.environ.get("NEON_TESTS_ENDPOINT")
 
 
 @click.group()
@@ -198,20 +197,6 @@ def run_subprocess(command):
     subprocess.run(command, shell=True)
 
 
-def get_container_name(project_name, service_name):
-    data = subprocess.run(
-        f"docker-compose -p {project_name} -f ./ci/docker-compose-ci.yml ps",
-        shell=True, capture_output=True, text=True).stdout
-    click.echo(data)
-    pattern = rf'{project_name}[-_]{service_name}[-_]1'
-    match = re.search(pattern, data)
-    return match.group(0)
-
-
-def stop_containers(project_name):
-    run_subprocess(f"docker-compose -p {project_name} -f ./ci/docker-compose-ci.yml down")
-
-
 @cli.command(name="trigger_proxy_action")
 @click.option('--evm_pr_version_branch')
 @click.option('--is_evm_release')
@@ -284,9 +269,8 @@ def wait_condition(func_cond, timeout_sec=60, delay=0.5):
 @click.option("--url", help="slack app endpoint url.")
 @click.option("--build_url", help="github action test build url.")
 def send_notification(evm_tag, url, build_url):
-
     if re.match(RELEASE_TAG_TEMPLATE, evm_tag) is not None \
-        or re.match(VERSION_BRANCH_TEMPLATE, evm_tag) is not None \
+            or re.match(VERSION_BRANCH_TEMPLATE, evm_tag) is not None \
             or evm_tag == "latest":
         tpl = ERR_MSG_TPL.copy()
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -16,7 +16,6 @@ env:
   DHUBP: ${{secrets.DHUBP}}
   MAINNET_SOLANA_URL: ${{secrets.MAINNET_SOLANA_URL}}
   PROXY_ENDPOINT: "https://api.github.com/repos/${{ github.repository_owner }}/neon-proxy.py"
-  NEON_TESTS_ENDPOINT: ${{vars.NEON_TESTS_ENDPOINT}}
   DOCKERHUB_ORG_NAME: ${{vars.DOCKERHUB_ORG_NAME}}
   RUN_LINK_REPO: "${{ github.repository_owner }}/neon-proxy.py"
   BUILD_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/evm_loader/Cargo.lock
+++ b/evm_loader/Cargo.lock
@@ -3856,6 +3856,7 @@ dependencies = [
  "log",
  "mollusk-svm",
  "neon-lib-interface",
+ "num-traits",
  "once_cell",
  "rand 0.8.5",
  "scroll",
@@ -3873,8 +3874,8 @@ dependencies = [
  "solana-sdk",
  "solana-sdk-ids",
  "solana-system-interface",
- "spl-associated-token-account 6.0.0",
- "spl-token 7.0.0",
+ "spl-associated-token-account-interface",
+ "spl-token-interface",
  "strum",
  "strum_macros",
  "thiserror 1.0.69",
@@ -4119,18 +4120,19 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -8309,6 +8311,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-associated-token-account-interface"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6bbe0794e532ac08428d3abf5bf8ae75bd81dfddd785c388e326c00c92c6f5"
+dependencies = [
+ "solana-instruction",
+ "solana-pubkey",
+]
+
+[[package]]
 name = "spl-discriminator"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8750,6 +8762,26 @@ dependencies = [
  "solana-pubkey",
  "spl-discriminator",
  "spl-pod",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "spl-token-interface"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06e0c2d4e38ef5834cf7fb1b592b8a8c6eab8485f5ac7a04a151b502c63a0aaa"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive 0.4.2",
+ "num-traits",
+ "num_enum",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey",
+ "solana-sdk-ids",
  "thiserror 2.0.12",
 ]
 

--- a/evm_loader/Cargo.lock
+++ b/evm_loader/Cargo.lock
@@ -306,13 +306,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "agave-transaction-view"
-version = "2.1.21"
+name = "agave-feature-set"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92445a0916c328daf4cf3ba93b39af5eb45af13aa9593eae6504d7167a6dddbd"
+checksum = "305be18924e302fbc082a145f9c747fabedfaf136dbcb3820134db2d9855a44b"
 dependencies = [
- "solana-sdk",
- "solana-svm-transaction",
+ "ahash",
+ "solana-epoch-schedule",
+ "solana-hash",
+ "solana-pubkey",
+ "solana-sha256-hasher",
+ "solana-svm-feature-set",
+]
+
+[[package]]
+name = "agave-precompiles"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36b72ead0da029d1dab286a094bb330702a037d121043183343a60c429fd69"
+dependencies = [
+ "agave-feature-set",
+ "bincode",
+ "digest 0.10.7",
+ "ed25519-dalek",
+ "libsecp256k1",
+ "openssl",
+ "sha3",
+ "solana-ed25519-program",
+ "solana-message",
+ "solana-precompile-error",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-secp256k1-program",
+ "solana-secp256r1-program",
+]
+
+[[package]]
+name = "agave-reserved-account-keys"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a6adf0495bf92935e022ec0e0caf533ad5d7f47c11145f15e07c276649980a"
+dependencies = [
+ "agave-feature-set",
+ "solana-pubkey",
+ "solana-sdk-ids",
 ]
 
 [[package]]
@@ -409,20 +446,6 @@ name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
-
-[[package]]
-name = "aquamarine"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da02abba9f9063d786eab1509833ebb2fac0f966862ca59439c76b9c566760"
-dependencies = [
- "include_dir",
- "itertools 0.10.5",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "ark-bn254"
@@ -611,12 +634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_matches"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
-
-[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,15 +785,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -1027,9 +1035,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.8.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fa76293b4f7bb636ab88fd78228235b5248b4d05cc589aed610f954af5d7c7a"
+checksum = "441473f2b4b0459a68628c744bc61d23e730fb00128b841d30fa4bb3972257e4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1047,6 +1055,9 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytestring"
@@ -1055,26 +1066,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e465647ae23b2823b0753f50decb2d5a86d2bb2cac04788fafd1f80e45378e5f"
 dependencies = [
  "bytes",
-]
-
-[[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
 ]
 
 [[package]]
@@ -1513,7 +1504,7 @@ version = "3.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
 dependencies = [
- "nix 0.30.1",
+ "nix",
  "windows-sys 0.59.0",
 ]
 
@@ -1605,7 +1596,6 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
- "rayon",
 ]
 
 [[package]]
@@ -1786,12 +1776,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1809,15 +1793,6 @@ dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dir-diff"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ad16bf5f84253b50d6557681c58c3ab67c47c77d39fed9aeb56e947290bd10"
-dependencies = [
- "walkdir",
 ]
 
 [[package]]
@@ -1874,12 +1849,6 @@ dependencies = [
  "quote",
  "syn 2.0.101",
 ]
-
-[[package]]
-name = "downcast"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "eager"
@@ -2129,10 +2098,12 @@ dependencies = [
  "solana-bn254",
  "solana-compute-budget-interface",
  "solana-program",
+ "solana-sdk-ids",
+ "solana-system-interface",
  "spl-associated-token-account 6.0.0",
  "spl-token 7.0.0",
  "static_assertions",
- "strum 0.26.3",
+ "strum",
  "thiserror 1.0.69",
 ]
 
@@ -2198,15 +2169,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
-name = "filetime"
-version = "0.2.25"
+name = "five8"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+checksum = "a75b8549488b4715defcb0d8a8a1c1c76a80661b5fa106b4ca0e7fce59d7d875"
 dependencies = [
- "cfg-if",
- "libc",
- "libredox",
- "windows-sys 0.59.0",
+ "five8_core",
 ]
 
 [[package]]
@@ -2247,15 +2215,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2290,12 +2249,6 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fragile"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -2428,7 +2381,6 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
- "serde",
  "typenum",
  "version_check",
 ]
@@ -2516,7 +2468,7 @@ checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
 dependencies = [
  "log",
  "plain",
- "scroll 0.12.0",
+ "scroll",
 ]
 
 [[package]]
@@ -2560,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "hash32"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
@@ -2641,9 +2593,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2839,7 +2791,24 @@ dependencies = [
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http 1.3.1",
+ "hyper 1.6.0",
+ "hyper-util",
+ "rustls 0.23.27",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tower-service",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -2861,13 +2830,16 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -3023,22 +2995,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "im"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
-dependencies = [
- "bitmaps",
- "rand_core 0.6.4",
- "rand_xoshiro",
- "rayon",
- "serde",
- "sized-chunks",
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3081,31 +3037,6 @@ dependencies = [
  "quote",
  "syn 2.0.101",
 ]
-
-[[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "index_list"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05caee923b644542e92a659bfceb868a4053fb7d4230ef2141931e8b01e91a"
 
 [[package]]
 name = "indexmap"
@@ -3156,6 +3087,16 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "itertools"
@@ -3293,7 +3234,7 @@ dependencies = [
  "soketto",
  "thiserror 1.0.69",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tracing",
  "url",
@@ -3351,14 +3292,14 @@ checksum = "1ccf93fc4a0bfe05d851d37d7c32b7f370fe94336b52a2f0efc5f1981895c2e5"
 dependencies = [
  "async-trait",
  "hyper 0.14.32",
- "hyper-rustls",
+ "hyper-rustls 0.24.2",
  "jsonrpsee-core 0.22.5",
  "jsonrpsee-types 0.22.5",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tracing",
  "url",
 ]
@@ -3395,7 +3336,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tracing",
 ]
 
@@ -3437,6 +3378,16 @@ dependencies = [
  "jsonrpsee-core 0.20.4",
  "jsonrpsee-types 0.20.4",
  "url",
+]
+
+[[package]]
+name = "kaigan"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba15de5aeb137f0f65aa3bf82187647f1285abfe5b20c80c2c37f7007ad519a"
+dependencies = [
+ "borsh 0.10.4",
+ "serde",
 ]
 
 [[package]]
@@ -3496,7 +3447,6 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
- "redox_syscall",
 ]
 
 [[package]]
@@ -3629,25 +3579,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "lz4"
-version = "1.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
-dependencies = [
- "lz4-sys",
-]
-
-[[package]]
-name = "lz4-sys"
-version = "1.11.1+lz4-1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "lz4_flex"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3716,16 +3647,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3753,51 +3674,79 @@ dependencies = [
 ]
 
 [[package]]
-name = "mockall"
-version = "0.11.4"
+name = "mollusk-svm"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
+checksum = "fe5e2f229c38a778c6e629f32ad2de2adb69df8dba07cbbf99b944aa330b1c4f"
 dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "lazy_static",
- "mockall_derive",
- "predicates",
- "predicates-tree",
+ "agave-feature-set",
+ "agave-precompiles",
+ "bincode",
+ "mollusk-svm-error",
+ "mollusk-svm-keys",
+ "mollusk-svm-result",
+ "solana-account",
+ "solana-bpf-loader-program",
+ "solana-clock",
+ "solana-compute-budget",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-hash",
+ "solana-instruction",
+ "solana-loader-v3-interface 3.0.0",
+ "solana-loader-v4-interface",
+ "solana-log-collector",
+ "solana-logger",
+ "solana-precompile-error",
+ "solana-program-error",
+ "solana-program-runtime",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-slot-hashes",
+ "solana-stake-interface",
+ "solana-svm-callback",
+ "solana-system-program",
+ "solana-sysvar",
+ "solana-sysvar-id",
+ "solana-timings",
+ "solana-transaction-context",
 ]
 
 [[package]]
-name = "mockall_derive"
-version = "0.11.4"
+name = "mollusk-svm-error"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
+checksum = "be2443a68c1f91e3ed4ac014b17a438cbcf976e636f0ad1e613c49873ee2e764"
 dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "solana-pubkey",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "modular-bitfield"
-version = "0.11.2"
+name = "mollusk-svm-keys"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
+checksum = "55f53f00fc28aa0561e04088fe90115fc2f348c3380adc9500de2a2b62b4d0ff"
 dependencies = [
- "modular-bitfield-impl",
- "static_assertions",
+ "mollusk-svm-error",
+ "solana-account",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-transaction-context",
 ]
 
 [[package]]
-name = "modular-bitfield-impl"
-version = "0.11.2"
+name = "mollusk-svm-result"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
+checksum = "b25a23a80c4273f698c595fa10f969050effca7bb2ecee2df72c956f582b174a"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "solana-account",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey",
+ "solana-rent",
 ]
 
 [[package]]
@@ -3880,6 +3829,8 @@ name = "neon-lib"
 version = "1.19.0-dev"
 dependencies = [
  "abi_stable",
+ "agave-feature-set",
+ "agave-reserved-account-keys",
  "anyhow",
  "arrayref",
  "async-ffi",
@@ -3903,32 +3854,29 @@ dependencies = [
  "jsonrpsee",
  "lazy_static",
  "log",
+ "mollusk-svm",
  "neon-lib-interface",
  "once_cell",
  "rand 0.8.5",
- "scroll 0.12.0",
+ "scroll",
  "serde",
  "serde_json",
  "serde_with",
  "solana-account-decoder",
- "solana-accounts-db",
- "solana-bpf-loader-program",
+ "solana-address-lookup-table-interface",
  "solana-cli",
  "solana-cli-config",
  "solana-client",
  "solana-compute-budget",
- "solana-loader-v4-program",
+ "solana-loader-v3-interface 5.0.0",
  "solana-log-collector",
- "solana-program-runtime",
- "solana-runtime",
  "solana-sdk",
- "solana-svm",
- "solana-timings",
- "solana-transaction-status",
+ "solana-sdk-ids",
+ "solana-system-interface",
  "spl-associated-token-account 6.0.0",
  "spl-token 7.0.0",
- "strum 0.26.3",
- "strum_macros 0.26.4",
+ "strum",
+ "strum_macros",
  "thiserror 1.0.69",
  "tokio",
  "tracerdb-api",
@@ -3987,19 +3935,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.9.1",
- "cfg-if",
- "cfg_aliases",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -4008,6 +3943,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -4031,12 +3967,6 @@ name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
-
-[[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
@@ -4179,11 +4109,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi 0.5.2",
  "libc",
 ]
 
@@ -4493,36 +4423,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "predicates"
-version = "2.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
-dependencies = [
- "difflib",
- "float-cmp",
- "itertools 0.10.5",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
-dependencies = [
- "predicates-core",
- "termtree",
 ]
 
 [[package]]
@@ -4857,15 +4757,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "raw-cpuid"
 version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4994,7 +4885,6 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "async-compression",
  "base64 0.21.7",
  "bytes",
  "encoding_rs",
@@ -5004,50 +4894,86 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
- "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.25.4",
  "winreg",
 ]
 
 [[package]]
-name = "reqwest-middleware"
-version = "0.2.5"
+name = "reqwest"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a735987236a8e238bf0296c7e351b999c188ccc11477f311b82b55c93984216"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
+dependencies = [
+ "async-compression",
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.27",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tokio-util",
+ "tower 0.5.2",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.2",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 0.2.12",
- "reqwest",
+ "http 1.3.1",
+ "reqwest 0.12.22",
  "serde",
- "task-local-extensions",
  "thiserror 1.0.69",
+ "tower-service",
 ]
 
 [[package]]
@@ -5329,12 +5255,6 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scroll"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
-
-[[package]]
-name = "scroll"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
@@ -5439,21 +5359,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "seqlock"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c67b6f14ecc5b86c66fa63d76b5092352678545a8a3cdae80aef5128371910"
-dependencies = [
- "parking_lot",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -5644,6 +5564,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5671,16 +5601,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5697,9 +5617,9 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -5723,49 +5643,71 @@ dependencies = [
 
 [[package]]
 name = "solana-account"
-version = "2.1.21"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a495abef137c65f58282720384262503172cddb937c94c1a01f0a6c553a0dc"
+checksum = "0f949fe4edaeaea78c844023bfc1c898e0b1f5a100f8a8d2d0f85d0a7b090258"
 dependencies = [
  "bincode",
+ "qualifier_attr",
  "serde",
  "serde_bytes",
  "serde_derive",
+ "solana-account-info",
+ "solana-clock",
  "solana-instruction",
- "solana-program",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-sysvar",
 ]
 
 [[package]]
 name = "solana-account-decoder"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e83b9f421857e9aee51df52aab53d03a9f5860a57c0adcda8a480392f2f85a"
+checksum = "ee858af4ca998a3d220a764a5b8f542a5ee6b6dc0e4051f8317f297855d7fada"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
  "bincode",
  "bs58",
  "bv",
- "lazy_static",
  "serde",
  "serde_derive",
  "serde_json",
+ "solana-account",
  "solana-account-decoder-client-types",
- "solana-config-program",
- "solana-sdk",
- "spl-token 6.0.0",
- "spl-token-2022 4.0.0",
- "spl-token-group-interface 0.3.0",
- "spl-token-metadata-interface 0.4.0",
- "thiserror 1.0.69",
+ "solana-address-lookup-table-interface",
+ "solana-clock",
+ "solana-config-program-client",
+ "solana-epoch-schedule",
+ "solana-fee-calculator",
+ "solana-instruction",
+ "solana-loader-v3-interface 5.0.0",
+ "solana-nonce",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-slot-hashes",
+ "solana-slot-history",
+ "solana-stake-interface",
+ "solana-sysvar",
+ "solana-vote-interface",
+ "spl-generic-token",
+ "spl-token 8.0.0",
+ "spl-token-2022 8.0.1",
+ "spl-token-group-interface 0.6.0",
+ "spl-token-metadata-interface 0.7.0",
+ "thiserror 2.0.12",
  "zstd",
 ]
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4af8ffcad184f2486e5e677fe25250f8f0d77b2d5eb24045fb720963525272b7"
+checksum = "4eec60c5d15cac5256ef566193b3a5a56cae9fa35572dc27708946e0a504e843"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -5779,9 +5721,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-info"
-version = "2.1.21"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b43b59c9659eb61504c4cc73a92a5995a117fa4ffc04bb0da002848cfdd7fcd"
+checksum = "c8f5152a288ef1912300fc6efa6c2d1f9bb55d9398eb6c72326360b8063987da"
 dependencies = [
  "bincode",
  "serde",
@@ -5791,84 +5733,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-accounts-db"
-version = "2.1.21"
+name = "solana-address-lookup-table-interface"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7397feffd9d3a68870f5712614121fcf55f028fdc41e7dbe2a7cc0f8e335a8"
+checksum = "d1673f67efe870b64a65cb39e6194be5b26527691ce5922909939961a6e6b395"
 dependencies = [
- "ahash",
  "bincode",
- "blake3",
- "bv",
  "bytemuck",
- "bytemuck_derive",
- "bzip2",
- "crossbeam-channel",
- "dashmap",
- "index_list",
- "indexmap 2.9.0",
- "itertools 0.12.1",
- "lazy_static",
- "log",
- "lz4",
- "memmap2",
- "modular-bitfield",
- "num_cpus",
- "num_enum",
- "rand 0.8.5",
- "rayon",
- "seqlock",
  "serde",
  "serde_derive",
- "smallvec",
- "solana-bucket-map",
- "solana-inline-spl",
- "solana-lattice-hash",
- "solana-measure",
- "solana-metrics",
- "solana-nohash-hasher",
- "solana-rayon-threadlimit",
- "solana-sdk",
- "solana-svm-transaction",
- "static_assertions",
- "tar",
- "tempfile",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "solana-address-lookup-table-program"
-version = "2.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65611f71c78bbe5bd8c5574cdab6095e11f75f2c3864487b844ff3a4a69be56"
-dependencies = [
- "bincode",
- "bytemuck",
- "log",
- "num-derive 0.4.2",
- "num-traits",
- "solana-feature-set",
- "solana-log-collector",
- "solana-program",
- "solana-program-runtime",
- "solana-sdk",
- "thiserror 1.0.69",
+ "solana-clock",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-slot-hashes",
 ]
 
 [[package]]
 name = "solana-atomic-u64"
-version = "2.1.21"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f9c33447056f11c1c486ffc2d803366847ba712463d9640891e50490faafd56"
+checksum = "d52e52720efe60465b052b9e7445a01c17550666beec855cce66f44766697bc2"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
-name = "solana-bincode"
-version = "2.1.21"
+name = "solana-big-mod-exp"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c4ce8ddc2f5343e64346f9f8a05e9f27579d848f059485290d5b9c962c352c"
+checksum = "75db7f2bbac3e62cfd139065d15bcda9e2428883ba61fc8d27ccb251081e7567"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "solana-define-syscall",
+]
+
+[[package]]
+name = "solana-bincode"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a3787b8cf9c9fe3dd360800e8b70982b9e5a8af9e11c354b6665dd4a003adc"
 dependencies = [
  "bincode",
  "serde",
@@ -5876,25 +5781,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-bn254"
-version = "2.1.21"
+name = "solana-blake3-hasher"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e485c027635dd7c6e558949d13bcc052340d704eef4219438593afea5632f42"
+checksum = "a1a0801e25a1b31a14494fc80882a036be0ffd290efc4c2d640bfcca120a4672"
+dependencies = [
+ "blake3",
+ "solana-define-syscall",
+ "solana-hash",
+ "solana-sanitize",
+]
+
+[[package]]
+name = "solana-bn254"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4420f125118732833f36facf96a27e7b78314b2d642ba07fa9ffdacd8d79e243"
 dependencies = [
  "ark-bn254",
  "ark-ec",
  "ark-ff",
  "ark-serialize",
  "bytemuck",
- "solana-program",
- "thiserror 1.0.69",
+ "solana-define-syscall",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "solana-borsh"
-version = "2.1.21"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad79f227829e9b3fa1227acf21b02877f1a0d99d1b753a8085254b706fbddfee"
+checksum = "718333bcd0a1a7aed6655aa66bef8d7fb047944922b2d3a18f49cbc13e73d004"
 dependencies = [
  "borsh 0.10.4",
  "borsh 1.5.7",
@@ -5902,83 +5819,75 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea31f52138383b981263f57fe2311dcdfddb489c2990615f23ab36d4f141fcc"
+checksum = "9f64ed51006b8cd4e65b0750b789c15501935c423bdd643572d31ad75e692f4b"
 dependencies = [
  "bincode",
- "byteorder",
  "libsecp256k1",
- "log",
+ "num-traits",
+ "qualifier_attr",
  "scopeguard",
+ "solana-account",
+ "solana-account-info",
+ "solana-big-mod-exp",
+ "solana-bincode",
+ "solana-blake3-hasher",
  "solana-bn254",
- "solana-compute-budget",
+ "solana-clock",
+ "solana-cpi",
  "solana-curve25519",
- "solana-feature-set",
+ "solana-hash",
+ "solana-instruction",
+ "solana-keccak-hasher",
+ "solana-loader-v3-interface 5.0.0",
+ "solana-loader-v4-interface",
  "solana-log-collector",
  "solana-measure",
+ "solana-packet",
  "solana-poseidon",
- "solana-program-memory",
+ "solana-program-entrypoint",
  "solana-program-runtime",
- "solana-sdk",
+ "solana-pubkey",
+ "solana-sbpf",
+ "solana-sdk-ids",
+ "solana-secp256k1-recover",
+ "solana-sha256-hasher",
+ "solana-stable-layout",
+ "solana-svm-feature-set",
+ "solana-system-interface",
+ "solana-sysvar",
+ "solana-sysvar-id",
  "solana-timings",
+ "solana-transaction-context",
  "solana-type-overrides",
- "solana_rbpf",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "solana-bucket-map"
-version = "2.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c3a9d8c4c58d02cc9284351536b18639a5cd5914d667810aefbe18fce00d95"
-dependencies = [
- "bv",
- "bytemuck",
- "bytemuck_derive",
- "log",
- "memmap2",
- "modular-bitfield",
- "num_enum",
- "rand 0.8.5",
- "solana-measure",
- "solana-sdk",
- "tempfile",
-]
-
-[[package]]
-name = "solana-builtins-default-costs"
-version = "2.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b97e2e9de1d0e6d40829826fbdad1655494d1e8eaece86f097fc80fd8e269b4"
-dependencies = [
- "ahash",
- "lazy_static",
- "log",
- "solana-address-lookup-table-program",
- "solana-bpf-loader-program",
- "solana-compute-budget-program",
- "solana-config-program",
- "solana-loader-v4-program",
- "solana-sdk",
- "solana-stake-program",
- "solana-system-program",
- "solana-vote-program",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "solana-clap-utils"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b3ba1cb4fd2a97efeff952c1f60cfe1bb93d06eabd5cff292666344395cf65"
+checksum = "cd2c2761fb93b264edc3973b934e1c716a8a15b87b7b7bdf4bc28f541d2bd15a"
 dependencies = [
  "chrono",
  "clap",
  "rpassword",
+ "solana-clock",
+ "solana-cluster-type",
+ "solana-commitment-config",
  "solana-derivation-path",
+ "solana-hash",
+ "solana-keypair",
+ "solana-message",
+ "solana-native-token",
+ "solana-presigner",
+ "solana-pubkey",
  "solana-remote-wallet",
- "solana-sdk",
- "thiserror 1.0.69",
+ "solana-seed-phrase",
+ "solana-signature",
+ "solana-signer",
+ "thiserror 2.0.12",
  "tiny-bip39",
  "uriparse",
  "url",
@@ -5986,10 +5895,11 @@ dependencies = [
 
 [[package]]
 name = "solana-cli"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adf8a912e5335c643cefb8522184e0c7184aeba127193ccbe4dffa0f4f51d9fe"
+checksum = "b69938414a3852f40c21e0e6aa975f320967b8d35b164d809412ebe520b0cac7"
 dependencies = [
+ "agave-feature-set",
  "bincode",
  "bs58",
  "clap",
@@ -6003,68 +5913,98 @@ dependencies = [
  "log",
  "num-traits",
  "pretty-hex",
- "reqwest",
+ "reqwest 0.12.22",
  "semver",
  "serde",
  "serde_derive",
  "serde_json",
+ "solana-account",
  "solana-account-decoder",
+ "solana-address-lookup-table-interface",
+ "solana-borsh",
  "solana-bpf-loader-program",
  "solana-clap-utils",
  "solana-cli-config",
  "solana-cli-output",
  "solana-client",
- "solana-compute-budget",
- "solana-config-program",
+ "solana-clock",
+ "solana-cluster-type",
+ "solana-commitment-config",
+ "solana-compute-budget-interface",
+ "solana-config-program-client",
  "solana-connection-cache",
  "solana-decode-error",
- "solana-feature-set",
+ "solana-epoch-schedule",
+ "solana-feature-gate-client",
+ "solana-feature-gate-interface",
+ "solana-fee-calculator",
+ "solana-fee-structure",
+ "solana-hash",
+ "solana-instruction",
+ "solana-keypair",
+ "solana-loader-v3-interface 5.0.0",
+ "solana-loader-v4-interface",
  "solana-loader-v4-program",
  "solana-logger",
+ "solana-message",
+ "solana-native-token",
+ "solana-nonce",
+ "solana-offchain-message",
+ "solana-packet",
  "solana-program-runtime",
+ "solana-pubkey",
  "solana-pubsub-client",
  "solana-quic-client",
  "solana-remote-wallet",
+ "solana-rent",
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-rpc-client-nonce-utils",
- "solana-sdk",
+ "solana-sbpf",
+ "solana-sdk-ids",
+ "solana-signature",
+ "solana-signer",
+ "solana-slot-history",
+ "solana-stake-interface",
  "solana-streamer",
+ "solana-system-interface",
+ "solana-sysvar",
  "solana-tps-client",
  "solana-tpu-client",
+ "solana-transaction",
+ "solana-transaction-error",
  "solana-transaction-status",
  "solana-udp-client",
  "solana-version",
  "solana-vote-program",
- "solana_rbpf",
- "spl-memo 5.0.0",
- "thiserror 1.0.69",
+ "spl-memo",
+ "thiserror 2.0.12",
  "tiny-bip39",
 ]
 
 [[package]]
 name = "solana-cli-config"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f9d8e368861419cd9495af853507d70dca5d6e30a48ebf4faa26e4d376f17b"
+checksum = "489867877d20887535fb921f0b8011870b1092df720b26dc32be28a8bb721745"
 dependencies = [
  "dirs-next",
- "lazy_static",
  "serde",
  "serde_derive",
  "serde_yaml",
  "solana-clap-utils",
- "solana-sdk",
+ "solana-commitment-config",
  "url",
 ]
 
 [[package]]
 name = "solana-cli-output"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da3c6af170fccd8d4d7da226dafb4762e7cf71e516bd9a7c9cdb8afa926beb6"
+checksum = "0fa04701a8309da9456198b3386159f71bd71da32ed7efc5c455f3f0914815af"
 dependencies = [
  "Inflector",
+ "agave-reserved-account-keys",
  "base64 0.22.1",
  "chrono",
  "clap",
@@ -6075,21 +6015,36 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "solana-account",
  "solana-account-decoder",
+ "solana-bincode",
  "solana-clap-utils",
  "solana-cli-config",
+ "solana-clock",
+ "solana-epoch-info",
+ "solana-hash",
+ "solana-message",
+ "solana-native-token",
+ "solana-packet",
+ "solana-pubkey",
  "solana-rpc-client-api",
- "solana-sdk",
+ "solana-sdk-ids",
+ "solana-signature",
+ "solana-stake-interface",
+ "solana-system-interface",
+ "solana-sysvar",
+ "solana-transaction",
+ "solana-transaction-error",
  "solana-transaction-status",
  "solana-vote-program",
- "spl-memo 5.0.0",
+ "spl-memo",
 ]
 
 [[package]]
 name = "solana-client"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e8b895b90c53861d2c9cfa5fa50ec1ff4eb5df904f8c3ef604c3c7d21bc048"
+checksum = "0996196c72ea12c9e2ae179c000d4cfc626697445058fea2951d5e8b5b054772"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6101,85 +6056,132 @@ dependencies = [
  "log",
  "quinn",
  "rayon",
+ "solana-account",
+ "solana-client-traits",
+ "solana-commitment-config",
  "solana-connection-cache",
+ "solana-epoch-info",
+ "solana-hash",
+ "solana-instruction",
+ "solana-keypair",
  "solana-measure",
+ "solana-message",
+ "solana-pubkey",
  "solana-pubsub-client",
  "solana-quic-client",
+ "solana-quic-definitions",
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-rpc-client-nonce-utils",
- "solana-sdk",
+ "solana-signature",
+ "solana-signer",
  "solana-streamer",
  "solana-thin-client",
+ "solana-time-utils",
  "solana-tpu-client",
+ "solana-transaction",
+ "solana-transaction-error",
  "solana-udp-client",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
 [[package]]
-name = "solana-clock"
-version = "2.1.21"
+name = "solana-client-traits"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd1a3f42e823861b812f388d4007bfb2d23aa316d999a2f2ca124fa33c72a40"
+checksum = "83f0071874e629f29e0eb3dab8a863e98502ac7aba55b7e0df1803fc5cac72a7"
+dependencies = [
+ "solana-account",
+ "solana-commitment-config",
+ "solana-epoch-info",
+ "solana-hash",
+ "solana-instruction",
+ "solana-keypair",
+ "solana-message",
+ "solana-pubkey",
+ "solana-signature",
+ "solana-signer",
+ "solana-system-interface",
+ "solana-transaction",
+ "solana-transaction-error",
+]
+
+[[package]]
+name = "solana-clock"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb482ab70fced82ad3d7d3d87be33d466a3498eb8aa856434ff3c0dfc2e2e31"
 dependencies = [
  "serde",
  "serde_derive",
+ "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
 ]
 
 [[package]]
-name = "solana-compute-budget"
-version = "2.1.21"
+name = "solana-cluster-type"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ac55f874d43496b1e1d091576dd99e74e5863911ca55ac36912fe8fe3aa155"
+checksum = "7ace9fea2daa28354d107ea879cff107181d85cd4e0f78a2bedb10e1a428c97e"
 dependencies = [
- "solana-sdk",
+ "serde",
+ "serde_derive",
+ "solana-hash",
+]
+
+[[package]]
+name = "solana-commitment-config"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac49c4dde3edfa832de1697e9bcdb7c3b3f7cb7a1981b7c62526c8bb6700fb73"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "solana-compute-budget"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956fab24ae74baa5b1f611b988365dc0b699977329ef9a3dec30d259e4236804"
+dependencies = [
+ "solana-fee-structure",
+ "solana-program-runtime",
 ]
 
 [[package]]
 name = "solana-compute-budget-interface"
-version = "0.0.2"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2d2f24b3b9bff0b70a77aaa48415f4c928795fc0e7cbbba73bd89570914cc7"
+checksum = "8432d2c4c22d0499aa06d62e4f7e333f81777b3d7c96050ae9e5cb71a8c3aee4"
 dependencies = [
  "borsh 1.5.7",
+ "serde",
+ "serde_derive",
  "solana-instruction",
  "solana-sdk-ids",
 ]
 
 [[package]]
-name = "solana-compute-budget-program"
-version = "2.1.21"
+name = "solana-config-program-client"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d0e239d2485e2909bc4da6db157892a22fdf7e529e13413d4f61e6170b2ca2"
-dependencies = [
- "solana-program-runtime",
- "solana-sdk",
-]
-
-[[package]]
-name = "solana-config-program"
-version = "2.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb08509a0969a3929fc48de314af650ce77d678ec742e49b6f60535c57eccb2"
+checksum = "53aceac36f105fd4922e29b4f0c1f785b69d7b3e7e387e384b8985c8e0c3595e"
 dependencies = [
  "bincode",
- "chrono",
+ "borsh 0.10.4",
+ "kaigan",
  "serde",
- "serde_derive",
- "solana-log-collector",
- "solana-program-runtime",
- "solana-sdk",
- "solana-short-vec",
+ "solana-program",
 ]
 
 [[package]]
 name = "solana-connection-cache"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dacc24987ab8878540216bbf98d637d9fc1df84722bf8e90a2f4f546d720d808"
+checksum = "c12756666d382704ebdb9e49f2f37f3d1262866df60cbd8799dd2877b3195528"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6189,37 +6191,20 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rayon",
+ "solana-keypair",
  "solana-measure",
  "solana-metrics",
- "solana-sdk",
- "thiserror 1.0.69",
+ "solana-time-utils",
+ "solana-transaction-error",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
 [[package]]
-name = "solana-cost-model"
-version = "2.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bf0069a964490c932303d77dbd1c1e5664c3d702b5ad8a19f561c6c59fb3d"
-dependencies = [
- "ahash",
- "lazy_static",
- "log",
- "solana-builtins-default-costs",
- "solana-compute-budget",
- "solana-feature-set",
- "solana-metrics",
- "solana-runtime-transaction",
- "solana-sdk",
- "solana-svm-transaction",
- "solana-vote-program",
-]
-
-[[package]]
 name = "solana-cpi"
-version = "2.1.21"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43b1391eecec7c15ae83477d0bfebc9a92ebe69f793683fd497ac02d180fcd5"
+checksum = "8dc71126edddc2ba014622fc32d0f5e2e78ec6c5a1e0eb511b85618c09e9ea11"
 dependencies = [
  "solana-account-info",
  "solana-define-syscall",
@@ -6231,37 +6216,38 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdcc0923e1fbfe614d4a5675c3e4398b521c9d128c2114aaf3e404ea81ad08ee"
+checksum = "e2b575bfa3a3775e4201cd5179d4d390a056b8dc691a3df8ac754e8d7e629454"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
- "solana-program",
- "thiserror 1.0.69",
+ "solana-define-syscall",
+ "subtle",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "solana-decode-error"
-version = "2.1.21"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "750a2c40fd97c96f7464ccf11142c598d5d35094d5988944f7ca5714e014737c"
+checksum = "10a6a6383af236708048f8bd8d03db8ca4ff7baf4a48e5d580f4cce545925470"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "solana-define-syscall"
-version = "2.1.21"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "592a9b501608cb642af6ad9d07c8be8827772c20d1afa5173c85c561da7942a3"
+checksum = "2ae3e2abcf541c8122eafe9a625d4d194b4023c20adde1e251f94e056bb1aee2"
 
 [[package]]
 name = "solana-derivation-path"
-version = "2.1.21"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59883e489a9f19caef8af9a198f791f2b62348e14e5279f87df950c233c7880"
+checksum = "939756d798b25c5ec3cca10e06212bdca3b1443cb9bb740a38124f58b258737b"
 dependencies = [
  "derivation-path",
  "qstring",
@@ -6269,25 +6255,129 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-epoch-schedule"
-version = "2.1.21"
+name = "solana-ed25519-program"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80ec39611020935101afd9a57ac57ea6961796b7d8705974408601e97d4dfb30"
+checksum = "a1feafa1691ea3ae588f99056f4bdd1293212c7ece28243d7da257c443e84753"
+dependencies = [
+ "bytemuck",
+ "bytemuck_derive",
+ "ed25519-dalek",
+ "solana-feature-set",
+ "solana-instruction",
+ "solana-precompile-error",
+ "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-epoch-info"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ef6f0b449290b0b9f32973eefd95af35b01c5c0c34c569f936c34c5b20d77b"
 dependencies = [
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "solana-epoch-rewards"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b575d3dd323b9ea10bb6fe89bf6bf93e249b215ba8ed7f68f1a3633f384db7"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-hash",
+ "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
 ]
 
 [[package]]
-name = "solana-feature-set"
-version = "2.1.21"
+name = "solana-epoch-rewards-hasher"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "286cb8e4d888f36026bcb1603ff8ab52565ff12705ed24ed44dc68047ef2f779"
+checksum = "96c5fd2662ae7574810904585fd443545ed2b568dbd304b25a31e79ccc76e81b"
 dependencies = [
- "lazy_static",
+ "siphasher 0.3.11",
+ "solana-hash",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "solana-epoch-schedule"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fce071fbddecc55d727b1d7ed16a629afe4f6e4c217bc8d00af3b785f6f67ed"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-example-mocks"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84461d56cbb8bb8d539347151e0525b53910102e4bced875d49d5139708e39d3"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-address-lookup-table-interface",
  "solana-clock",
+ "solana-hash",
+ "solana-instruction",
+ "solana-keccak-hasher",
+ "solana-message",
+ "solana-nonce",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-system-interface",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "solana-feature-gate-client"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1056507c534839b5cd1b1010ffedb9e8c92313269786fb5066ff53b30326dc3"
+dependencies = [
+ "borsh 0.10.4",
+ "num-derive 0.4.2",
+ "num-traits",
+ "solana-program",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "solana-feature-gate-interface"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f5c5382b449e8e4e3016fb05e418c53d57782d8b5c30aa372fc265654b956d"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_derive",
+ "solana-account",
+ "solana-account-info",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-system-interface",
+]
+
+[[package]]
+name = "solana-feature-set"
+version = "2.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93b93971e289d6425f88e6e3cb6668c4b05df78b3c518c249be55ced8efd6b6d"
+dependencies = [
+ "ahash",
+ "lazy_static",
  "solana-epoch-schedule",
  "solana-hash",
  "solana-pubkey",
@@ -6295,20 +6385,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-fee"
-version = "2.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c88253a60f613453e6c52d6811345cbb62c7ddae6c932a8d7a13475acc166c"
-dependencies = [
- "solana-sdk",
- "solana-svm-transaction",
-]
-
-[[package]]
 name = "solana-fee-calculator"
-version = "2.1.21"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb464dcd65c2737f25e85b4f40e11ae90b106fa5ed6127acc7e3f5d70a7128a2"
+checksum = "d89bc408da0fb3812bc3008189d148b4d3e08252c79ad810b245482a3f70cd8d"
 dependencies = [
  "log",
  "serde",
@@ -6316,15 +6396,67 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-hash"
-version = "2.1.21"
+name = "solana-fee-structure"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591e9192a4575792bb6a175f82b6bcfb301fc1113c4342bce7789f00726e98a"
+checksum = "33adf673581c38e810bf618f745bf31b683a0a4a4377682e6aaac5d9a058dd4e"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-message",
+ "solana-native-token",
+]
+
+[[package]]
+name = "solana-genesis-config"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3725085d47b96d37fef07a29d78d2787fc89a0b9004c66eed7753d1e554989f"
+dependencies = [
+ "bincode",
+ "chrono",
+ "memmap2",
+ "serde",
+ "serde_derive",
+ "solana-account",
+ "solana-clock",
+ "solana-cluster-type",
+ "solana-epoch-schedule",
+ "solana-fee-calculator",
+ "solana-hash",
+ "solana-inflation",
+ "solana-keypair",
+ "solana-logger",
+ "solana-poh-config",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-sha256-hasher",
+ "solana-shred-version",
+ "solana-signer",
+ "solana-time-utils",
+]
+
+[[package]]
+name = "solana-hard-forks"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c28371f878e2ead55611d8ba1b5fb879847156d04edea13693700ad1a28baf"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "solana-hash"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b96e9f0300fa287b545613f007dfe20043d7812bee255f418c1eb649c93b63"
 dependencies = [
  "borsh 1.5.7",
- "bs58",
  "bytemuck",
  "bytemuck_derive",
+ "five8",
  "js-sys",
  "serde",
  "serde_derive",
@@ -6335,29 +6467,19 @@ dependencies = [
 
 [[package]]
 name = "solana-inflation"
-version = "2.1.21"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c79ffef2dcf3c9361e8333276c08bd84f112f0760e2fe7273fd089d9bfd2c3b"
+checksum = "23eef6a09eb8e568ce6839573e4966850e85e9ce71e6ae1a6c930c1c43947de3"
 dependencies = [
  "serde",
  "serde_derive",
 ]
 
 [[package]]
-name = "solana-inline-spl"
-version = "2.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729ecbe3e375fc9cd385da4bab1caa97aca73937cb147fc117ad44cd1e65a8f"
-dependencies = [
- "bytemuck",
- "solana-pubkey",
-]
-
-[[package]]
 name = "solana-instruction"
-version = "2.1.21"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cfdcaf08849c1828899c5f9ac8da6077bd3b339e2b0648b2d99d3fd780c3c6f"
+checksum = "47298e2ce82876b64f71e9d13a46bc4b9056194e7f9937ad3084385befa50885"
 dependencies = [
  "bincode",
  "borsh 1.5.7",
@@ -6372,132 +6494,299 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-last-restart-slot"
-version = "2.1.21"
+name = "solana-instructions-sysvar"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b026280da05ff5a5fecd37057f85029b135b65df442467eeb15a8824b902294"
+checksum = "e0e85a6fad5c2d0c4f5b91d34b8ca47118fc593af706e523cdbedf846a954f57"
+dependencies = [
+ "bitflags 2.9.1",
+ "solana-account-info",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey",
+ "solana-sanitize",
+ "solana-sdk-ids",
+ "solana-serialize-utils",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-keccak-hasher"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7aeb957fbd42a451b99235df4942d96db7ef678e8d5061ef34c9b34cae12f79"
+dependencies = [
+ "sha3",
+ "solana-define-syscall",
+ "solana-hash",
+ "solana-sanitize",
+]
+
+[[package]]
+name = "solana-keypair"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dbb7042c2e0c561afa07242b2099d55c57bd1b1da3b6476932197d84e15e3e4"
+dependencies = [
+ "bs58",
+ "ed25519-dalek",
+ "ed25519-dalek-bip32",
+ "rand 0.7.3",
+ "solana-derivation-path",
+ "solana-pubkey",
+ "solana-seed-derivable",
+ "solana-seed-phrase",
+ "solana-signature",
+ "solana-signer",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "solana-last-restart-slot"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a6360ac2fdc72e7463565cd256eedcf10d7ef0c28a1249d261ec168c1b55cdd"
 dependencies = [
  "serde",
  "serde_derive",
+ "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
 ]
 
 [[package]]
-name = "solana-lattice-hash"
-version = "2.1.21"
+name = "solana-loader-v2-interface"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56a7051fbb3446b5dd712462220c443391d8218658d32562fea01928bdcb2471"
+checksum = "d8ab08006dad78ae7cd30df8eea0539e207d08d91eaefb3e1d49a446e1c49654"
 dependencies = [
- "base64 0.22.1",
- "blake3",
- "bs58",
- "bytemuck",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-loader-v3-interface"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4be76cfa9afd84ca2f35ebc09f0da0f0092935ccdac0595d98447f259538c2"
+dependencies = [
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-loader-v3-interface"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f7162a05b8b0773156b443bccd674ea78bb9aa406325b467ea78c06c99a63a2"
+dependencies = [
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-system-interface",
+]
+
+[[package]]
+name = "solana-loader-v4-interface"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "706a777242f1f39a83e2a96a2a6cb034cb41169c6ecbee2cf09cb873d9659e7e"
+dependencies = [
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-system-interface",
 ]
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d40fa34be5ff2836a9ab19113ae604c86b3303edc0ece9123dcf9c9136c0654"
+checksum = "ef686d9ddf3a9cccbf8a10d7618b2038a375bb65fb93e8969625e1c2b4bc0c29"
 dependencies = [
  "log",
+ "qualifier_attr",
+ "solana-account",
+ "solana-bincode",
  "solana-bpf-loader-program",
- "solana-compute-budget",
+ "solana-instruction",
+ "solana-loader-v3-interface 5.0.0",
+ "solana-loader-v4-interface",
  "solana-log-collector",
  "solana-measure",
+ "solana-packet",
  "solana-program-runtime",
- "solana-sdk",
+ "solana-pubkey",
+ "solana-sbpf",
+ "solana-sdk-ids",
+ "solana-transaction-context",
  "solana-type-overrides",
- "solana_rbpf",
 ]
 
 [[package]]
 name = "solana-log-collector"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca24a27f90bc5b3e27a97f0c7dd062a7ad068df240fd8df1267e4840f5d1991"
+checksum = "ec7b7fd84dc54f43c26417460cb1b420cf7abf193395155a7ba94ceb105e3568"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "solana-logger"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f3c07e378a9dec7ddf4d218d624b4c12b6dc5f68d7d60560d923737dca03753"
+checksum = "db8e777ec1afd733939b532a42492d888ec7c88d8b4127a5d867eb45c6eb5cd5"
 dependencies = [
  "env_logger",
  "lazy_static",
+ "libc",
  "log",
+ "signal-hook",
 ]
 
 [[package]]
 name = "solana-measure"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1520b3d2e1271adc263807fb6bea9d1ded1aaf4b3dffc4e8c1d51c4444417db"
+checksum = "9b595ca49ec02c6f3f31c6ff7788186b982ad211600c8d885baf389171af8a52"
+
+[[package]]
+name = "solana-message"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1796aabce376ff74bf89b78d268fa5e683d7d7a96a0a4e4813ec34de49d5314b"
+dependencies = [
+ "bincode",
+ "blake3",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "solana-bincode",
+ "solana-hash",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-sanitize",
+ "solana-sdk-ids",
+ "solana-short-vec",
+ "solana-system-interface",
+ "solana-transaction-error",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "solana-metrics"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5546d4505ca1d7c07fd4bedf5f20d256929c4bf614e031c0e84c94cc8d1a94"
+checksum = "f01c243a2c15e66f6db2c8b11b92c27bbf737b28fff0b39952a294e4befb8c46"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
- "lazy_static",
  "log",
- "reqwest",
- "solana-sdk",
- "thiserror 1.0.69",
+ "reqwest 0.12.22",
+ "solana-cluster-type",
+ "solana-sha256-hasher",
+ "solana-time-utils",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "solana-msg"
-version = "2.1.21"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddbd7c6efaea83a2bd85a14a0a062ccc77039070311d2ca1af4c887be500192f"
+checksum = "f36a1a14399afaabc2781a1db09cb14ee4cc4ee5c7a5a3cfcc601811379a8092"
 dependencies = [
  "solana-define-syscall",
 ]
 
 [[package]]
 name = "solana-native-token"
-version = "2.1.21"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b58d96fb3ff6d29e0afdb933888f65bcdf0775b334eee4f1f6f72b475cb531"
+checksum = "307fb2f78060995979e9b4f68f833623565ed4e55d3725f100454ce78a99a1a3"
 
 [[package]]
 name = "solana-net-utils"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e51e4517d9580de18b36d9ad8743b76b58332cbdbcf86931a4627e4f01e13b"
+checksum = "8d1c67baf3ee4a1adb5d57f1d68f05fa0d1b261feabe3bdcf51ce9b6a9c67c56"
 dependencies = [
+ "anyhow",
  "bincode",
- "crossbeam-channel",
+ "bytes",
+ "itertools 0.12.1",
  "log",
- "nix 0.29.0",
+ "nix",
  "rand 0.8.5",
  "serde",
  "serde_derive",
  "socket2",
- "solana-sdk",
+ "solana-serde",
  "tokio",
  "url",
 ]
 
 [[package]]
-name = "solana-nohash-hasher"
-version = "0.2.1"
+name = "solana-nonce"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8a731ed60e89177c8a7ab05fe0f1511cedd3e70e773f288f9de33a9cfdc21e"
+checksum = "703e22eb185537e06204a5bd9d509b948f0066f2d1d814a6f475dafb3ddf1325"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-fee-calculator",
+ "solana-hash",
+ "solana-pubkey",
+ "solana-sha256-hasher",
+]
+
+[[package]]
+name = "solana-nonce-account"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde971a20b8dbf60144d6a84439dda86b5466e00e2843091fe731083cda614da"
+dependencies = [
+ "solana-account",
+ "solana-hash",
+ "solana-nonce",
+ "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-offchain-message"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b526398ade5dea37f1f147ce55dae49aa017a5d7326606359b0445ca8d946581"
+dependencies = [
+ "num_enum",
+ "solana-hash",
+ "solana-packet",
+ "solana-pubkey",
+ "solana-sanitize",
+ "solana-sha256-hasher",
+ "solana-signature",
+ "solana-signer",
+]
 
 [[package]]
 name = "solana-packet"
-version = "2.1.21"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a46ca92cd3303aa3a225b4b3b4d9b2d29e42927545f1c1ff4042ca516b4decbd"
+checksum = "004f2d2daf407b3ec1a1ca5ec34b3ccdfd6866dd2d3c7d0715004a96e4b6d127"
 dependencies = [
  "bincode",
  "bitflags 2.9.1",
@@ -6509,103 +6798,149 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89bb80d7168654e72c3414b70d6c6e8fcd2de7eb291ed72e4a646f133b8b8e1"
+checksum = "ce580238dc07ab2c38555c9dc0e6b02ec44734bf28bac7ab7d70bd4f821b2614"
 dependencies = [
  "ahash",
  "bincode",
  "bv",
+ "bytes",
  "caps",
  "curve25519-dalek 4.1.3",
  "dlopen2",
  "fnv",
- "lazy_static",
  "libc",
  "log",
- "nix 0.29.0",
+ "nix",
  "rand 0.8.5",
  "rayon",
  "serde",
+ "solana-hash",
+ "solana-message",
  "solana-metrics",
+ "solana-packet",
+ "solana-pubkey",
  "solana-rayon-threadlimit",
- "solana-sdk",
+ "solana-sdk-ids",
  "solana-short-vec",
- "solana-vote-program",
+ "solana-signature",
+ "solana-time-utils",
+]
+
+[[package]]
+name = "solana-poh-config"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d650c3b4b9060082ac6b0efbbb66865089c58405bfb45de449f3f2b91eccee75"
+dependencies = [
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
 name = "solana-poseidon"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8decadf56e36bb312c5b5775d14963a5f4c027b001c86e5934d3abf4f9ddd18"
+checksum = "95a44faa88ef8d2b0bbc50d6e43fc24adcaf76a716e3d77af23d670e5f9adc36"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
  "solana-define-syscall",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "solana-precompile-error"
-version = "2.1.21"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c58acffc2369dd3965e666a69015a978ef639e7e11cfe950b80d3ccfb44115"
+checksum = "4d87b2c1f5de77dfe2b175ee8dd318d196aaca4d0f66f02842f80c852811f9f8"
 dependencies = [
  "num-traits",
  "solana-decode-error",
 ]
 
 [[package]]
-name = "solana-program"
-version = "2.1.21"
+name = "solana-precompiles"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c3aa133068171f46e9583dc9c20221b9a67459e7b8aecd3be5b49af60b2887f"
+checksum = "36e92768a57c652edb0f5d1b30a7d0bc64192139c517967c18600debe9ae3832"
 dependencies = [
- "base64 0.22.1",
+ "lazy_static",
+ "solana-ed25519-program",
+ "solana-feature-set",
+ "solana-message",
+ "solana-precompile-error",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-secp256k1-program",
+ "solana-secp256r1-program",
+]
+
+[[package]]
+name = "solana-presigner"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a57a24e6a4125fc69510b6774cd93402b943191b6cddad05de7281491c90fe"
+dependencies = [
+ "solana-pubkey",
+ "solana-signature",
+ "solana-signer",
+]
+
+[[package]]
+name = "solana-program"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98eca145bd3545e2fbb07166e895370576e47a00a7d824e325390d33bf467210"
+dependencies = [
  "bincode",
- "bitflags 2.9.1",
  "blake3",
  "borsh 0.10.4",
  "borsh 1.5.7",
  "bs58",
- "bv",
  "bytemuck",
- "bytemuck_derive",
  "console_error_panic_hook",
  "console_log",
- "curve25519-dalek 4.1.3",
- "five8_const",
  "getrandom 0.2.16",
- "js-sys",
  "lazy_static",
  "log",
  "memoffset",
  "num-bigint 0.4.6",
  "num-derive 0.4.2",
  "num-traits",
- "parking_lot",
  "rand 0.8.5",
  "serde",
  "serde_bytes",
  "serde_derive",
- "sha2 0.10.9",
- "sha3",
  "solana-account-info",
+ "solana-address-lookup-table-interface",
  "solana-atomic-u64",
+ "solana-big-mod-exp",
  "solana-bincode",
+ "solana-blake3-hasher",
  "solana-borsh",
  "solana-clock",
  "solana-cpi",
  "solana-decode-error",
  "solana-define-syscall",
+ "solana-epoch-rewards",
  "solana-epoch-schedule",
+ "solana-example-mocks",
+ "solana-feature-gate-interface",
  "solana-fee-calculator",
  "solana-hash",
  "solana-instruction",
+ "solana-instructions-sysvar",
+ "solana-keccak-hasher",
  "solana-last-restart-slot",
+ "solana-loader-v2-interface",
+ "solana-loader-v3-interface 5.0.0",
+ "solana-loader-v4-interface",
+ "solana-message",
  "solana-msg",
  "solana-native-token",
+ "solana-nonce",
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-program-memory",
@@ -6614,6 +6949,7 @@ dependencies = [
  "solana-pubkey",
  "solana-rent",
  "solana-sanitize",
+ "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-secp256k1-recover",
  "solana-serde-varint",
@@ -6623,17 +6959,20 @@ dependencies = [
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-stable-layout",
+ "solana-stake-interface",
+ "solana-system-interface",
+ "solana-sysvar",
  "solana-sysvar-id",
- "solana-transaction-error",
- "thiserror 1.0.69",
+ "solana-vote-interface",
+ "thiserror 2.0.12",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "solana-program-entrypoint"
-version = "2.1.21"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42577056d9910b5e3badfb4ae8e234a814ff854e645e679b4286e1b4338c0f03"
+checksum = "32ce041b1a0ed275290a5008ee1a4a6c48f5054c8a3d78d313c08958a06aedbd"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -6643,9 +6982,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-error"
-version = "2.1.21"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a268d99b9f7a2ebfee0e8aa03be2f926626575d2e3c33ef02245c1e99477202e"
+checksum = "9ee2e0217d642e2ea4bee237f37bd61bb02aec60da3647c48ff88f6556ade775"
 dependencies = [
  "borsh 1.5.7",
  "num-traits",
@@ -6659,71 +6998,83 @@ dependencies = [
 
 [[package]]
 name = "solana-program-memory"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d5f1d48635ce777d931ba85a4be23d9da2443cb24bcd9cc380636444a3e234"
+checksum = "3a5426090c6f3fd6cfdc10685322fede9ca8e5af43cd6a59e98bfe4e91671712"
 dependencies = [
- "num-traits",
  "solana-define-syscall",
 ]
 
 [[package]]
 name = "solana-program-option"
-version = "2.1.21"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f8d02965a1f8382b55c834fc9388c95112e8b238625f5c1e6289f20573b91a"
+checksum = "dc677a2e9bc616eda6dbdab834d463372b92848b2bfe4a1ed4e4b4adba3397d0"
 
 [[package]]
 name = "solana-program-pack"
-version = "2.1.21"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "019fc8c5e8698918bb0675afce683a17248e1c38b178c59f23577fbfd2374aa5"
+checksum = "319f0ef15e6e12dc37c597faccb7d62525a509fec5f6975ecb9419efddeb277b"
 dependencies = [
  "solana-program-error",
 ]
 
 [[package]]
 name = "solana-program-runtime"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7702436e95dadea0553a5b29b42271b81da61c2ae78e4425c74fadd7ce2252b5"
+checksum = "b8e68cc7ec43ce85bc4074edb0a31019b09f098620dde220bd94ccec5e158b27"
 dependencies = [
  "base64 0.22.1",
  "bincode",
  "enum-iterator",
  "itertools 0.12.1",
- "libc",
  "log",
- "num-derive 0.4.2",
- "num-traits",
  "percentage",
  "rand 0.8.5",
  "serde",
- "solana-compute-budget",
- "solana-feature-set",
+ "solana-account",
+ "solana-clock",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-fee-structure",
+ "solana-hash",
+ "solana-instruction",
+ "solana-last-restart-slot",
  "solana-log-collector",
  "solana-measure",
  "solana-metrics",
- "solana-sdk",
+ "solana-program-entrypoint",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sbpf",
+ "solana-sdk-ids",
+ "solana-slot-hashes",
+ "solana-stable-layout",
+ "solana-svm-callback",
+ "solana-svm-feature-set",
+ "solana-system-interface",
+ "solana-sysvar",
+ "solana-sysvar-id",
  "solana-timings",
+ "solana-transaction-context",
  "solana-type-overrides",
- "solana-vote",
- "solana_rbpf",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "solana-pubkey"
-version = "2.1.21"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bcff57fc2a096f6c57851e22587a7a36b6fdaa567eab75bb0bcd06f449fcbc"
+checksum = "9b62adb9c3261a052ca1f999398c388f1daf558a1b492f60a6d9e64857db4ff1"
 dependencies = [
  "borsh 0.10.4",
  "borsh 1.5.7",
- "bs58",
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
+ "five8",
  "five8_const",
  "getrandom 0.2.16",
  "js-sys",
@@ -6741,22 +7092,24 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b05c6477415c6d1e049f3813ba9ff43ee2b2a195e78f67873c46cfd120051b5"
+checksum = "790b7f82ba1a94e2b4157b80b96a5aa6e1935884011d42bc2e741fcf2e04719d"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
+ "http 0.2.12",
  "log",
- "reqwest",
  "semver",
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account-decoder",
- "solana-rpc-client-api",
- "solana-sdk",
- "thiserror 1.0.69",
+ "solana-account-decoder-client-types",
+ "solana-clock",
+ "solana-pubkey",
+ "solana-rpc-client-types",
+ "solana-signature",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -6766,45 +7119,57 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708098feb24edd2d85c8236d7264b43d8004f55e06615544dc73a04466ff02de"
+checksum = "b6ebbc200b13f9025959d3d5b449dc21fed85a8e206e93df7d41692623b81fe9"
 dependencies = [
  "async-lock 3.4.0",
  "async-trait",
  "futures",
  "itertools 0.12.1",
- "lazy_static",
  "log",
  "quinn",
  "quinn-proto",
  "rustls 0.23.27",
  "solana-connection-cache",
+ "solana-keypair",
  "solana-measure",
  "solana-metrics",
  "solana-net-utils",
+ "solana-pubkey",
+ "solana-quic-definitions",
  "solana-rpc-client-api",
- "solana-sdk",
+ "solana-signer",
  "solana-streamer",
- "thiserror 1.0.69",
+ "solana-tls-utils",
+ "solana-transaction-error",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
 [[package]]
-name = "solana-rayon-threadlimit"
-version = "2.1.21"
+name = "solana-quic-definitions"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783a59bfe2eb5a3d6e1e3945edaa7defd24f61898e97e34aa18ba8ca59cd1b8e"
+checksum = "fbf0d4d5b049eb1d0c35f7b18f305a27c8986fc5c0c9b383e97adaa35334379e"
 dependencies = [
- "lazy_static",
+ "solana-keypair",
+]
+
+[[package]]
+name = "solana-rayon-threadlimit"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9c13901b04461d7e40c49c34b3ba8acc78c268ecdfa069388a1af7689f948eb"
+dependencies = [
  "num_cpus",
 ]
 
 [[package]]
 name = "solana-remote-wallet"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb8c4b7d62c55f87ff13aec7639c12ae3d0683e490c43605a69dd375db9d4c68"
+checksum = "f4239570d97091162bbd6b9ff1c09c1b77c266a151f73145ede3ab8d7580c054"
 dependencies = [
  "console",
  "dialoguer",
@@ -6816,276 +7181,291 @@ dependencies = [
  "qstring",
  "semver",
  "solana-derivation-path",
- "solana-sdk",
- "thiserror 1.0.69",
+ "solana-offchain-message",
+ "solana-pubkey",
+ "solana-signature",
+ "solana-signer",
+ "thiserror 2.0.12",
  "uriparse",
 ]
 
 [[package]]
 name = "solana-rent"
-version = "2.1.21"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb867706bd6e7bbbdf303416f44a5560bcef6f9a0fc5610a725c1a92103abc7"
+checksum = "d1aea8fdea9de98ca6e8c2da5827707fb3842833521b528a713810ca685d2480"
 dependencies = [
  "serde",
  "serde_derive",
+ "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
 ]
 
 [[package]]
-name = "solana-rpc-client"
-version = "2.1.21"
+name = "solana-rent-collector"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd7f12d85566cd6657548d545b0ef231eeb9b290bbed690fb7221dac27426ac"
+checksum = "7c1e19f5d5108b0d824244425e43bc78bbb9476e2199e979b0230c9f632d3bf4"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-account",
+ "solana-clock",
+ "solana-epoch-schedule",
+ "solana-genesis-config",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-rent-debits"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f6f9113c6003492e74438d1288e30cffa8ccfdc2ef7b49b9e816d8034da18cd"
+dependencies = [
+ "solana-pubkey",
+ "solana-reward-info",
+]
+
+[[package]]
+name = "solana-reserved-account-keys"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4b22ea19ca2a3f28af7cd047c914abf833486bf7a7c4a10fc652fff09b385b1"
+dependencies = [
+ "lazy_static",
+ "solana-feature-set",
+ "solana-pubkey",
+ "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-reward-info"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18205b69139b1ae0ab8f6e11cdcb627328c0814422ad2482000fa2ca54ae4a2f"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "solana-rpc-client"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d1d20f10a354123122bdbf6ad90997d7615504f3256a6408717fadc8bcd26f9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bincode",
  "bs58",
+ "futures",
  "indicatif",
  "log",
- "reqwest",
+ "reqwest 0.12.22",
  "reqwest-middleware",
  "semver",
  "serde",
  "serde_derive",
  "serde_json",
+ "solana-account",
  "solana-account-decoder-client-types",
+ "solana-clock",
+ "solana-commitment-config",
+ "solana-epoch-info",
+ "solana-epoch-schedule",
+ "solana-feature-gate-interface",
+ "solana-hash",
+ "solana-instruction",
+ "solana-message",
+ "solana-pubkey",
  "solana-rpc-client-api",
- "solana-sdk",
+ "solana-signature",
+ "solana-transaction",
+ "solana-transaction-error",
  "solana-transaction-status-client-types",
  "solana-version",
- "solana-vote-program",
+ "solana-vote-interface",
  "tokio",
 ]
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92c52ee4203b244f1ba171fcd09730e4071dac44f049f9bea4cc7413b3cb06e"
+checksum = "627c1c573afaa2515cb8127766535c3a88e845e3fba264db3e3e7da63ac508fc"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
- "bs58",
  "jsonrpc-core",
- "reqwest",
+ "reqwest 0.12.22",
  "reqwest-middleware",
- "semver",
  "serde",
  "serde_derive",
  "serde_json",
  "solana-account-decoder-client-types",
- "solana-inline-spl",
- "solana-sdk",
+ "solana-clock",
+ "solana-rpc-client-types",
+ "solana-signer",
+ "solana-transaction-error",
  "solana-transaction-status-client-types",
- "solana-version",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9347580aff889be20793bc7f3370c8a400179dba626c324165e011cf2a42f2"
+checksum = "65cd21225d3c95f10dccf51516454ff9e1ff788aabd2c799d97f14691eb7224c"
 dependencies = [
  "clap",
+ "solana-account",
  "solana-clap-utils",
+ "solana-commitment-config",
+ "solana-hash",
+ "solana-message",
+ "solana-nonce",
+ "solana-pubkey",
  "solana-rpc-client",
- "solana-sdk",
- "thiserror 1.0.69",
+ "solana-sdk-ids",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
-name = "solana-runtime"
-version = "2.1.21"
+name = "solana-rpc-client-types"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e26f4bb49e5f393fc4f9090db3eecd213163ce93c3e7d41e4c5f3c75d693c76"
+checksum = "046675cd97165f93460535f7ff241c44f90a73d8dabe7edc009505b393ff9248"
 dependencies = [
- "ahash",
- "aquamarine",
- "arrayref",
  "base64 0.22.1",
- "bincode",
- "blake3",
- "bv",
- "bytemuck",
- "byteorder",
- "bzip2",
- "crossbeam-channel",
- "dashmap",
- "dir-diff",
- "flate2",
- "fnv",
- "im",
- "index_list",
- "itertools 0.12.1",
- "lazy_static",
- "libc",
- "log",
- "lz4",
- "memmap2",
- "mockall",
- "modular-bitfield",
- "num-derive 0.4.2",
- "num-traits",
- "num_cpus",
- "num_enum",
- "percentage",
- "qualifier_attr",
- "rand 0.8.5",
- "rayon",
- "regex",
+ "bs58",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
- "serde_with",
- "solana-accounts-db",
- "solana-address-lookup-table-program",
- "solana-bpf-loader-program",
- "solana-bucket-map",
- "solana-compute-budget",
- "solana-compute-budget-program",
- "solana-config-program",
- "solana-cost-model",
- "solana-feature-set",
- "solana-fee",
- "solana-inline-spl",
- "solana-lattice-hash",
- "solana-loader-v4-program",
- "solana-measure",
- "solana-metrics",
- "solana-perf",
- "solana-program",
- "solana-program-runtime",
- "solana-rayon-threadlimit",
- "solana-runtime-transaction",
- "solana-sdk",
- "solana-stake-program",
- "solana-svm",
- "solana-svm-rent-collector",
- "solana-svm-transaction",
- "solana-system-program",
- "solana-timings",
- "solana-transaction-status",
- "solana-version",
- "solana-vote",
- "solana-vote-program",
- "solana-zk-elgamal-proof-program",
- "solana-zk-sdk",
- "solana-zk-token-proof-program",
- "solana-zk-token-sdk",
- "static_assertions",
- "strum 0.24.1",
- "strum_macros 0.24.3",
- "symlink",
- "tar",
- "tempfile",
- "thiserror 1.0.69",
- "zstd",
-]
-
-[[package]]
-name = "solana-runtime-transaction"
-version = "2.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec3c967946b2af3c3ae93dc2e741a440a87d141a8d54ee0113c538b981bddfc"
-dependencies = [
- "agave-transaction-view",
- "log",
- "solana-builtins-default-costs",
- "solana-compute-budget",
+ "solana-account",
+ "solana-account-decoder-client-types",
+ "solana-clock",
+ "solana-commitment-config",
+ "solana-fee-calculator",
+ "solana-inflation",
  "solana-pubkey",
- "solana-sdk",
- "solana-svm-transaction",
- "thiserror 1.0.69",
+ "solana-transaction-error",
+ "solana-transaction-status-client-types",
+ "solana-version",
+ "spl-generic-token",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "solana-sanitize"
-version = "2.1.21"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac599243d068ed88b40e781e02c92c8ed3edd0170337b1b4cee995e4fbe84af0"
+checksum = "61f1bc1357b8188d9c4a3af3fc55276e56987265eb7ad073ae6f8180ee54cecf"
+
+[[package]]
+name = "solana-sbpf"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "474a2d95dc819898ded08d24f29642d02189d3e1497bbb442a92a3997b7eb55f"
+dependencies = [
+ "byteorder",
+ "combine 3.8.1",
+ "hash32",
+ "libc",
+ "log",
+ "rand 0.8.5",
+ "rustc-demangle",
+ "thiserror 2.0.12",
+ "winapi",
+]
 
 [[package]]
 name = "solana-sdk"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef4d9a579ff99aa5109921f729ab9cba07b207486b2c1eab8240c97777102ba"
+checksum = "8cc0e4a7635b902791c44b6581bfb82f3ada32c5bc0929a64f39fe4bb384c86a"
 dependencies = [
  "bincode",
- "bitflags 2.9.1",
- "borsh 1.5.7",
  "bs58",
- "bytemuck",
- "bytemuck_derive",
- "byteorder",
- "chrono",
- "digest 0.10.7",
- "ed25519-dalek",
- "ed25519-dalek-bip32",
  "getrandom 0.1.16",
- "hmac 0.12.1",
- "itertools 0.12.1",
  "js-sys",
- "lazy_static",
- "libsecp256k1",
- "log",
- "memmap2",
- "num-derive 0.4.2",
- "num-traits",
- "num_enum",
- "pbkdf2 0.11.0",
- "rand 0.7.3",
- "rand 0.8.5",
  "serde",
- "serde_bytes",
- "serde_derive",
  "serde_json",
- "serde_with",
- "sha2 0.10.9",
- "sha3",
- "siphasher 0.3.11",
  "solana-account",
  "solana-bn254",
+ "solana-client-traits",
+ "solana-cluster-type",
+ "solana-commitment-config",
+ "solana-compute-budget-interface",
  "solana-decode-error",
  "solana-derivation-path",
+ "solana-ed25519-program",
+ "solana-epoch-info",
+ "solana-epoch-rewards-hasher",
  "solana-feature-set",
+ "solana-fee-structure",
+ "solana-genesis-config",
+ "solana-hard-forks",
  "solana-inflation",
  "solana-instruction",
+ "solana-keypair",
+ "solana-message",
  "solana-native-token",
+ "solana-nonce-account",
+ "solana-offchain-message",
  "solana-packet",
+ "solana-poh-config",
  "solana-precompile-error",
+ "solana-precompiles",
+ "solana-presigner",
  "solana-program",
  "solana-program-memory",
  "solana-pubkey",
+ "solana-quic-definitions",
+ "solana-rent-collector",
+ "solana-rent-debits",
+ "solana-reserved-account-keys",
+ "solana-reward-info",
  "solana-sanitize",
+ "solana-sdk-ids",
  "solana-sdk-macro",
+ "solana-secp256k1-program",
  "solana-secp256k1-recover",
  "solana-secp256r1-program",
+ "solana-seed-derivable",
+ "solana-seed-phrase",
+ "solana-serde",
  "solana-serde-varint",
  "solana-short-vec",
+ "solana-shred-version",
  "solana-signature",
+ "solana-signer",
+ "solana-system-transaction",
+ "solana-time-utils",
+ "solana-transaction",
+ "solana-transaction-context",
  "solana-transaction-error",
- "thiserror 1.0.69",
+ "solana-validator-exit",
+ "thiserror 2.0.12",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "solana-sdk-ids"
-version = "0.0.3"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd3718f21f667ce3f721a2fd1716d31d4292db4f81d7162adaddd7a7cb28ebe"
+checksum = "5c5d8b9cc68d5c88b062a33e23a6466722467dde0035152d8fb1afbcdf350a5f"
 dependencies = [
  "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-sdk-macro"
-version = "2.1.21"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ea6cfa40c712e5de92ffa2d62a2b296379d09411e0f1d7fcd9fecf5fcc5a30"
+checksum = "86280da8b99d03560f6ab5aca9de2e38805681df34e0bb8f238e69b29433b9df"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -7094,29 +7474,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-secp256k1-recover"
-version = "2.1.21"
+name = "solana-secp256k1-program"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9d4483cde845bb0f70374d2905014650057eafdcc546a3e50059e7643318e8"
+checksum = "f19833e4bc21558fe9ec61f239553abe7d05224347b57d65c2218aeeb82d6149"
+dependencies = [
+ "bincode",
+ "digest 0.10.7",
+ "libsecp256k1",
+ "serde",
+ "serde_derive",
+ "sha3",
+ "solana-feature-set",
+ "solana-instruction",
+ "solana-precompile-error",
+ "solana-sdk-ids",
+ "solana-signature",
+]
+
+[[package]]
+name = "solana-secp256k1-recover"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baa3120b6cdaa270f39444f5093a90a7b03d296d362878f7a6991d6de3bbe496"
 dependencies = [
  "borsh 1.5.7",
  "libsecp256k1",
  "solana-define-syscall",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "solana-secp256r1-program"
-version = "2.1.21"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6feaf48cad9bf5ca1a04c8cd1fb45d4fa507ff86dae77802b8e8f47b89fb0eed"
+checksum = "ce0ae46da3071a900f02d367d99b2f3058fe2e90c5062ac50c4f20cfedad8f0f"
 dependencies = [
  "bytemuck",
  "openssl",
  "solana-feature-set",
  "solana-instruction",
  "solana-precompile-error",
- "solana-pubkey",
+ "solana-sdk-ids",
 ]
 
 [[package]]
@@ -7126,19 +7525,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
-name = "solana-serde-varint"
-version = "2.1.21"
+name = "solana-seed-derivable"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3778f75e718af3c3e4b42ca67ec3a4197658855eaa5372a2f41e2378290b4fc"
+checksum = "3beb82b5adb266c6ea90e5cf3967235644848eac476c5a1f2f9283a143b7c97f"
+dependencies = [
+ "solana-derivation-path",
+]
+
+[[package]]
+name = "solana-seed-phrase"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36187af2324f079f65a675ec22b31c24919cb4ac22c79472e85d819db9bbbc15"
+dependencies = [
+ "hmac 0.12.1",
+ "pbkdf2 0.11.0",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "solana-serde"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1931484a408af466e14171556a47adaa215953c7f48b24e5f6b0282763818b04"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "solana-serde-varint"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a7e155eba458ecfb0107b98236088c3764a09ddf0201ec29e52a0be40857113"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "solana-serialize-utils"
-version = "2.1.21"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ccf458c0aaa5d517fa358c70a6322e2cb7c18c659464eaa7135de5b3c1b2837"
+checksum = "817a284b63197d2b27afdba829c5ab34231da4a9b4e763466a003c40ca4f535e"
 dependencies = [
  "solana-instruction",
  "solana-pubkey",
@@ -7147,9 +7575,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sha256-hasher"
-version = "2.1.21"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4028550a372b5ce9514941fb1a04cfac9aa66f76fd9684a7b11ef37ac586e492"
+checksum = "5aa3feb32c28765f6aa1ce8f3feac30936f16c5c3f7eb73d63a5b8f6f8ecdc44"
 dependencies = [
  "sha2 0.10.9",
  "solana-define-syscall",
@@ -7158,84 +7586,112 @@ dependencies = [
 
 [[package]]
 name = "solana-short-vec"
-version = "2.1.21"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be97defacda69848b33aa1fec3571435e5a3bfb55cdd2afd66867604eee3ff84"
+checksum = "5c54c66f19b9766a56fa0057d060de8378676cb64987533fa088861858fc5a69"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "solana-signature"
-version = "2.1.21"
+name = "solana-shred-version"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fdb44ae08fa08bcaf5a3c01cf0d1b9c363ab2e3e2602e9b7806f653d08b4d0"
+checksum = "afd3db0461089d1ad1a78d9ba3f15b563899ca2386351d38428faa5350c60a98"
 dependencies = [
- "bs58",
+ "solana-hard-forks",
+ "solana-hash",
+ "solana-sha256-hasher",
+]
+
+[[package]]
+name = "solana-signature"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c8ec8e657aecfc187522fc67495142c12f35e55ddeca8698edbb738b8dbd8c"
+dependencies = [
  "ed25519-dalek",
- "generic-array",
+ "five8",
  "rand 0.8.5",
  "serde",
+ "serde-big-array",
  "serde_derive",
  "solana-sanitize",
 ]
 
 [[package]]
-name = "solana-slot-hashes"
-version = "2.1.21"
+name = "solana-signer"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7bb06f75cb9d4c44f71dbc1cf46b1e67aaa9f737b66389b18471a8db1d9a09"
+checksum = "7c41991508a4b02f021c1342ba00bcfa098630b213726ceadc7cb032e051975b"
+dependencies = [
+ "solana-pubkey",
+ "solana-signature",
+ "solana-transaction-error",
+]
+
+[[package]]
+name = "solana-slot-hashes"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8691982114513763e88d04094c9caa0376b867a29577939011331134c301ce"
 dependencies = [
  "serde",
  "serde_derive",
  "solana-hash",
+ "solana-sdk-ids",
  "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-slot-history"
-version = "2.1.21"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff10530199def6788f8750cc274629e49e2c4baf181ddfb7c754813fd0bc252e"
+checksum = "97ccc1b2067ca22754d5283afb2b0126d61eae734fc616d23871b0943b0d935e"
 dependencies = [
  "bv",
  "serde",
  "serde_derive",
+ "solana-sdk-ids",
  "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-stable-layout"
-version = "2.1.21"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36af09027fa5a658210d7add0c7661934a879439b68336dbe680263255d3f62"
+checksum = "9f14f7d02af8f2bc1b5efeeae71bc1c2b7f0f65cd75bcc7d8180f2c762a57f54"
 dependencies = [
  "solana-instruction",
  "solana-pubkey",
 ]
 
 [[package]]
-name = "solana-stake-program"
-version = "2.1.21"
+name = "solana-stake-interface"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b68bfa531432c4b873cd3dee4d889ed6fa8b332237aa8e77e4e21f91a692fe3"
+checksum = "5269e89fde216b4d7e1d1739cf5303f8398a1ff372a81232abbee80e554a838c"
 dependencies = [
- "bincode",
- "log",
- "solana-config-program",
- "solana-feature-set",
- "solana-log-collector",
- "solana-program-runtime",
- "solana-sdk",
- "solana-type-overrides",
- "solana-vote-program",
+ "borsh 0.10.4",
+ "borsh 1.5.7",
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-clock",
+ "solana-cpi",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey",
+ "solana-system-interface",
+ "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-streamer"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d2e47061df599f6d924ad28e8ea884e4305079e440704f816edd7892df529e"
+checksum = "cb37589b70d001ea9be5712322c941ed49e50c5b51b9242ec363213ebcd1ad79"
 dependencies = [
  "async-channel",
  "bytes",
@@ -7249,7 +7705,7 @@ dependencies = [
  "itertools 0.12.1",
  "libc",
  "log",
- "nix 0.29.0",
+ "nix",
  "pem",
  "percentage",
  "quinn",
@@ -7258,142 +7714,242 @@ dependencies = [
  "rustls 0.23.27",
  "smallvec",
  "socket2",
+ "solana-keypair",
  "solana-measure",
  "solana-metrics",
+ "solana-net-utils",
+ "solana-packet",
  "solana-perf",
- "solana-sdk",
+ "solana-pubkey",
+ "solana-quic-definitions",
+ "solana-signature",
+ "solana-signer",
+ "solana-time-utils",
+ "solana-tls-utils",
+ "solana-transaction-error",
  "solana-transaction-metrics-tracker",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "x509-parser",
 ]
 
 [[package]]
-name = "solana-svm"
-version = "2.1.21"
+name = "solana-svm-callback"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51048c4758c8cdc4fe92c49d9f97f9fe11a8a4a5866104dbfefbcbb0b957c8d3"
+checksum = "7dfa93939bf68a7fcce87cc055ca10e5022ea413d0ab68347ac9cf4c2bd4279b"
 dependencies = [
- "itertools 0.12.1",
- "log",
- "percentage",
- "qualifier_attr",
- "serde",
- "serde_derive",
- "solana-bpf-loader-program",
- "solana-compute-budget",
- "solana-feature-set",
- "solana-fee",
- "solana-loader-v4-program",
- "solana-log-collector",
- "solana-measure",
- "solana-program-runtime",
- "solana-runtime-transaction",
- "solana-sdk",
- "solana-svm-rent-collector",
- "solana-svm-transaction",
- "solana-system-program",
- "solana-timings",
- "solana-type-overrides",
- "solana-vote",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "solana-svm-rent-collector"
-version = "2.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3482c5429304f1e0824b7afbf17aa31910f2c884e470b8ed245d5a243dda4d72"
-dependencies = [
- "solana-sdk",
-]
-
-[[package]]
-name = "solana-svm-transaction"
-version = "2.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeeba8361828e574ea223494c76167153adb012540494ff4eb3d5f54edb6180"
-dependencies = [
- "solana-sdk",
-]
-
-[[package]]
-name = "solana-system-program"
-version = "2.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5bdb09f4b6e8b524949dbecd5a7957c3412ebbcffbf7bd94d9b4d6189d4a37"
-dependencies = [
- "bincode",
- "log",
- "serde",
- "serde_derive",
- "solana-log-collector",
- "solana-program-runtime",
- "solana-sdk",
- "solana-type-overrides",
-]
-
-[[package]]
-name = "solana-sysvar-id"
-version = "2.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d72e2ff3e0a3b14d0fd4010d1fe7e4fcc9c4d8e5d43826c75c5629477e8b1a"
-dependencies = [
+ "solana-account",
+ "solana-precompile-error",
  "solana-pubkey",
 ]
 
 [[package]]
-name = "solana-thin-client"
-version = "2.1.21"
+name = "solana-svm-feature-set"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088dc95940d918063ddb317911b4c52c4647bfc68f012cde71bd2cd728a78a82"
+checksum = "16c5cf1acee9ce9333f62fea518b641e0454245004def6cb938fd3a182e1526c"
+
+[[package]]
+name = "solana-system-interface"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94d7c18cb1a91c6be5f5a8ac9276a1d7c737e39a21beba9ea710ab4b9c63bc90"
+dependencies = [
+ "js-sys",
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-pubkey",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "solana-system-program"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e737e67d327b8260306522fde5758a1b09af5e6cd630d589c25e610f74a0c6a8"
+dependencies = [
+ "bincode",
+ "log",
+ "serde",
+ "serde_derive",
+ "solana-account",
+ "solana-bincode",
+ "solana-fee-calculator",
+ "solana-instruction",
+ "solana-log-collector",
+ "solana-nonce",
+ "solana-nonce-account",
+ "solana-packet",
+ "solana-program-runtime",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-system-interface",
+ "solana-sysvar",
+ "solana-transaction-context",
+ "solana-type-overrides",
+]
+
+[[package]]
+name = "solana-system-transaction"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bd98a25e5bcba8b6be8bcbb7b84b24c2a6a8178d7fb0e3077a916855ceba91a"
+dependencies = [
+ "solana-hash",
+ "solana-keypair",
+ "solana-message",
+ "solana-pubkey",
+ "solana-signer",
+ "solana-system-interface",
+ "solana-transaction",
+]
+
+[[package]]
+name = "solana-sysvar"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d50c92bc019c590f5e42c61939676e18d14809ed00b2a59695dd5c67ae72c097"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "bytemuck",
+ "bytemuck_derive",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "solana-account-info",
+ "solana-clock",
+ "solana-define-syscall",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-fee-calculator",
+ "solana-hash",
+ "solana-instruction",
+ "solana-instructions-sysvar",
+ "solana-last-restart-slot",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sanitize",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-slot-hashes",
+ "solana-slot-history",
+ "solana-stake-interface",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-sysvar-id"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5762b273d3325b047cfda250787f8d796d781746860d5d0a746ee29f3e8812c1"
+dependencies = [
+ "solana-pubkey",
+ "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-thin-client"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec856519104a1a627128814613c394298035682ff17f84b43dcfebe7d06b070f"
 dependencies = [
  "bincode",
  "log",
  "rayon",
+ "solana-account",
+ "solana-client-traits",
+ "solana-clock",
+ "solana-commitment-config",
  "solana-connection-cache",
+ "solana-epoch-info",
+ "solana-hash",
+ "solana-instruction",
+ "solana-keypair",
+ "solana-message",
+ "solana-pubkey",
  "solana-rpc-client",
  "solana-rpc-client-api",
- "solana-sdk",
+ "solana-signature",
+ "solana-signer",
+ "solana-system-interface",
+ "solana-transaction",
+ "solana-transaction-error",
 ]
 
 [[package]]
-name = "solana-timings"
-version = "2.1.21"
+name = "solana-time-utils"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a4cb26e92fe54cff708393ea63cb4b5c983cd1c86c5b5d4962523f57e95239e"
+checksum = "6af261afb0e8c39252a04d026e3ea9c405342b08c871a2ad8aa5448e068c784c"
+
+[[package]]
+name = "solana-timings"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda43b3a20f03b5cc0bb235861b53debcf01885de214dd77087c4d349e571bd6"
 dependencies = [
  "eager",
  "enum-iterator",
- "solana-sdk",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "solana-tls-utils"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "551324868ad575956030bdebd21f59e3acd4aa479d60cd34a799fb1b08b1bfbe"
+dependencies = [
+ "rustls 0.23.27",
+ "solana-keypair",
+ "solana-pubkey",
+ "solana-signer",
+ "x509-parser",
 ]
 
 [[package]]
 name = "solana-tps-client"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a7ed7ce1a0020ca4b2d68f1361ec3e2245fe10f4d8f12894cd2cb17087719a"
+checksum = "3791e05c75eb20cdd151603be15e5bf58e7487b210f6fa467303360fa9a96f10"
 dependencies = [
  "log",
+ "solana-account",
  "solana-client",
+ "solana-clock",
+ "solana-commitment-config",
  "solana-connection-cache",
+ "solana-epoch-info",
+ "solana-hash",
+ "solana-keypair",
+ "solana-message",
+ "solana-pubkey",
  "solana-quic-client",
  "solana-rpc-client",
  "solana-rpc-client-api",
- "solana-runtime",
- "solana-sdk",
+ "solana-signature",
+ "solana-signer",
  "solana-streamer",
  "solana-tpu-client",
+ "solana-transaction",
+ "solana-transaction-error",
  "solana-transaction-status",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "solana-tpu-client"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9488a780907414a3688bec172e5a659639fd4bfcf2316ebd1e38eb945e8c16ef"
+checksum = "28d4344d21c30da45d114b70ad2080a6cee0905babf1abbd450c92627118cb5a"
 dependencies = [
  "async-trait",
  "bincode",
@@ -7402,21 +7958,76 @@ dependencies = [
  "indicatif",
  "log",
  "rayon",
+ "solana-client-traits",
+ "solana-clock",
+ "solana-commitment-config",
  "solana-connection-cache",
+ "solana-epoch-info",
  "solana-measure",
+ "solana-message",
+ "solana-net-utils",
+ "solana-pubkey",
  "solana-pubsub-client",
+ "solana-quic-definitions",
  "solana-rpc-client",
  "solana-rpc-client-api",
- "solana-sdk",
- "thiserror 1.0.69",
+ "solana-signature",
+ "solana-signer",
+ "solana-transaction",
+ "solana-transaction-error",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
 [[package]]
-name = "solana-transaction-error"
-version = "2.1.21"
+name = "solana-transaction"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf8715c2acb247f4592eb7dc1d616454836f10c2d0e397a557fae4192337618"
+checksum = "abec848d081beb15a324c633cd0e0ab33033318063230389895cae503ec9b544"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_derive",
+ "solana-bincode",
+ "solana-feature-set",
+ "solana-hash",
+ "solana-instruction",
+ "solana-keypair",
+ "solana-message",
+ "solana-precompiles",
+ "solana-pubkey",
+ "solana-sanitize",
+ "solana-sdk-ids",
+ "solana-short-vec",
+ "solana-signature",
+ "solana-signer",
+ "solana-system-interface",
+ "solana-transaction-error",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "solana-transaction-context"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48a900e43746e45fb0ae279b89b24bd527c35411e483413a1dd39339cea7177a"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_derive",
+ "solana-account",
+ "solana-instruction",
+ "solana-instructions-sysvar",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-transaction-error"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a9dc8fdb61c6088baab34fc3a8b8473a03a7a5fd404ed8dd502fa79b67cb1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -7426,53 +8037,69 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da8cde1a888002debdbb216efdb9b86de52df48fa2804bb66ea7c780465e79d"
+checksum = "0dc97b2a99ff9280ecdbd3475c43659a3fb40e04e2fbf2967089cfc96b35b396"
 dependencies = [
  "base64 0.22.1",
  "bincode",
- "lazy_static",
  "log",
  "rand 0.8.5",
+ "solana-packet",
  "solana-perf",
- "solana-sdk",
  "solana-short-vec",
+ "solana-signature",
 ]
 
 [[package]]
 name = "solana-transaction-status"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c62ad1caf3e15f05cf40dc82e765319750b4f6a48e1ad3ae2e8a4f6be6e7de"
+checksum = "5dcfad9fb2dd75f1cddaeb087bb8edb4f8cfd91c8b407789c7bed9c68149a573"
 dependencies = [
  "Inflector",
+ "agave-reserved-account-keys",
  "base64 0.22.1",
  "bincode",
  "borsh 1.5.7",
  "bs58",
- "lazy_static",
  "log",
  "serde",
  "serde_derive",
  "serde_json",
  "solana-account-decoder",
- "solana-sdk",
+ "solana-address-lookup-table-interface",
+ "solana-clock",
+ "solana-hash",
+ "solana-instruction",
+ "solana-loader-v2-interface",
+ "solana-loader-v3-interface 5.0.0",
+ "solana-message",
+ "solana-program-option",
+ "solana-pubkey",
+ "solana-reward-info",
+ "solana-sdk-ids",
+ "solana-signature",
+ "solana-stake-interface",
+ "solana-system-interface",
+ "solana-transaction",
+ "solana-transaction-error",
  "solana-transaction-status-client-types",
- "spl-associated-token-account 4.0.0",
- "spl-memo 5.0.0",
- "spl-token 6.0.0",
- "spl-token-2022 4.0.0",
- "spl-token-group-interface 0.3.0",
- "spl-token-metadata-interface 0.4.0",
- "thiserror 1.0.69",
+ "solana-vote-interface",
+ "spl-associated-token-account 7.0.0",
+ "spl-memo",
+ "spl-token 8.0.0",
+ "spl-token-2022 8.0.1",
+ "spl-token-group-interface 0.6.0",
+ "spl-token-metadata-interface 0.7.0",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a0e47c3d688676b37c1e3ff6a1fbb6a8b3bfaf050ee6343b6b993e3cc91cd"
+checksum = "9ae65ed465048492d7e3a413300430e340518da4c924394691d1339d99715282"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -7481,104 +8108,124 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder-client-types",
- "solana-sdk",
+ "solana-commitment-config",
+ "solana-message",
+ "solana-reward-info",
  "solana-signature",
- "thiserror 1.0.69",
+ "solana-transaction",
+ "solana-transaction-context",
+ "solana-transaction-error",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "solana-type-overrides"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb3bf3b629b5730bbc12ae75ef23b4665f3940fa98ac9bb4e251509952ae863"
+checksum = "33dcab747a0c14e7eeb8b0f2fbf4f9c6879ee88040cddd4c35cce2d94d751bcb"
 dependencies = [
- "lazy_static",
  "rand 0.8.5",
 ]
 
 [[package]]
 name = "solana-udp-client"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d67cb6f6406739bc1f14e6ae3a5818c6f1dce9a8924c1ee74df62fcb27ce38"
+checksum = "b5f306726ddef01de07332fb6a2d42a53fc8e36f8fe42286bc830ffb65c2b368"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
+ "solana-keypair",
  "solana-net-utils",
- "solana-sdk",
  "solana-streamer",
- "thiserror 1.0.69",
+ "solana-transaction-error",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
 [[package]]
-name = "solana-version"
-version = "2.1.21"
+name = "solana-validator-exit"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1651104543d32dca4b623be4f8792b1dc72bb515f40d7ea865c1b0ba6786d0"
+checksum = "7bbf6d7a3c0b28dd5335c52c0e9eae49d0ae489a8f324917faf0ded65a812c1d"
+
+[[package]]
+name = "solana-version"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7733d93e7e7efcdb6452e1b3b90b6793eb1fd431dcda54f40b846342aa158f1f"
 dependencies = [
+ "agave-feature-set",
+ "rand 0.8.5",
  "semver",
  "serde",
  "serde_derive",
- "solana-feature-set",
  "solana-sanitize",
  "solana-serde-varint",
 ]
 
 [[package]]
-name = "solana-vote"
-version = "2.1.21"
+name = "solana-vote-interface"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76360d4e0e639a8f593ea7a314b2d930fc473419479fc3ce1f3a633bf8ea159f"
+checksum = "b80d57478d6599d30acc31cc5ae7f93ec2361a06aefe8ea79bc81739a08af4c3"
 dependencies = [
- "itertools 0.12.1",
- "log",
+ "bincode",
+ "num-derive 0.4.2",
+ "num-traits",
  "serde",
  "serde_derive",
- "solana-sdk",
- "thiserror 1.0.69",
+ "solana-clock",
+ "solana-decode-error",
+ "solana-hash",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-serde-varint",
+ "solana-serialize-utils",
+ "solana-short-vec",
+ "solana-system-interface",
 ]
 
 [[package]]
 name = "solana-vote-program"
-version = "2.1.21"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcfb452c460133ba79f50437f455d50d0cf59f9937c2e680c4dc54e021b9bca"
+checksum = "94a34da4eb6552033affdb85ef68496f8d64c2d227fdcaf6490d1be7f10bf294"
 dependencies = [
+ "agave-feature-set",
  "bincode",
  "log",
  "num-derive 0.4.2",
  "num-traits",
  "serde",
  "serde_derive",
- "solana-feature-set",
- "solana-metrics",
- "solana-program",
+ "solana-account",
+ "solana-bincode",
+ "solana-clock",
+ "solana-epoch-schedule",
+ "solana-hash",
+ "solana-instruction",
+ "solana-keypair",
+ "solana-packet",
  "solana-program-runtime",
- "solana-sdk",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "solana-zk-elgamal-proof-program"
-version = "2.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b21e798df8b3d6f27398d0208e7e2444d7713db06786ade98e750eb0701972c8"
-dependencies = [
- "bytemuck",
- "num-derive 0.4.2",
- "num-traits",
- "solana-log-collector",
- "solana-program-runtime",
- "solana-sdk",
- "solana-zk-sdk",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-signer",
+ "solana-slot-hashes",
+ "solana-transaction",
+ "solana-transaction-context",
+ "solana-vote-interface",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.1.21"
+version = "2.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f166693492d3d4af95b75a06471d83a60d71b6b02172ff7364f572330d20158e"
+checksum = "05857892ac50fe03c125d8445fd790c6768015b76f4ad1e4b4b1499938b357f0"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -7588,7 +8235,6 @@ dependencies = [
  "curve25519-dalek 4.1.3",
  "itertools 0.12.1",
  "js-sys",
- "lazy_static",
  "merlin",
  "num-derive 0.4.2",
  "num-traits",
@@ -7598,78 +8244,17 @@ dependencies = [
  "serde_json",
  "sha3",
  "solana-derivation-path",
- "solana-program",
- "solana-sdk",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-seed-derivable",
+ "solana-seed-phrase",
+ "solana-signature",
+ "solana-signer",
  "subtle",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "wasm-bindgen",
  "zeroize",
-]
-
-[[package]]
-name = "solana-zk-token-proof-program"
-version = "2.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d2cfc4fbfed77b936b1abb22588a9e27a8c9518bd03bb3609643b2df70b400"
-dependencies = [
- "bytemuck",
- "num-derive 0.4.2",
- "num-traits",
- "solana-feature-set",
- "solana-log-collector",
- "solana-program-runtime",
- "solana-sdk",
- "solana-zk-token-sdk",
-]
-
-[[package]]
-name = "solana-zk-token-sdk"
-version = "2.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2cc3254bc3d6f09fcf7677a4606d8bb5d7719860065cde3dd8e7e41022740a"
-dependencies = [
- "aes-gcm-siv",
- "base64 0.22.1",
- "bincode",
- "bytemuck",
- "bytemuck_derive",
- "byteorder",
- "curve25519-dalek 4.1.3",
- "itertools 0.12.1",
- "lazy_static",
- "merlin",
- "num-derive 0.4.2",
- "num-traits",
- "rand 0.8.5",
- "serde",
- "serde_derive",
- "serde_json",
- "sha3",
- "solana-curve25519",
- "solana-derivation-path",
- "solana-program",
- "solana-sdk",
- "subtle",
- "thiserror 1.0.69",
- "zeroize",
-]
-
-[[package]]
-name = "solana_rbpf"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1941b5ef0c3ce8f2ac5dd984d0fb1a97423c4ff2a02eec81e3913f02e2ac2b"
-dependencies = [
- "byteorder",
- "combine 3.8.1",
- "hash32",
- "libc",
- "log",
- "rand 0.8.5",
- "rustc-demangle",
- "scroll 0.11.0",
- "thiserror 1.0.69",
- "winapi",
 ]
 
 [[package]]
@@ -7679,22 +8264,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
-]
-
-[[package]]
-name = "spl-associated-token-account"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68034596cf4804880d265f834af1ff2f821ad5293e41fa0f8f59086c181fc38e"
-dependencies = [
- "assert_matches",
- "borsh 1.5.7",
- "num-derive 0.4.2",
- "num-traits",
- "solana-program",
- "spl-token 6.0.0",
- "spl-token-2022 4.0.0",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7714,6 +8283,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-associated-token-account"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae179d4a26b3c7a20c839898e6aed84cb4477adf108a366c95532f058aea041b"
+dependencies = [
+ "borsh 1.5.7",
+ "num-derive 0.4.2",
+ "num-traits",
+ "solana-program",
+ "spl-associated-token-account-client",
+ "spl-token 8.0.0",
+ "spl-token-2022 8.0.1",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "spl-associated-token-account-client"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7721,17 +8306,6 @@ checksum = "d6f8349dbcbe575f354f9a533a21f272f3eb3808a49e2fdc1c34393b88ba76cb"
 dependencies = [
  "solana-instruction",
  "solana-pubkey",
-]
-
-[[package]]
-name = "spl-discriminator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38ea8b6dedb7065887f12d62ed62c1743aa70749e8558f963609793f6fb12bc"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator-derive",
 ]
 
 [[package]]
@@ -7779,17 +8353,41 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "solana-zk-sdk",
- "spl-pod 0.5.0",
- "spl-token-confidential-transfer-proof-extraction",
+ "spl-pod",
+ "spl-token-confidential-transfer-proof-extraction 0.2.1",
 ]
 
 [[package]]
-name = "spl-memo"
-version = "5.0.0"
+name = "spl-elgamal-registry"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0dba2f2bb6419523405d21c301a32c9f9568354d4742552e7972af801f4bdb3"
+checksum = "65edfeed09cd4231e595616aa96022214f9c9d2be02dea62c2b30d5695a6833a"
 dependencies = [
- "solana-program",
+ "bytemuck",
+ "solana-account-info",
+ "solana-cpi",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-system-interface",
+ "solana-sysvar",
+ "solana-zk-sdk",
+ "spl-pod",
+ "spl-token-confidential-transfer-proof-extraction 0.3.0",
+]
+
+[[package]]
+name = "spl-generic-token"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741a62a566d97c58d33f9ed32337ceedd4e35109a686e31b1866c5dfa56abddc"
+dependencies = [
+ "bytemuck",
+ "solana-pubkey",
 ]
 
 [[package]]
@@ -7808,23 +8406,9 @@ dependencies = [
 
 [[package]]
 name = "spl-pod"
-version = "0.3.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c704c88fc457fa649ba3aabe195c79d885c3f26709efaddc453c8de352c90b87"
-dependencies = [
- "borsh 1.5.7",
- "bytemuck",
- "bytemuck_derive",
- "solana-program",
- "solana-zk-token-sdk",
- "spl-program-error 0.5.0",
-]
-
-[[package]]
-name = "spl-pod"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a7d5950993e1ff2680bd989df298eeb169367fb2f9deeef1f132de6e4e8016"
+checksum = "d994afaf86b779104b4a95ba9ca75b8ced3fdb17ee934e38cb69e72afbe17799"
 dependencies = [
  "borsh 1.5.7",
  "bytemuck",
@@ -7837,20 +8421,7 @@ dependencies = [
  "solana-program-option",
  "solana-pubkey",
  "solana-zk-sdk",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-program-error"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b28bed65356558133751cc32b48a7a5ddfc59ac4e941314630bbed1ac10532"
-dependencies = [
- "num-derive 0.4.2",
- "num-traits",
- "solana-program",
- "spl-program-error-derive",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -7862,8 +8433,23 @@ dependencies = [
  "num-derive 0.4.2",
  "num-traits",
  "solana-program",
- "spl-program-error-derive",
+ "spl-program-error-derive 0.4.1",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-program-error"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdebc8b42553070b75aa5106f071fef2eb798c64a7ec63375da4b1f058688c6"
+dependencies = [
+ "num-derive 0.4.2",
+ "num-traits",
+ "solana-decode-error",
+ "solana-msg",
+ "solana-program-error",
+ "spl-program-error-derive 0.5.0",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -7879,17 +8465,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-tlv-account-resolution"
-version = "0.7.0"
+name = "spl-program-error-derive"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a75a5f0fcc58126693ed78a17042e9dc53f07e357d6be91789f7d62aff61a4"
+checksum = "2a2539e259c66910d78593475540e8072f0b10f0f61d7607bbf7593899ed52d0"
 dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.3.0",
- "spl-pod 0.3.1",
- "spl-program-error 0.5.0",
- "spl-type-length-value 0.5.0",
+ "proc-macro2",
+ "quote",
+ "sha2 0.10.9",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7907,26 +8491,33 @@ dependencies = [
  "solana-msg",
  "solana-program-error",
  "solana-pubkey",
- "spl-discriminator 0.4.1",
- "spl-pod 0.5.0",
+ "spl-discriminator",
+ "spl-pod",
  "spl-program-error 0.6.0",
  "spl-type-length-value 0.7.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "spl-token"
-version = "6.0.0"
+name = "spl-tlv-account-resolution"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a0f06ac7f23dc0984931b1fe309468f14ea58e32660439c1cef19456f5d0e3"
+checksum = "1408e961215688715d5a1063cbdcf982de225c45f99c82b4f7d7e1dd22b998d7"
 dependencies = [
- "arrayref",
  "bytemuck",
  "num-derive 0.4.2",
  "num-traits",
- "num_enum",
- "solana-program",
- "thiserror 1.0.69",
+ "solana-account-info",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error 0.7.0",
+ "spl-type-length-value 0.8.0",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -7945,27 +8536,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-token-2022"
-version = "4.0.0"
+name = "spl-token"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c10f3483e48679619c76598d4e4aebb955bc49b0a5cc63323afbf44135c9bf"
+checksum = "053067c6a82c705004f91dae058b11b4780407e9ccd6799dc9e7d0fab5f242da"
 dependencies = [
  "arrayref",
  "bytemuck",
  "num-derive 0.4.2",
  "num-traits",
  "num_enum",
- "solana-program",
- "solana-security-txt",
- "solana-zk-token-sdk",
- "spl-memo 5.0.0",
- "spl-pod 0.3.1",
- "spl-token 6.0.0",
- "spl-token-group-interface 0.3.0",
- "spl-token-metadata-interface 0.4.0",
- "spl-transfer-hook-interface 0.7.0",
- "spl-type-length-value 0.5.0",
- "thiserror 1.0.69",
+ "solana-account-info",
+ "solana-cpi",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-sysvar",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -7982,13 +8577,13 @@ dependencies = [
  "solana-program",
  "solana-security-txt",
  "solana-zk-sdk",
- "spl-elgamal-registry",
- "spl-memo 6.0.0",
- "spl-pod 0.5.0",
+ "spl-elgamal-registry 0.1.1",
+ "spl-memo",
+ "spl-pod",
  "spl-token 7.0.0",
- "spl-token-confidential-transfer-ciphertext-arithmetic",
- "spl-token-confidential-transfer-proof-extraction",
- "spl-token-confidential-transfer-proof-generation",
+ "spl-token-confidential-transfer-ciphertext-arithmetic 0.2.1",
+ "spl-token-confidential-transfer-proof-extraction 0.2.1",
+ "spl-token-confidential-transfer-proof-generation 0.2.0",
  "spl-token-group-interface 0.5.0",
  "spl-token-metadata-interface 0.6.0",
  "spl-transfer-hook-interface 0.9.0",
@@ -7997,10 +8592,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-token-2022"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f0dfbb079eebaee55e793e92ca5f433744f4b71ee04880bfd6beefba5973e5"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive 0.4.2",
+ "num-traits",
+ "num_enum",
+ "solana-account-info",
+ "solana-clock",
+ "solana-cpi",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-native-token",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-security-txt",
+ "solana-system-interface",
+ "solana-sysvar",
+ "solana-zk-sdk",
+ "spl-elgamal-registry 0.2.0",
+ "spl-memo",
+ "spl-pod",
+ "spl-token 8.0.0",
+ "spl-token-confidential-transfer-ciphertext-arithmetic 0.3.0",
+ "spl-token-confidential-transfer-proof-extraction 0.3.0",
+ "spl-token-confidential-transfer-proof-generation 0.4.0",
+ "spl-token-group-interface 0.6.0",
+ "spl-token-metadata-interface 0.7.0",
+ "spl-transfer-hook-interface 0.10.0",
+ "spl-type-length-value 0.8.0",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "spl-token-confidential-transfer-ciphertext-arithmetic"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170378693c5516090f6d37ae9bad2b9b6125069be68d9acd4865bbe9fc8499fd"
+dependencies = [
+ "base64 0.22.1",
+ "bytemuck",
+ "solana-curve25519",
+ "solana-zk-sdk",
+]
+
+[[package]]
+name = "spl-token-confidential-transfer-ciphertext-arithmetic"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94ab20faf7b5edaa79acd240e0f21d5a2ef936aa99ed98f698573a2825b299c4"
 dependencies = [
  "base64 0.22.1",
  "bytemuck",
@@ -8018,7 +8669,27 @@ dependencies = [
  "solana-curve25519",
  "solana-program",
  "solana-zk-sdk",
- "spl-pod 0.5.0",
+ "spl-pod",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "spl-token-confidential-transfer-proof-extraction"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe2629860ff04c17bafa9ba4bed8850a404ecac81074113e1f840dbd0ebb7bd6"
+dependencies = [
+ "bytemuck",
+ "solana-account-info",
+ "solana-curve25519",
+ "solana-instruction",
+ "solana-instructions-sysvar",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-zk-sdk",
+ "spl-pod",
  "thiserror 2.0.12",
 ]
 
@@ -8034,16 +8705,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-token-group-interface"
-version = "0.3.0"
+name = "spl-token-confidential-transfer-proof-generation"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8752b85a5ecc1d9f3a43bce3dd9a6a053673aacf5deb513d1cbb88d3534ffd"
+checksum = "ae5b124840d4aed474cef101d946a798b806b46a509ee4df91021e1ab1cef3ef"
 dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.3.0",
- "spl-pod 0.3.1",
- "spl-program-error 0.5.0",
+ "curve25519-dalek 4.1.3",
+ "solana-zk-sdk",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8060,23 +8729,28 @@ dependencies = [
  "solana-msg",
  "solana-program-error",
  "solana-pubkey",
- "spl-discriminator 0.4.1",
- "spl-pod 0.5.0",
+ "spl-discriminator",
+ "spl-pod",
  "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "spl-token-metadata-interface"
-version = "0.4.0"
+name = "spl-token-group-interface"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c2318ddff97e006ed9b1291ebec0750a78547f870f62a69c56fe3b46a5d8fc"
+checksum = "5597b4cd76f85ce7cd206045b7dc22da8c25516573d42d267c8d1fd128db5129"
 dependencies = [
- "borsh 1.5.7",
- "solana-program",
- "spl-discriminator 0.3.0",
- "spl-pod 0.3.1",
- "spl-program-error 0.5.0",
- "spl-type-length-value 0.5.0",
+ "bytemuck",
+ "num-derive 0.4.2",
+ "num-traits",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey",
+ "spl-discriminator",
+ "spl-pod",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8094,26 +8768,31 @@ dependencies = [
  "solana-msg",
  "solana-program-error",
  "solana-pubkey",
- "spl-discriminator 0.4.1",
- "spl-pod 0.5.0",
+ "spl-discriminator",
+ "spl-pod",
  "spl-type-length-value 0.7.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "spl-transfer-hook-interface"
+name = "spl-token-metadata-interface"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a110f33d941275d9f868b96daaa993f1e73b6806cc8836e43075b4d3ad8338a7"
+checksum = "304d6e06f0de0c13a621464b1fd5d4b1bebf60d15ca71a44d3839958e0da16ee"
 dependencies = [
- "arrayref",
- "bytemuck",
- "solana-program",
- "spl-discriminator 0.3.0",
- "spl-pod 0.3.1",
- "spl-program-error 0.5.0",
- "spl-tlv-account-resolution 0.7.0",
- "spl-type-length-value 0.5.0",
+ "borsh 1.5.7",
+ "num-derive 0.4.2",
+ "num-traits",
+ "solana-borsh",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-type-length-value 0.8.0",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8133,8 +8812,8 @@ dependencies = [
  "solana-msg",
  "solana-program-error",
  "solana-pubkey",
- "spl-discriminator 0.4.1",
- "spl-pod 0.5.0",
+ "spl-discriminator",
+ "spl-pod",
  "spl-program-error 0.6.0",
  "spl-tlv-account-resolution 0.9.0",
  "spl-type-length-value 0.7.0",
@@ -8142,16 +8821,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-type-length-value"
-version = "0.5.0"
+name = "spl-transfer-hook-interface"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdcd73ec187bc409464c60759232e309f83b52a18a9c5610bf281c9c6432918c"
+checksum = "a7e905b849b6aba63bde8c4badac944ebb6c8e6e14817029cbe1bc16829133bd"
 dependencies = [
+ "arrayref",
  "bytemuck",
- "solana-program",
- "spl-discriminator 0.3.0",
- "spl-pod 0.3.1",
- "spl-program-error 0.5.0",
+ "num-derive 0.4.2",
+ "num-traits",
+ "solana-account-info",
+ "solana-cpi",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error 0.7.0",
+ "spl-tlv-account-resolution 0.10.0",
+ "spl-type-length-value 0.8.0",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8167,9 +8858,27 @@ dependencies = [
  "solana-decode-error",
  "solana-msg",
  "solana-program-error",
- "spl-discriminator 0.4.1",
- "spl-pod 0.5.0",
+ "spl-discriminator",
+ "spl-pod",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-type-length-value"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d417eb548214fa822d93f84444024b4e57c13ed6719d4dcc68eec24fb481e9f5"
+dependencies = [
+ "bytemuck",
+ "num-derive 0.4.2",
+ "num-traits",
+ "solana-account-info",
+ "solana-decode-error",
+ "solana-msg",
+ "solana-program-error",
+ "spl-discriminator",
+ "spl-pod",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8198,33 +8907,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-dependencies = [
- "strum_macros 0.24.3",
-]
-
-[[package]]
-name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
+ "strum_macros",
 ]
 
 [[package]]
@@ -8245,12 +8932,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "symlink"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -8279,6 +8960,15 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -8331,26 +9021,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "tar"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
-name = "task-local-extensions"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
-dependencies = [
- "pin-utils",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8371,12 +9041,6 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "termtree"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "textwrap"
@@ -8577,6 +9241,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+dependencies = [
+ "rustls 0.23.27",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8597,7 +9271,7 @@ dependencies = [
  "log",
  "rustls 0.21.12",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tungstenite",
  "webpki-roots 0.25.4",
 ]
@@ -8690,6 +9364,39 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -8855,12 +9562,6 @@ dependencies = [
  "hex",
  "static_assertions",
 ]
-
-[[package]]
-name = "unicase"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-bidi"
@@ -9157,7 +9858,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pin-project",
- "reqwest",
+ "reqwest 0.11.27",
  "rlp",
  "secp256k1",
  "serde",
@@ -9215,6 +9916,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "wide"
@@ -9598,16 +10308,6 @@ dependencies = [
  "rusticata-macros",
  "thiserror 1.0.69",
  "time",
-]
-
-[[package]]
-name = "xattr"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
-dependencies = [
- "libc",
- "rustix",
 ]
 
 [[package]]

--- a/evm_loader/Cargo.toml
+++ b/evm_loader/Cargo.toml
@@ -13,26 +13,27 @@ members = [
 ]
 
 [workspace.dependencies]
-solana-clap-utils = "=2.1.21"
-solana-cli = "=2.1.21"
-solana-cli-config = "=2.1.21"
-solana-client = "=2.1.21"
-solana-account = "=2.1.21"
-solana-account-decoder = "=2.1.21"
-solana-program = { version = "=2.1.21", default-features = false }
-solana-bn254 = "=2.1.21"
-solana-sdk = "=2.1.21"
-solana-compute-budget-interface = "0.0.2"
-solana-program-runtime = "=2.1.21"
-solana-runtime = { version = "=2.1.21", features = ["dev-context-only-utils"] }
-solana-accounts-db = { version = "=2.1.21", default-features = false }
-solana-bpf-loader-program = "=2.1.21"
-solana-loader-v4-program = "=2.1.21"
-solana-transaction-status = "=2.1.21"
-solana-compute-budget = "=2.1.21"
-solana-log-collector = "=2.1.21"
-solana-timings = "=2.1.21"
-solana-svm = "=2.1.21"
+agave-feature-set = "=2.3.1"
+agave-reserved-account-keys = "=2.3.1"
+solana-clap-utils = "=2.3.1"
+solana-cli = "=2.3.1"
+solana-cli-config = "=2.3.1"
+solana-client = "=2.3.1"
+solana-sdk = "=2.3.1"
+solana-account-decoder = "=2.3.1"
+solana-compute-budget = "=2.3.1"
+solana-log-collector = "=2.3.1"
+
+solana-program = { version = "=2.3.0", default-features = false }
+solana-sdk-ids = "=2.2.1"
+solana-account = "=2.2.1"
+solana-bn254 = "=2.2.2"
+
+solana-address-lookup-table-interface = "2.2.2"
+solana-compute-budget-interface = "2.2.2"
+solana-system-interface = "1.0.0"
+solana-loader-v3-interface = "5.0.0"
+
 spl-associated-token-account = { version = "6.0", default-features = false, features = ["no-entrypoint"] }
 spl-token = { version = "7.0", default-features = false, features = ["no-entrypoint"] }
 ethnum = { version = "=1.5.0", default-features = false, features = ["serde"] }

--- a/evm_loader/Cargo.toml
+++ b/evm_loader/Cargo.toml
@@ -33,6 +33,8 @@ solana-address-lookup-table-interface = "2.2.2"
 solana-compute-budget-interface = "2.2.2"
 solana-system-interface = "1.0.0"
 solana-loader-v3-interface = "5.0.0"
+spl-token-interface = "1.0.0"
+spl-associated-token-account-interface = "1.0.0"
 
 spl-associated-token-account = { version = "6.0", default-features = false, features = ["no-entrypoint"] }
 spl-token = { version = "7.0", default-features = false, features = ["no-entrypoint"] }

--- a/evm_loader/lib/Cargo.toml
+++ b/evm_loader/lib/Cargo.toml
@@ -27,8 +27,8 @@ solana-account-decoder.workspace = true
 solana-system-interface.workspace = true
 solana-loader-v3-interface.workspace = true
 solana-address-lookup-table-interface.workspace = true
-spl-token.workspace = true
-spl-associated-token-account.workspace = true
+spl-token-interface.workspace = true
+spl-associated-token-account-interface.workspace = true
 bs58 = "0.5.1"
 base64 = "0.22"
 hex = { version = "0.4", features = ["serde"] }
@@ -58,6 +58,7 @@ elsa = "1.10.0"
 arrayref = "0.3.8"
 futures = "0.3.30"
 once_cell = "1.19.0"
+num-traits = "0.2"
 
 [dev-dependencies]
 hex-literal = "0.4.1"

--- a/evm_loader/lib/Cargo.toml
+++ b/evm_loader/lib/Cargo.toml
@@ -13,21 +13,20 @@ hyper = "0.14"
 evm-loader = { path = "../program", default-features = false, features = ["log", "async-trait"] }
 tracerdb-api= { path = "../tracerdb-api" }
 jsonrpsee = { version = "0.20", features = ["server", "ws-client", "macros"] }
+mollusk-svm = { version = "0.4.1" }
+agave-feature-set.workspace = true
+agave-reserved-account-keys.workspace = true
 solana-sdk.workspace = true
+solana-sdk-ids.workspace = true
 solana-client.workspace = true
-solana-account-decoder.workspace = true
 solana-cli-config.workspace = true
 solana-cli.workspace = true
-solana-program-runtime.workspace = true
-solana-runtime.workspace = true
-solana-accounts-db.workspace = true
-solana-bpf-loader-program.workspace = true
-solana-loader-v4-program.workspace = true
-solana-transaction-status.workspace = true
-solana-compute-budget.workspace = true
 solana-log-collector.workspace = true
-solana-timings.workspace = true
-solana-svm.workspace = true
+solana-compute-budget.workspace = true
+solana-account-decoder.workspace = true
+solana-system-interface.workspace = true
+solana-loader-v3-interface.workspace = true
+solana-address-lookup-table-interface.workspace = true
 spl-token.workspace = true
 spl-associated-token-account.workspace = true
 bs58 = "0.5.1"

--- a/evm_loader/lib/src/account_data.rs
+++ b/evm_loader/lib/src/account_data.rs
@@ -1,13 +1,14 @@
 use std::fmt;
 
 use solana_sdk::account_info::IntoAccountInfo;
+use solana_sdk::debug_account_data::debug_account_data;
 use solana_sdk::entrypoint::MAX_PERMITTED_DATA_INCREASE;
 use solana_sdk::{
     account::{Account, ReadableAccount},
     account_info::AccountInfo,
     pubkey::Pubkey,
 };
-use solana_sdk::{debug_account_data::debug_account_data, system_program};
+use solana_sdk_ids::system_program;
 
 use serde::{Deserialize, Serialize};
 use serde_with::hex::Hex;
@@ -194,7 +195,7 @@ mod tests {
         {
             let account_info = (&mut account_data).into_account_info();
             assert_eq!(account_info.try_data_len().unwrap(), 0);
-            account_info.realloc(new_size - 1, false).unwrap();
+            account_info.resize(new_size - 1).unwrap();
             account_info.assign(&new_owner);
         }
 
@@ -203,9 +204,9 @@ mod tests {
         {
             let account_info = (&mut account_data).into_account_info();
             assert_eq!(account_info.try_data_len().unwrap(), new_size - 1);
-            assert_eq!(account_info.realloc(new_size, false), Ok(()));
+            assert_eq!(account_info.resize(new_size), Ok(()));
             assert_eq!(
-                account_info.realloc(new_size + 1, false),
+                account_info.resize(new_size + 1),
                 Err(solana_sdk::program_error::ProgramError::InvalidRealloc)
             );
             let mut lamports = account_info.try_borrow_mut_lamports().unwrap();
@@ -218,7 +219,7 @@ mod tests {
 
         {
             let account_info = (&mut account_data).into_account_info();
-            account_info.realloc(0, false).unwrap();
+            account_info.resize(0).unwrap();
             account_info.assign(&Pubkey::default());
         }
         assert_eq!(account_data.get_length(), 0);

--- a/evm_loader/lib/src/commands/collect_treasury.rs
+++ b/evm_loader/lib/src/commands/collect_treasury.rs
@@ -12,7 +12,7 @@ use solana_sdk::{
     transaction::Transaction,
 };
 use solana_sdk_ids::system_program;
-use spl_token::instruction::sync_native;
+use spl_token_interface::instruction::sync_native;
 use std::ops::Deref;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -84,7 +84,10 @@ pub async fn execute(
         }
     }
     let mut message = Message::new(
-        &[sync_native(&spl_token::id(), &main_balance_address)?],
+        &[sync_native(
+            &spl_token_interface::id(),
+            &main_balance_address,
+        )?],
         Some(&signer.pubkey()),
     );
     let blockhash = rpc_client.get_latest_blockhash().await?;

--- a/evm_loader/lib/src/commands/collect_treasury.rs
+++ b/evm_loader/lib/src/commands/collect_treasury.rs
@@ -9,9 +9,9 @@ use solana_sdk::signature::Signer;
 use solana_sdk::{
     instruction::{AccountMeta, Instruction},
     message::Message,
-    system_program,
     transaction::Transaction,
 };
+use solana_sdk_ids::system_program;
 use spl_token::instruction::sync_native;
 use std::ops::Deref;
 

--- a/evm_loader/lib/src/commands/emulate.rs
+++ b/evm_loader/lib/src/commands/emulate.rs
@@ -251,7 +251,7 @@ async fn calculate_response(
     tracer: Option<impl Tracer>,
     provide_account_info: Option<AccountInfoLevel>,
 ) -> NeonResult<(EmulateResponse, Option<Value>)> {
-    debug!("Execute done, result={exit_status:?}");
+    debug!("Execute done, result={}", exit_status.status());
     debug!("{steps_executed} steps executed");
 
     let execute_status = platform.execute_status();

--- a/evm_loader/lib/src/commands/emulate_multiple.rs
+++ b/evm_loader/lib/src/commands/emulate_multiple.rs
@@ -4,12 +4,40 @@ use solana_sdk::pubkey::Pubkey;
 
 use crate::{
     config::DbConfig,
+    solana_simulator::instruction_error_to_string,
     tracing::tracers::TracerTypeEnum,
     types::{AccountInfoLevel, EmulateMultipleRequest, EmulateRequest, SerializedAccount},
     NeonResult,
 };
 
 use super::{emulate::EmulateResponse, get_config::BuildConfigSimulator};
+
+/// Executes Solana simulation and checks for errors in instruction execution results
+async fn simulate_preparatory_instructions(
+    rpc: &impl BuildConfigSimulator,
+    solana_tx: crate::types::SimulateSolanaRequest,
+) -> NeonResult<crate::solana_simulator::SolanaSimulator> {
+    let instructions = solana_tx.instructions.clone();
+
+    let (result, simulator) = super::simulate_solana::execute(rpc, solana_tx).await?;
+
+    let instructions = result
+        .instructions
+        .into_iter()
+        .zip(instructions.into_iter());
+
+    for (result, instruction) in instructions {
+        let Some(error) = result.error else {
+            continue; // Skip successful instructions
+        };
+
+        let error = instruction_error_to_string(instruction.program_id, error);
+        let error = evm_loader::error::Error::ExternalCallFailed(instruction.program_id, error);
+        return Err(error.into());
+    }
+
+    Ok(simulator)
+}
 
 pub async fn execute(
     rpc: &impl BuildConfigSimulator,
@@ -27,7 +55,7 @@ pub async fn execute(
 
     let mut overrides: HashMap<_, _> = request.accounts.into_iter().zip(accounts).collect();
 
-    let (_, simulator) = super::simulate_solana::execute(rpc, request.solana_tx).await?;
+    let simulator = simulate_preparatory_instructions(rpc, request.solana_tx).await?;
     for (key, account) in simulator.into_accounts() {
         overrides.insert(key, Some(account.into()));
     }

--- a/evm_loader/lib/src/commands/get_config.rs
+++ b/evm_loader/lib/src/commands/get_config.rs
@@ -169,7 +169,7 @@ impl ConfigInstructionSimulator for SolanaSimulator {
         &mut self,
         instruction: Instruction,
     ) -> NeonResult<Vec<String>> {
-        let (result, logs) = self.process_instruction(&instruction);
+        let (result, logs) = self.process_instruction(&instruction)?;
         if let Err(e) = result.raw_result {
             return Err(e.into());
         }

--- a/evm_loader/lib/src/commands/get_config.rs
+++ b/evm_loader/lib/src/commands/get_config.rs
@@ -13,7 +13,6 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 pub use solana_account_decoder::UiDataSliceConfig as SliceConfig;
 use solana_client::rpc_config::RpcSimulateTransactionConfig;
-use solana_sdk::signer::Signer;
 use solana_sdk::{instruction::Instruction, pubkey::Pubkey, transaction::Transaction};
 
 use crate::NeonResult;
@@ -170,17 +169,12 @@ impl ConfigInstructionSimulator for SolanaSimulator {
         &mut self,
         instruction: Instruction,
     ) -> NeonResult<Vec<String>> {
-        let payer_pubkey = self.payer().pubkey();
-
-        let mut transaction = Transaction::new_with_payer(&[instruction], Some(&payer_pubkey));
-        transaction.message.recent_blockhash = self.blockhash();
-
-        let r = self.process_legacy_transaction(transaction)?;
-        if let Err(e) = r.result {
+        let (result, logs) = self.process_instruction(&instruction);
+        if let Err(e) = result.raw_result {
             return Err(e.into());
         }
 
-        Ok(r.logs)
+        Ok(logs)
     }
 }
 

--- a/evm_loader/lib/src/commands/get_neon_elf.rs
+++ b/evm_loader/lib/src/commands/get_neon_elf.rs
@@ -1,10 +1,7 @@
 use anyhow::{Context as AContext, Result};
-use solana_sdk::{
-    account_utils::StateMut,
-    bpf_loader, bpf_loader_deprecated,
-    bpf_loader_upgradeable::{self, UpgradeableLoaderState},
-    pubkey::Pubkey,
-};
+use solana_loader_v3_interface::state::UpgradeableLoaderState;
+use solana_sdk::{account_utils::StateMut, bpf_loader, bpf_loader_deprecated, pubkey::Pubkey};
+use solana_sdk_ids::bpf_loader_upgradeable;
 use std::{collections::HashMap, convert::TryFrom, fs::File, io::Read};
 
 use crate::rpc::Rpc;

--- a/evm_loader/lib/src/commands/init_environment.rs
+++ b/evm_loader/lib/src/commands/init_environment.rs
@@ -31,8 +31,8 @@ use {
     },
     solana_sdk_ids::system_program,
     solana_system_interface::instruction as system_instruction,
-    spl_associated_token_account::get_associated_token_address,
-    spl_token::{self, native_mint},
+    spl_associated_token_account_interface::address::get_associated_token_address,
+    spl_token_interface::{self, native_mint},
     std::collections::HashMap,
     std::path::Path,
     thiserror::Error,
@@ -152,7 +152,7 @@ pub async fn execute(
         let mint_signer = keys
             .get(&mint)
             .ok_or(EnvironmentError::MissingPrivateKey(mint))?;
-        let data_len = spl_token::state::Mint::LEN;
+        let data_len = spl_token_interface::state::Mint::LEN;
         let lamports = client
             .get_minimum_balance_for_rent_exemption(data_len)
             .await?;
@@ -162,10 +162,10 @@ pub async fn execute(
                 &mint,
                 lamports,
                 data_len as u64,
-                &spl_token::id(),
+                &spl_token_interface::id(),
             ),
-            spl_token::instruction::initialize_mint2(
-                &spl_token::id(),
+            spl_token_interface::instruction::initialize_mint2(
+                &spl_token_interface::id(),
                 &mint,
                 &signer.pubkey(),
                 None,
@@ -184,7 +184,10 @@ pub async fn execute(
         .check_and_create_object(
             "NEON-token mint",
             executor
-                .get_account_data_pack::<spl_token::state::Mint>(&spl_token::id(), &neon_token_mint)
+                .get_account_data_pack::<spl_token_interface::state::Mint>(
+                    &spl_token_interface::id(),
+                    &neon_token_mint,
+                )
                 .await,
             |mint| async move {
                 if mint.decimals != neon_token_mint_decimals {
@@ -209,7 +212,10 @@ pub async fn execute(
             .check_and_create_object(
                 "Token pool account",
                 executor
-                    .get_account_data_pack::<spl_token::state::Account>(&spl_token::id(), &pool)
+                    .get_account_data_pack::<spl_token_interface::state::Account>(
+                        &spl_token_interface::id(),
+                        &pool,
+                    )
                     .await,
                 |account| async move {
                     if account.mint != chain.token || account.owner != deposit_authority {
@@ -221,11 +227,11 @@ pub async fn execute(
                 || async {
                     let transaction = executor
                     .create_transaction_with_payer_only(&[
-                        spl_associated_token_account::instruction::create_associated_token_account(
+                        spl_associated_token_account_interface::instruction::create_associated_token_account(
                             &executor.fee_payer.pubkey(),
                             &deposit_authority,
                             &chain.token,
-                            &spl_token::id(),
+                            &spl_token_interface::id(),
                         ),
                     ])
                     .await?;
@@ -263,7 +269,7 @@ pub async fn execute(
                                 AccountMeta::new(main_balance_address, false),
                                 AccountMeta::new_readonly(program_data_address, false),
                                 AccountMeta::new_readonly(signer.pubkey(), true),
-                                AccountMeta::new_readonly(spl_token::id(), false),
+                                AccountMeta::new_readonly(spl_token_interface::id(), false),
                                 AccountMeta::new_readonly(system_program::id(), false),
                                 AccountMeta::new_readonly(native_mint::id(), false),
                                 AccountMeta::new(executor.fee_payer.pubkey(), true),

--- a/evm_loader/lib/src/commands/init_environment.rs
+++ b/evm_loader/lib/src/commands/init_environment.rs
@@ -21,15 +21,16 @@ use {
         config::TREASURY_POOL_SEED,
     },
     log::{error, info, warn},
+    solana_loader_v3_interface::get_program_data_address,
     solana_sdk::{
-        bpf_loader_upgradeable,
         instruction::{AccountMeta, Instruction},
         program_pack::Pack,
         pubkey::Pubkey,
         signer::keypair::{read_keypair_file, Keypair},
         signer::Signer,
-        system_instruction, system_program,
     },
+    solana_sdk_ids::system_program,
+    solana_system_interface::instruction as system_instruction,
     spl_associated_token_account::get_associated_token_address,
     spl_token::{self, native_mint},
     std::collections::HashMap,
@@ -124,7 +125,7 @@ pub async fn execute(
     let executor = Rc::new(TransactionExecutor::new(client, fee_payer, send_trx));
     let keys = keys_dir.map_or(Ok(HashMap::new()), read_keys_dir)?;
 
-    let program_data_address = bpf_loader_upgradeable::get_program_data_address(&config.evm_loader);
+    let program_data_address = get_program_data_address(&config.evm_loader);
     let (program_upgrade_authority, program_data) =
         read_program_data_from_account(config, client, &config.evm_loader).await?;
     let data = file.map_or(Ok(program_data), read_program_data)?;

--- a/evm_loader/lib/src/commands/simulate_solana.rs
+++ b/evm_loader/lib/src/commands/simulate_solana.rs
@@ -1,27 +1,25 @@
 use crate::{
-    rpc::Rpc,
+    rpc::{CachedRpc, Rpc},
     solana_simulator::{SolanaSimulator, SyncState},
     types::SimulateSolanaRequest,
     NeonResult,
 };
-use bincode::Options;
-use log::info;
+
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use solana_compute_budget::compute_budget::ComputeBudget;
-use solana_runtime::runtime_config::RuntimeConfig;
 use solana_sdk::{
     account::Account,
+    instruction::{Instruction, InstructionError},
     pubkey::Pubkey,
-    transaction::{SanitizedTransaction, Transaction, VersionedTransaction},
 };
-use solana_transaction_status::EncodableWithMeta;
+use solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable, loader_v4, native_loader};
 use std::collections::HashSet;
 
 #[serde_as]
 #[derive(Deserialize, Serialize, Debug, Default)]
-pub struct SimulateSolanaTransactionResult {
-    pub error: Option<solana_sdk::transaction::TransactionError>,
+pub struct SimulateSolanaResult {
+    pub error: Option<InstructionError>,
     pub logs: Vec<String>,
     pub executed_units: u64,
 }
@@ -29,63 +27,55 @@ pub struct SimulateSolanaTransactionResult {
 #[serde_as]
 #[derive(Deserialize, Serialize, Debug, Default)]
 pub struct SimulateSolanaResponse {
-    transactions: Vec<SimulateSolanaTransactionResult>,
+    instructions: Vec<SimulateSolanaResult>,
 }
 
-fn decode_transaction(data: &[u8]) -> NeonResult<VersionedTransaction> {
-    let tx_result = bincode::options()
-        .with_fixint_encoding()
-        .allow_trailing_bytes()
-        .deserialize::<VersionedTransaction>(data);
-
-    if let Ok(tx) = tx_result {
-        return Ok(tx);
+fn account_keys(instructions: &[Instruction]) -> HashSet<Pubkey> {
+    let mut pubkeys: HashSet<Pubkey> = HashSet::<Pubkey>::new();
+    for instruction in instructions {
+        let accounts = instruction.accounts.iter().map(|a| a.pubkey);
+        pubkeys.extend(accounts);
     }
 
-    let tx = bincode::options()
-        .with_fixint_encoding()
-        .allow_trailing_bytes()
-        .deserialize::<Transaction>(data)?;
-
-    Ok(tx.into())
+    pubkeys
 }
 
-fn address_table_lookups(txs: &[VersionedTransaction]) -> Vec<Pubkey> {
-    let mut accounts: HashSet<Pubkey> = HashSet::<Pubkey>::new();
-    for tx in txs {
-        let Some(address_table_lookups) = tx.message.address_table_lookups() else {
-            continue;
-        };
+fn compute_budget(request: &SimulateSolanaRequest) -> ComputeBudget {
+    let compute_unit_limit = request.compute_units.unwrap_or(1_400_000);
+    let heap_size = request.heap_size.unwrap_or(256 * 1024);
 
-        for alt in address_table_lookups {
-            accounts.insert(alt.account_key);
+    ComputeBudget {
+        compute_unit_limit,
+        heap_size,
+        ..Default::default()
+    }
+}
+
+fn override_accounts(
+    simulator: &mut SolanaSimulator,
+    solana_keys: &mut HashSet<Pubkey>,
+    request: &SimulateSolanaRequest,
+) {
+    if let Some(program_overrides) = &request.programs_overrides {
+        for (pubkey, program) in program_overrides {
+            solana_keys.remove(pubkey);
+            simulator.add_program(pubkey, &program.elf, &program.loader);
         }
     }
 
-    accounts.into_iter().collect()
-}
+    if let Some(account_overrides) = &request.accounts_overrides {
+        for (pubkey, account) in account_overrides {
+            if bpf_loader::check_id(&account.owner)
+                || bpf_loader_upgradeable::check_id(&account.owner)
+                || loader_v4::check_id(&account.owner)
+                || native_loader::check_id(&account.owner)
+            {
+                continue; // Use `program_overrides` for executable accounts
+            }
 
-fn account_keys(txs: &[SanitizedTransaction]) -> Vec<Pubkey> {
-    let mut accounts: HashSet<Pubkey> = HashSet::<Pubkey>::new();
-    for tx in txs {
-        let keys = tx.message().account_keys();
-        accounts.extend(keys.iter());
-    }
-
-    accounts.into_iter().collect()
-}
-
-fn runtime_config(request: &SimulateSolanaRequest) -> RuntimeConfig {
-    let compute_units = request.compute_units.unwrap_or(1_400_000);
-    let heap_size = request.heap_size.unwrap_or(256 * 1024);
-
-    let mut compute_budget = ComputeBudget::new(compute_units);
-    compute_budget.heap_size = heap_size;
-
-    RuntimeConfig {
-        compute_budget: Some(compute_budget),
-        log_messages_bytes_limit: Some(100 * 1024),
-        transaction_account_lock_limit: request.account_limit,
+            solana_keys.remove(pubkey);
+            simulator.add_account(pubkey, Account::from(account));
+        }
     }
 }
 
@@ -93,70 +83,44 @@ pub async fn execute(
     rpc: &impl Rpc,
     request: SimulateSolanaRequest,
 ) -> NeonResult<(SimulateSolanaResponse, SolanaSimulator)> {
-    let verify = request.verify.unwrap_or(true);
-    let config = runtime_config(&request);
+    let rpc = CachedRpc::new(rpc);
 
-    let mut simulator = SolanaSimulator::new_with_config(rpc, config, SyncState::Yes).await?;
+    let budget = compute_budget(&request);
 
-    // Decode transactions from bytes
-    let mut transactions: Vec<VersionedTransaction> = vec![];
-    for data in request.transactions {
-        let tx = decode_transaction(&data)?;
-        info!(
-            "Encoded transaction: {}",
-            serde_json::to_string(&tx.json_encode()).unwrap()
-        );
-        transactions.push(tx);
-    }
+    let mut simulator = SolanaSimulator::new_with_config(&rpc, budget, SyncState::Yes).await?;
 
-    // Download ALT
-    let alt = address_table_lookups(&transactions);
-    simulator.sync_accounts(rpc, &alt).await?;
-
-    // Sanitize transactions (verify tx and decode ALT)
-    let mut sanitized_transactions: Vec<SanitizedTransaction> = vec![];
-    for tx in transactions {
-        let sanitized = simulator.sanitize_transaction(tx, verify)?;
-        sanitized_transactions.push(sanitized);
+    // Decode instruction
+    let mut instructions: Vec<Instruction> = vec![];
+    for serialized in request.instructions.iter().cloned() {
+        let instruction = serialized.into();
+        instructions.push(instruction);
     }
 
     // Take keys for accounts that should be downloaded from Solana
-    let mut solana_keys = account_keys(&sanitized_transactions);
+    let mut solana_keys: HashSet<Pubkey> = account_keys(&instructions);
 
     // Take override accounts from request, if set
-    if let Some(solana_overrides) = request.solana_overrides {
-        let mut override_accounts: Vec<(&Pubkey, Account)> = vec![];
-        for (pubkey, account) in &solana_overrides {
-            if let Some(account) = account {
-                // don't retrieve override accounts from Solana
-                solana_keys.retain(|pk| pk != pubkey);
-                override_accounts.push((pubkey, Account::from(account)));
-            }
-        }
-        let storable_accounts: Vec<_> = override_accounts
-            .iter()
-            .map(|(pubkey, account)| (*pubkey, account))
-            .collect();
-        simulator.set_multiple_accounts(&storable_accounts);
-    }
+    override_accounts(&mut simulator, &mut solana_keys, &request);
 
     // Download accounts from Solana
-    simulator.sync_accounts(rpc, &solana_keys).await?;
+    let solana_keys: Vec<Pubkey> = solana_keys.into_iter().collect();
+    simulator.sync_accounts(&rpc, &solana_keys).await?;
 
-    // Process transactions
+    // Process instructions
     let mut results = Vec::new();
-    for tx in sanitized_transactions {
-        let r = simulator.process_transaction(request.blockhash.into(), &tx)?;
-        results.push(SimulateSolanaTransactionResult {
-            error: r.result.err(),
-            logs: r.logs,
-            executed_units: r.units_consumed,
+    for instruction in instructions {
+        let (r, logs) = simulator.process_instruction(&instruction);
+
+        results.push(SimulateSolanaResult {
+            error: r.raw_result.err(),
+            executed_units: r.compute_units_consumed,
+            logs,
         });
     }
 
     Ok((
         SimulateSolanaResponse {
-            transactions: results,
+            instructions: results,
         },
         simulator,
     ))

--- a/evm_loader/lib/src/commands/simulate_solana.rs
+++ b/evm_loader/lib/src/commands/simulate_solana.rs
@@ -27,7 +27,7 @@ pub struct SimulateSolanaResult {
 #[serde_as]
 #[derive(Deserialize, Serialize, Debug, Default)]
 pub struct SimulateSolanaResponse {
-    instructions: Vec<SimulateSolanaResult>,
+    pub instructions: Vec<SimulateSolanaResult>,
 }
 
 fn account_keys(instructions: &[Instruction]) -> HashSet<Pubkey> {

--- a/evm_loader/lib/src/commands/simulate_solana.rs
+++ b/evm_loader/lib/src/commands/simulate_solana.rs
@@ -33,6 +33,8 @@ pub struct SimulateSolanaResponse {
 fn account_keys(instructions: &[Instruction]) -> HashSet<Pubkey> {
     let mut pubkeys: HashSet<Pubkey> = HashSet::<Pubkey>::new();
     for instruction in instructions {
+        pubkeys.insert(instruction.program_id);
+
         let accounts = instruction.accounts.iter().map(|a| a.pubkey);
         pubkeys.extend(accounts);
     }
@@ -109,7 +111,7 @@ pub async fn execute(
     // Process instructions
     let mut results = Vec::new();
     for instruction in instructions {
-        let (r, logs) = simulator.process_instruction(&instruction);
+        let (r, logs) = simulator.process_instruction(&instruction)?;
 
         results.push(SimulateSolanaResult {
             error: r.raw_result.err(),

--- a/evm_loader/lib/src/deactivated_features_tests.rs
+++ b/evm_loader/lib/src/deactivated_features_tests.rs
@@ -7,7 +7,6 @@ mod deactivated_features_tests {
     use solana_sdk::{
         account::{Account, AccountSharedData},
         feature::Feature,
-        feature_set,
         pubkey::Pubkey,
     };
 
@@ -25,7 +24,7 @@ mod deactivated_features_tests {
 
     impl Default for RpcMockFeatures {
         fn default() -> Self {
-            let accounts: Vec<_> = feature_set::FEATURE_NAMES.keys().copied().collect();
+            let accounts: Vec<_> = agave_feature_set::FEATURE_NAMES.keys().copied().collect();
 
             let mut features = HashMap::<Pubkey, Option<u64>>::new();
 

--- a/evm_loader/lib/src/emulator_platform.rs
+++ b/evm_loader/lib/src/emulator_platform.rs
@@ -14,13 +14,9 @@ use evm_loader::{
 use solana_account_decoder::UiDataSliceConfig;
 use solana_sdk::account::Account as SolanaSdkAccount;
 use solana_sdk::clock::Clock;
-use solana_sdk::message::Message;
 use solana_sdk::program_error::ProgramError;
 use solana_sdk::rent::Rent;
-use solana_sdk::signer::Signer;
-use solana_sdk::system_program;
 use solana_sdk::sysvar::SysvarId;
-use solana_sdk::transaction::Transaction;
 use solana_sdk::transaction_context::TransactionReturnData;
 use solana_sdk::{instruction::Instruction, pubkey::Pubkey, sysvar::Sysvar};
 
@@ -39,7 +35,7 @@ const fn fake_operator_account() -> SolanaSdkAccount {
     SolanaSdkAccount {
         lamports: 100 * 1_000_000_000,
         data: vec![],
-        owner: system_program::ID,
+        owner: solana_sdk_ids::system_program::ID,
         executable: false,
         rent_epoch: u64::MAX,
     }
@@ -389,10 +385,6 @@ impl<'a, R: Rpc> Platform<'a> for EmulatorPlatform<R> {
 
         // Add accounts to the current stack frame
         self.add_accounts_to_stack(&accounts).await?;
-        for meta in instruction.accounts.iter().filter(|m| m.is_writable) {
-            let account = self.shared_account(meta.pubkey).await?;
-            account.mark_modified();
-        }
 
         // Sync accounts with the simulator
         simulator
@@ -401,30 +393,26 @@ impl<'a, R: Rpc> Platform<'a> for EmulatorPlatform<R> {
             .map_err(|e| Error::Custom(e.to_string()))?;
 
         // Execute the instruction
-        let trx = Transaction::new_unsigned(Message::new(
-            &[instruction],
-            Some(&simulator.payer().pubkey()),
-        ));
+        let (simulation_result, _) = simulator.process_instruction(&instruction);
 
-        let simulation_result = simulator
-            .process_legacy_transaction(trx)
-            .map_err(|e| Error::Custom(e.to_string()))?;
+        self.return_data = Some(TransactionReturnData {
+            program_id: target_program_id,
+            data: simulation_result.return_data,
+        });
 
-        self.return_data = simulation_result.return_data;
-
-        if let Err(error) = simulation_result.result {
+        if let Err(error) = simulation_result.raw_result {
             let message = error.to_string();
             return Err(Error::ExternalCallFailed(target_program_id, message));
         }
 
         // Update modified accounts
         let mut stack = self.current_stack_frame();
-        for (key, account_data) in simulation_result.post_simulation_accounts {
-            let Some(shared_account) = stack.get_mut(&key) else {
-                continue;
-            };
+        for meta in instruction.accounts.iter().filter(|m| m.is_writable) {
+            let account_data = simulator.get_account(&meta.pubkey);
 
+            let shared_account = stack.get_mut(&meta.pubkey).unwrap();
             shared_account.update(&account_data);
+            shared_account.mark_modified();
         }
 
         Ok(())

--- a/evm_loader/lib/src/emulator_platform.rs
+++ b/evm_loader/lib/src/emulator_platform.rs
@@ -284,8 +284,10 @@ impl<R: Rpc> EmulatorPlatform<R> {
             Error::Custom(emulator_error.to_string())
         })?;
 
+        let accounts = pubkeys.iter().copied().zip(accounts.into_iter());
+
         let mut stack = self.current_stack_frame();
-        for (key, account) in pubkeys.iter().copied().zip(accounts.into_iter()) {
+        for (key, account) in accounts {
             stack.entry(key).or_insert_with(|| {
                 account.map_or_else(
                     || SharedAccount::new_empty(key),
@@ -377,17 +379,24 @@ impl<'a, R: Rpc> Platform<'a> for EmulatorPlatform<R> {
             .map(|seed| Pubkey::create_program_address(seed, &self.program_id).unwrap())
             .collect();
 
-        let mut accounts = Vec::with_capacity(instruction.accounts.len() + 1);
-        accounts.push(target_program_id);
+        let mut accounts = HashSet::with_capacity(instruction.accounts.len() + 1); // Use HashSet to remove dupplicates
+        accounts.insert(target_program_id);
+
         for meta in &instruction.accounts {
             if meta.pubkey != FAKE_OPERATOR && meta.is_signer && !signers.contains(&meta.pubkey) {
                 return Err(ProgramError::MissingRequiredSignature.into());
             }
-            accounts.push(meta.pubkey);
+            accounts.insert(meta.pubkey);
         }
+
+        let accounts = accounts.into_iter().collect::<Vec<_>>();
 
         // Add accounts to the current stack frame
         self.add_accounts_to_stack(&accounts).await?;
+        for meta in instruction.accounts.iter().filter(|m| m.is_writable) {
+            let shared_account = self.account_from_stack(meta.pubkey).await?;
+            shared_account.mark_modified();
+        }
 
         // Sync accounts with the simulator
         simulator
@@ -417,7 +426,6 @@ impl<'a, R: Rpc> Platform<'a> for EmulatorPlatform<R> {
 
             let shared_account = stack.get_mut(&meta.pubkey).unwrap();
             shared_account.update(&account_data);
-            shared_account.mark_modified();
         }
 
         Ok(())

--- a/evm_loader/lib/src/emulator_platform.rs
+++ b/evm_loader/lib/src/emulator_platform.rs
@@ -393,7 +393,9 @@ impl<'a, R: Rpc> Platform<'a> for EmulatorPlatform<R> {
             .map_err(|e| Error::Custom(e.to_string()))?;
 
         // Execute the instruction
-        let (simulation_result, _) = simulator.process_instruction(&instruction);
+        let (simulation_result, _) = simulator
+            .process_instruction(&instruction)
+            .map_err(|e| Error::Custom(e.to_string()))?;
 
         self.return_data = Some(TransactionReturnData {
             program_id: target_program_id,

--- a/evm_loader/lib/src/emulator_platform.rs
+++ b/evm_loader/lib/src/emulator_platform.rs
@@ -27,7 +27,7 @@ use crate::account_data::AccountData;
 use crate::commands::emulate::SolanaAccount;
 use crate::commands::get_config::ChainInfo;
 use crate::rpc::{CachedRpc, Rpc};
-use crate::solana_simulator::SolanaSimulator;
+use crate::solana_simulator::{instruction_error_to_string, SolanaSimulator};
 use crate::sysvar::get_sysvar;
 use crate::tracing::{AccountOverride, BlockOverrides};
 use crate::types::AccountInfoLevel;
@@ -406,7 +406,7 @@ impl<'a, R: Rpc> Platform<'a> for EmulatorPlatform<R> {
         });
 
         if let Err(error) = simulation_result.raw_result {
-            let message = error.to_string();
+            let message = instruction_error_to_string(target_program_id, error);
             return Err(Error::ExternalCallFailed(target_program_id, message));
         }
 

--- a/evm_loader/lib/src/emulator_platform.rs
+++ b/evm_loader/lib/src/emulator_platform.rs
@@ -440,7 +440,7 @@ impl<'a, R: Rpc> Platform<'a> for EmulatorPlatform<R> {
         // Execute the instruction
         let (simulation_result, _) = simulator
             .process_instruction(&instruction)
-            .map_err(|e| Error::Custom(e.to_string()))?;
+            .map_err(|error| Error::Fatal(Box::new(error)))?;
 
         self.return_data = Some(TransactionReturnData {
             program_id: target_program_id,

--- a/evm_loader/lib/src/errors.rs
+++ b/evm_loader/lib/src/errors.rs
@@ -10,8 +10,10 @@ use neon_lib_interface::NeonEVMLibLoadError;
 use solana_cli::cli::CliError as SolanaCliError;
 use solana_client::client_error::ClientError as SolanaClientError;
 use solana_client::tpu_client::TpuSenderError as SolanaTpuSenderError;
+use solana_sdk::instruction::InstructionError;
 use solana_sdk::program_error::ProgramError as SolanaProgramError;
 use solana_sdk::pubkey::{Pubkey, PubkeyError as SolanaPubkeyError};
+use solana_sdk::sanitize::SanitizeError;
 use solana_sdk::signer::SignerError as SolanaSignerError;
 use solana_sdk::transaction::TransactionError;
 use thiserror::Error;
@@ -128,6 +130,10 @@ pub enum NeonError {
     RpcReturnedEmptyAccount(Pubkey),
     #[error("TryFromIntError {0}")]
     TryFromIntError(#[from] std::num::TryFromIntError),
+    #[error("Instruction Error. {0}")]
+    InstructionError(#[from] InstructionError),
+    #[error("Transction Sanitize Error. {0}")]
+    SanitizeError(#[from] SanitizeError),
 }
 
 impl NeonError {
@@ -177,6 +183,8 @@ impl NeonError {
             NeonError::RocksDb(_) => 266,
             NeonError::RpcReturnedEmptyAccount(_) => 267,
             NeonError::TryFromIntError(_) => 268,
+            NeonError::InstructionError(_) => 269,
+            NeonError::SanitizeError(_) => 270,
         }
     }
 }

--- a/evm_loader/lib/src/rpc/mod.rs
+++ b/evm_loader/lib/src/rpc/mod.rs
@@ -15,14 +15,14 @@ use async_trait::async_trait;
 
 use bincode::deserialize;
 use enum_dispatch::enum_dispatch;
-use evm_loader::solana_program::bpf_loader_upgradeable::UpgradeableLoaderState;
 pub use solana_account_decoder::UiDataSliceConfig as SliceConfig;
 use solana_cli::cli::CliError;
 use solana_client::client_error::{ClientErrorKind, Result as ClientResult};
+use solana_loader_v3_interface::state::UpgradeableLoaderState;
 use solana_sdk::{
-    account::Account, bpf_loader, bpf_loader_upgradeable, message::Message,
-    native_token::lamports_to_sol, pubkey::Pubkey,
+    account::Account, message::Message, native_token::lamports_to_sol, pubkey::Pubkey,
 };
+use solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable};
 use std::cmp::max;
 
 #[async_trait(?Send)]

--- a/evm_loader/lib/src/solana_simulator/error.rs
+++ b/evm_loader/lib/src/solana_simulator/error.rs
@@ -10,4 +10,6 @@ pub enum Error {
     SysvarError,
     #[error("Failed to extract ELF from account")]
     AccountIsNotProgram,
+    #[error("Account {0} is not supported for simulation")]
+    UnsupportedAccount(solana_sdk::pubkey::Pubkey),
 }

--- a/evm_loader/lib/src/solana_simulator/error.rs
+++ b/evm_loader/lib/src/solana_simulator/error.rs
@@ -1,23 +1,13 @@
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    // #[error("Unexpected response")]
-    // UnexpectedResponse,
     #[error("Program Account error")]
     ProgramAccountError,
     #[error("Rpc Client error {0:?}")]
     RpcClientError(#[from] solana_client::client_error::ClientError),
-    // #[error("IO error {0:?}")]
-    // IoError(#[from] std::io::Error),
     #[error("Bincode error {0:?}")]
     BincodeError(#[from] bincode::Error),
-    // #[error("TryFromIntError error {0:?}")]
-    // TryFromIntError(#[from] std::num::TryFromIntError),
-    #[error("Transaction error {0:?}")]
-    TransactionError(#[from] solana_sdk::transaction::TransactionError),
-    // #[error("Sanitize error {0:?}")]
-    // SanitizeError(#[from] solana_sdk::sanitize::SanitizeError),
-    #[error("Instruction error {0:?}")]
-    InstructionError(#[from] solana_sdk::instruction::InstructionError),
-    #[error("Invalid ALT")]
-    InvalidALT,
+    #[error("Failed to download sysvar accounts")]
+    SysvarError,
+    #[error("Failed to extract ELF from account")]
+    AccountIsNotProgram,
 }

--- a/evm_loader/lib/src/solana_simulator/mod.rs
+++ b/evm_loader/lib/src/solana_simulator/mod.rs
@@ -1,9 +1,13 @@
-use std::{cell::RefCell, collections::HashMap, rc::Rc};
+use std::{
+    cell::{Ref, RefCell},
+    collections::HashMap,
+    rc::Rc,
+};
 
 use mollusk_svm::{result::ContextResult, Mollusk, MolluskContext};
 use solana_compute_budget::compute_budget::ComputeBudget;
 use solana_log_collector::LogCollector;
-use solana_sdk::{account::Account, instruction::Instruction, pubkey::Pubkey};
+use solana_sdk::{account::Account, instruction::Instruction, native_loader, pubkey::Pubkey};
 pub use utils::SyncState;
 
 use crate::rpc::Rpc;
@@ -50,13 +54,11 @@ impl SolanaSimulator {
     }
 
     pub async fn sync_accounts(&mut self, rpc: &impl Rpc, keys: &[Pubkey]) -> Result<(), Error> {
-        let keys = utils::filter_reserved_accounts(keys);
-
-        let accounts = rpc.get_multiple_accounts(&keys).await?;
+        let accounts = rpc.get_multiple_accounts(keys).await?;
         for (pubkey, account) in keys.iter().zip(accounts.into_iter()) {
             let account = account.unwrap_or_default();
 
-            if account.executable {
+            if account.executable && !native_loader::check_id(&account.owner) {
                 let loader = account.owner;
                 let elf = utils::extract_elf(rpc, account).await?;
 
@@ -92,37 +94,81 @@ impl SolanaSimulator {
             .unwrap_or_default()
     }
 
+    #[must_use]
+    pub fn try_get_account(&self, pubkey: &Pubkey) -> Option<Ref<Account>> {
+        let store = self.mollusk_context.account_store.borrow();
+        Ref::filter_map(store, |s| s.get(pubkey)).ok()
+    }
+
     pub fn into_accounts(self) -> impl Iterator<Item = (Pubkey, Account)> {
         let store = Rc::into_inner(self.mollusk_context.account_store).unwrap();
         let store = RefCell::into_inner(store);
         store.into_iter()
     }
 
-    #[must_use]
+    fn is_account_allowed_in_instruction(&self, pubkey: &Pubkey) -> bool {
+        if solana_sdk_ids::system_program::check_id(pubkey) {
+            return true;
+        }
+
+        if solana_sdk_ids::bpf_loader::check_id(pubkey) {
+            return true;
+        }
+
+        if solana_sdk_ids::bpf_loader_upgradeable::check_id(pubkey) {
+            return true;
+        }
+
+        let Some(account) = self.try_get_account(pubkey) else {
+            return true;
+        };
+
+        account.owner != native_loader::ID
+    }
+
+    fn validate_instruction(&self, instruction: &Instruction) -> Result<(), Error> {
+        if !self.is_account_allowed_in_instruction(&instruction.program_id) {
+            return Err(Error::UnsupportedAccount(instruction.program_id));
+        }
+
+        for account in &instruction.accounts {
+            if !self.is_account_allowed_in_instruction(&account.pubkey) {
+                return Err(Error::UnsupportedAccount(account.pubkey));
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn process_instruction(
         &mut self,
         instruction: &Instruction,
-    ) -> (ContextResult, Vec<String>) {
+    ) -> Result<(ContextResult, Vec<String>), Error> {
+        self.validate_instruction(instruction)?;
+
         let log_collector = LogCollector::new_ref_with_limit(None);
         self.mollusk_context.mollusk.logger = Some(Rc::clone(&log_collector));
 
         let result = self.mollusk_context.process_instruction(instruction);
         let logs = log_collector.borrow().get_recorded_content().to_vec();
 
-        (result, logs)
+        Ok((result, logs))
     }
 
-    #[must_use]
     pub fn process_instruction_chain(
         &mut self,
         instructions: &[Instruction],
-    ) -> (ContextResult, Vec<String>) {
+    ) -> Result<(ContextResult, Vec<String>), Error> {
+        for instruction in instructions {
+            self.validate_instruction(instruction)?;
+        }
+
         let log_collector = LogCollector::new_ref_with_limit(None);
         self.mollusk_context.mollusk.logger = Some(Rc::clone(&log_collector));
 
         let result = self.mollusk_context.process_instruction_chain(instructions);
         let logs = log_collector.borrow().get_recorded_content().to_vec();
 
-        (result, logs)
+        Ok((result, logs))
     }
 }

--- a/evm_loader/lib/src/solana_simulator/mod.rs
+++ b/evm_loader/lib/src/solana_simulator/mod.rs
@@ -4,7 +4,14 @@ use std::{
     rc::Rc,
 };
 
-use mollusk_svm::{result::ContextResult, Mollusk, MolluskContext};
+use mollusk_svm::{
+    program::{
+        create_program_account_loader_v2, create_program_account_loader_v3,
+        create_program_data_account_loader_v3,
+    },
+    result::ContextResult,
+    Mollusk, MolluskContext,
+};
 use solana_compute_budget::compute_budget::ComputeBudget;
 use solana_log_collector::LogCollector;
 use solana_sdk::{account::Account, instruction::Instruction, native_loader, pubkey::Pubkey};
@@ -82,6 +89,21 @@ impl SolanaSimulator {
         self.mollusk_context
             .mollusk
             .add_program_with_elf_and_loader(pubkey, elf, loader);
+
+        if solana_sdk_ids::bpf_loader::check_id(loader) {
+            let account = create_program_account_loader_v2(elf);
+            self.add_account(pubkey, account);
+        }
+
+        if solana_sdk_ids::bpf_loader_upgradeable::check_id(loader) {
+            let program_account = create_program_account_loader_v3(pubkey);
+
+            let data_pubkey = solana_loader_v3_interface::get_program_data_address(pubkey);
+            let data_account = create_program_data_account_loader_v3(elf);
+
+            self.add_account(pubkey, program_account);
+            self.add_account(&data_pubkey, data_account);
+        }
     }
 
     #[must_use]

--- a/evm_loader/lib/src/solana_simulator/mod.rs
+++ b/evm_loader/lib/src/solana_simulator/mod.rs
@@ -4,12 +4,14 @@ use std::{
     rc::Rc,
 };
 
+use agave_feature_set::FeatureSet;
 use mollusk_svm::{
     program::{
         create_program_account_loader_v2, create_program_account_loader_v3,
-        create_program_data_account_loader_v3,
+        create_program_data_account_loader_v3, ProgramCache,
     },
     result::ContextResult,
+    sysvar::Sysvars,
     Mollusk, MolluskContext,
 };
 use solana_compute_budget::compute_budget::ComputeBudget;
@@ -44,15 +46,25 @@ impl SolanaSimulator {
         compute_budget: ComputeBudget,
         sync_state: SyncState,
     ) -> Result<Self, Error> {
-        let mut mollusk = Mollusk {
-            compute_budget,
-            ..Default::default()
+        let feature_set = if sync_state == SyncState::Yes {
+            utils::download_feature_set(rpc).await?
+        } else {
+            FeatureSet::all_enabled()
         };
 
-        if sync_state == SyncState::Yes {
-            mollusk.sysvars = utils::download_sysvar_accounts(rpc).await?;
-            mollusk.feature_set = utils::download_feature_set(rpc).await?;
-        }
+        let sysvars = if sync_state == SyncState::Yes {
+            utils::download_sysvar_accounts(rpc).await?
+        } else {
+            Sysvars::default()
+        };
+
+        let mollusk = Mollusk {
+            program_cache: ProgramCache::new(&feature_set, &compute_budget),
+            feature_set,
+            compute_budget,
+            sysvars,
+            ..Mollusk::default()
+        };
 
         let account_store = InMemoryAccountStore::default();
         Ok(Self {

--- a/evm_loader/lib/src/solana_simulator/mod.rs
+++ b/evm_loader/lib/src/solana_simulator/mod.rs
@@ -25,6 +25,7 @@ mod error;
 pub use error::Error;
 
 mod utils;
+pub use utils::instruction_error_to_string;
 
 type InMemoryAccountStore = HashMap<Pubkey, Account>;
 

--- a/evm_loader/lib/src/solana_simulator/mod.rs
+++ b/evm_loader/lib/src/solana_simulator/mod.rs
@@ -1,802 +1,128 @@
-use std::collections::{HashMap, HashSet};
-use std::rc::Rc;
-use std::sync::Arc;
+use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
-pub use error::Error;
-use evm_loader::solana_program::bpf_loader_upgradeable::UpgradeableLoaderState;
-use evm_loader::solana_program::clock::Slot;
-
-use evm_loader::solana_program::loader_v4;
-use evm_loader::solana_program::loader_v4::{LoaderV4State, LoaderV4Status};
-use evm_loader::solana_program::message::SanitizedMessage;
-use log::debug;
-use solana_bpf_loader_program::syscalls::{
-    create_program_runtime_environment_v1, create_program_runtime_environment_v2,
-};
+use mollusk_svm::{result::ContextResult, Mollusk, MolluskContext};
 use solana_compute_budget::compute_budget::ComputeBudget;
 use solana_log_collector::LogCollector;
-use solana_program_runtime::invoke_context::{EnvironmentConfig, InvokeContext};
-use solana_program_runtime::loaded_programs::{LoadProgramMetrics, ProgramRuntimeEnvironments};
-use solana_program_runtime::loaded_programs::{
-    ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType, ProgramCacheForTxBatch,
-};
-use solana_program_runtime::sysvar_cache::SysvarCache;
-use solana_runtime::bank::builtins::BUILTINS;
-use solana_runtime::{bank::TransactionSimulationResult, runtime_config::RuntimeConfig};
-use solana_sdk::account::{
-    create_account_shared_data_with_fields, AccountSharedData, ReadableAccount,
-    DUMMY_INHERITABLE_ACCOUNT_FIELDS, PROGRAM_OWNERS,
-};
-use solana_sdk::account_utils::StateMut;
-use solana_sdk::address_lookup_table::error::AddressLookupError;
-use solana_sdk::address_lookup_table::state::AddressLookupTable;
-use solana_sdk::clock::Clock;
-use solana_sdk::feature_set::FeatureSet;
-use solana_sdk::fee_calculator::DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE;
-use solana_sdk::inner_instruction::{InnerInstruction, InnerInstructionsList};
-use solana_sdk::instruction::{CompiledInstruction, TRANSACTION_LEVEL_STACK_HEIGHT};
-use solana_sdk::message::v0::{LoadedAddresses, MessageAddressTableLookup};
-use solana_sdk::message::{AddressLoader, AddressLoaderError};
-use solana_sdk::sysvar;
-use solana_sdk::sysvar::instructions::construct_instructions_data;
-use solana_svm::message_processor::MessageProcessor;
-
-use solana_sdk::rent::Rent;
-use solana_sdk::transaction::TransactionError;
-use solana_sdk::transaction_context::{ExecutionRecord, IndexOfAccount, TransactionContext};
-use solana_sdk::{
-    account::Account,
-    address_lookup_table, bpf_loader_upgradeable,
-    hash::Hash,
-    pubkey::Pubkey,
-    signature::Keypair,
-    sysvar::{Sysvar, SysvarId},
-    transaction::{SanitizedTransaction, VersionedTransaction},
-};
-use solana_timings::ExecuteTimings;
+use solana_sdk::{account::Account, instruction::Instruction, pubkey::Pubkey};
 pub use utils::SyncState;
 
 use crate::rpc::Rpc;
-use crate::types::programs_cache::programdata_cache_get_values_by_keys;
 
 mod error;
+pub use error::Error;
+
 mod utils;
 
+type InMemoryAccountStore = HashMap<Pubkey, Account>;
+
 pub struct SolanaSimulator {
-    runtime_config: RuntimeConfig,
-    feature_set: Arc<FeatureSet>,
-    accounts_db: HashMap<Pubkey, AccountSharedData>,
-    sysvar_cache: SysvarCache,
-    payer: Keypair,
+    mollusk_context: MolluskContext<InMemoryAccountStore>,
 }
 
 impl SolanaSimulator {
     pub async fn new(rpc: &impl Rpc) -> Result<Self, Error> {
-        Self::new_with_config(rpc, RuntimeConfig::default(), SyncState::Yes).await
+        Self::new_with_config(rpc, ComputeBudget::default(), SyncState::Yes).await
     }
 
     pub async fn new_without_sync(rpc: &impl Rpc) -> Result<Self, Error> {
-        Self::new_with_config(rpc, RuntimeConfig::default(), SyncState::No).await
+        Self::new_with_config(rpc, ComputeBudget::default(), SyncState::No).await
     }
 
     pub async fn new_with_config(
         rpc: &impl Rpc,
-        runtime_config: RuntimeConfig,
+        compute_budget: ComputeBudget,
         sync_state: SyncState,
     ) -> Result<Self, Error> {
-        let mut feature_set = FeatureSet::all_enabled();
+        let mut mollusk = Mollusk {
+            compute_budget,
+            ..Default::default()
+        };
 
         if sync_state == SyncState::Yes {
-            for feature in rpc.get_deactivated_solana_features().await? {
-                feature_set.deactivate(&feature);
-            }
+            mollusk.sysvars = utils::download_sysvar_accounts(rpc).await?;
+            mollusk.feature_set = utils::download_feature_set(rpc).await?;
         }
 
-        let mut sysvar_cache = SysvarCache::default();
-
-        sysvar_cache.fill_missing_entries(|pubkey, setter| match *pubkey {
-            sysvar::clock::ID => {
-                if let Ok(mut data) = bincode::serialize(&Clock::default()) {
-                    setter(data.as_mut());
-                }
-            }
-            sysvar::rent::ID => {
-                if let Ok(mut data) = bincode::serialize(&Rent::default()) {
-                    setter(data.as_mut());
-                }
-            }
-            _ => {}
-        });
-
-        if sync_state == SyncState::Yes {
-            utils::sync_sysvar_accounts(rpc, &mut sysvar_cache).await?;
-        }
-
+        let account_store = InMemoryAccountStore::default();
         Ok(Self {
-            runtime_config,
-            feature_set: Arc::new(feature_set),
-            accounts_db: HashMap::new(),
-            sysvar_cache,
-            payer: Keypair::new(),
+            mollusk_context: mollusk.with_context(account_store),
         })
     }
 
     pub async fn sync_accounts(&mut self, rpc: &impl Rpc, keys: &[Pubkey]) -> Result<(), Error> {
-        let mut storable_accounts: Vec<(&Pubkey, &Account)> = vec![];
+        let keys = utils::filter_reserved_accounts(keys);
 
-        let mut programdata_keys = vec![];
+        let accounts = rpc.get_multiple_accounts(&keys).await?;
+        for (pubkey, account) in keys.iter().zip(accounts.into_iter()) {
+            let account = account.unwrap_or_default();
 
-        let mut accounts = rpc.get_multiple_accounts(keys).await?;
-        for (key, account) in keys.iter().zip(&mut accounts) {
-            let Some(account) = account else {
-                continue;
-            };
-            if account.executable && bpf_loader_upgradeable::check_id(&account.owner) {
-                let programdata_address = utils::program_data_address(account)?;
-                debug!(
-                    "program_data_account: program={key} programdata=address{programdata_address}"
-                );
-                programdata_keys.push(programdata_address);
+            if account.executable {
+                let loader = account.owner;
+                let elf = utils::extract_elf(rpc, account).await?;
+
+                self.add_program(pubkey, &elf, &loader);
+            } else {
+                self.add_account(pubkey, account);
             }
-
-            if account.owner == address_lookup_table::program::id() {
-                utils::reset_alt_slot(account).map_err(|_| Error::InvalidALT)?;
-            }
-
-            storable_accounts.push((key, account));
         }
-
-        let mut programdata_accounts =
-            programdata_cache_get_values_by_keys(&programdata_keys, rpc).await?;
-
-        for (key, account) in programdata_keys.iter().zip(&mut programdata_accounts) {
-            let Some(account) = account else {
-                continue;
-            };
-
-            debug!("program_data_account: key={key} account={account:?}");
-            utils::reset_program_data_slot(account)?;
-            storable_accounts.push((key, account));
-        }
-
-        self.set_multiple_accounts(&storable_accounts);
 
         Ok(())
     }
 
-    #[must_use]
-    pub const fn payer(&self) -> &Keypair {
-        &self.payer
+    pub fn add_account(&mut self, pubkey: &Pubkey, account: Account) {
+        self.mollusk_context
+            .account_store
+            .borrow_mut()
+            .insert(*pubkey, account);
+    }
+
+    pub fn add_program(&mut self, pubkey: &Pubkey, elf: &[u8], loader: &Pubkey) {
+        self.mollusk_context
+            .mollusk
+            .add_program_with_elf_and_loader(pubkey, elf, loader);
     }
 
     #[must_use]
-    pub fn blockhash(&self) -> Hash {
-        Hash::new_unique()
+    pub fn get_account(&self, pubkey: &Pubkey) -> Account {
+        self.mollusk_context
+            .account_store
+            .borrow()
+            .get(pubkey)
+            .cloned()
+            .unwrap_or_default()
     }
 
-    pub fn slot(&self) -> Result<u64, Error> {
-        let clock = self.sysvar_cache.get_clock()?;
-        Ok(clock.slot)
-    }
-
-    fn replace_sysvar_account<S>(&mut self, sysvar: &S)
-    where
-        S: Sysvar + SysvarId,
-    {
-        let old_account = self.accounts_db.get(&S::id());
-        let inherit = old_account.map_or(DUMMY_INHERITABLE_ACCOUNT_FIELDS, |a| {
-            (a.lamports(), a.rent_epoch())
-        });
-
-        let account = create_account_shared_data_with_fields(sysvar, inherit);
-        self.accounts_db.insert(S::id(), account);
-    }
-
-    pub fn set_clock(&mut self, clock: &Clock) {
-        self.replace_sysvar_account(clock);
-        self.sysvar_cache.fill_missing_entries(|pubkey, setter| {
-            if *pubkey == sysvar::clock::ID {
-                if let Ok(mut data) = bincode::serialize(clock) {
-                    setter(data.as_mut());
-                }
-            }
-        });
-    }
-
-    pub fn set_multiple_accounts(&mut self, accounts: &[(&Pubkey, &Account)]) {
-        for (pubkey, account) in accounts {
-            self.accounts_db
-                .insert(**pubkey, AccountSharedData::from((*account).clone()));
-        }
+    pub fn into_accounts(self) -> impl Iterator<Item = (Pubkey, Account)> {
+        let store = Rc::into_inner(self.mollusk_context.account_store).unwrap();
+        let store = RefCell::into_inner(store);
+        store.into_iter()
     }
 
     #[must_use]
-    pub fn get_shared_account(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
-        self.accounts_db.get(pubkey).cloned()
-    }
-
-    pub fn into_accounts(self) -> impl Iterator<Item = (Pubkey, AccountSharedData)> {
-        self.accounts_db.into_iter()
-    }
-
-    pub fn sanitize_transaction(
-        &self,
-        tx: VersionedTransaction,
-        verify: bool,
-    ) -> Result<SanitizedTransaction, Error> {
-        let sanitized_tx = {
-            let size = bincode::serialized_size(&tx)?;
-            if verify && (size > solana_sdk::packet::PACKET_DATA_SIZE as u64) {
-                return Err(TransactionError::SanitizeFailure.into());
-            }
-
-            let message_hash = if verify {
-                tx.verify_and_hash_message()?
-            } else {
-                tx.message.hash()
-            };
-
-            SanitizedTransaction::try_create(tx, message_hash, None, self, &HashSet::default())
-        }?;
-
-        if verify {
-            sanitized_tx.verify_precompiles(&self.feature_set)?;
-        }
-
-        Ok(sanitized_tx)
-    }
-
-    pub fn process_transaction(
+    pub fn process_instruction(
         &mut self,
-        blockhash: Hash,
-        tx: &SanitizedTransaction,
-    ) -> Result<TransactionSimulationResult, Error> {
-        let mut transaction_accounts = Vec::new();
-        for key in tx.message().account_keys().iter() {
-            let account = if solana_sdk::sysvar::instructions::check_id(key) {
-                construct_instructions_account(tx.message())
-            } else {
-                self.accounts_db.get(key).cloned().unwrap_or_default()
-            };
-            transaction_accounts.push((*key, account));
-        }
+        instruction: &Instruction,
+    ) -> (ContextResult, Vec<String>) {
+        let log_collector = LogCollector::new_ref_with_limit(None);
+        self.mollusk_context.mollusk.logger = Some(Rc::clone(&log_collector));
 
-        let program_indices = Self::build_program_indices(tx, &mut transaction_accounts);
+        let result = self.mollusk_context.process_instruction(instruction);
+        let logs = log_collector.borrow().get_recorded_content().to_vec();
 
-        let compute_budget = self.runtime_config.compute_budget.unwrap_or_default();
-        let rent: Arc<Rent> = self.sysvar_cache.get_rent()?;
-        let clock: Arc<Clock> = self.sysvar_cache.get_clock()?;
-
-        let lamports_before_tx =
-            transaction_accounts_lamports_sum(&transaction_accounts, tx.message()).unwrap_or(0);
-
-        let mut transaction_context = TransactionContext::new(
-            transaction_accounts,
-            (*rent).clone(),
-            compute_budget.max_instruction_stack_depth,
-            compute_budget.max_instruction_trace_length,
-        );
-
-        let mut loaded_programs = self.load_programs(tx, &compute_budget, &clock);
-
-        let log_collector =
-            LogCollector::new_ref_with_limit(self.runtime_config.log_messages_bytes_limit);
-
-        let mut units_consumed = 0u64;
-
-        let environment_config = EnvironmentConfig::new(
-            blockhash,
-            None, // looks like not used
-            None, // looks like not used
-            Arc::clone(&self.feature_set),
-            DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE / 2,
-            &self.sysvar_cache,
-        );
-
-        let mut invoke_context = InvokeContext::new(
-            &mut transaction_context,
-            &mut loaded_programs,
-            environment_config,
-            Some(Rc::clone(&log_collector)),
-            compute_budget,
-        );
-
-        let mut status = MessageProcessor::process_message(
-            tx.message(),
-            &program_indices,
-            &mut invoke_context,
-            &mut ExecuteTimings::default(),
-            &mut units_consumed,
-        );
-
-        let inner_instructions = Some(Self::inner_instructions_list_from_instruction_trace(
-            &transaction_context,
-        ));
-
-        let ExecutionRecord {
-            accounts,
-            return_data,
-            touched_account_count: _touched_account_count,
-            accounts_resize_delta: _accounts_resize_delta,
-        } = transaction_context.into();
-
-        if status.is_ok()
-            && transaction_accounts_lamports_sum(&accounts, tx.message())
-                .filter(|lamports_after_tx| lamports_before_tx == *lamports_after_tx)
-                .is_none()
-        {
-            status = Err(TransactionError::UnbalancedTransaction);
-        }
-
-        let logs = log_collector.borrow().messages.clone();
-
-        let return_data = if return_data.data.is_empty() {
-            None
-        } else {
-            Some(return_data)
-        };
-
-        if status.is_ok() {
-            for (pubkey, account) in &accounts {
-                if solana_sdk::sysvar::instructions::check_id(pubkey) {
-                    continue;
-                }
-
-                self.accounts_db.insert(*pubkey, account.clone());
-            }
-        }
-
-        Ok(TransactionSimulationResult {
-            result: status,
-            logs,
-            post_simulation_accounts: accounts,
-            units_consumed,
-            return_data,
-            inner_instructions,
-        })
+        (result, logs)
     }
 
-    /// Extract the `InnerInstructionsList` from a `TransactionContext`
-    fn inner_instructions_list_from_instruction_trace(
-        transaction_context: &TransactionContext,
-    ) -> InnerInstructionsList {
-        debug_assert!(transaction_context
-            .get_instruction_context_at_index_in_trace(0)
-            .map(|instruction_context| instruction_context.get_stack_height()
-                == TRANSACTION_LEVEL_STACK_HEIGHT)
-            .unwrap_or(true));
-        let mut outer_instructions = Vec::new();
-        for index_in_trace in 0..transaction_context.get_instruction_trace_length() {
-            if let Ok(instruction_context) =
-                transaction_context.get_instruction_context_at_index_in_trace(index_in_trace)
-            {
-                let stack_height = instruction_context.get_stack_height();
-                if stack_height == TRANSACTION_LEVEL_STACK_HEIGHT {
-                    outer_instructions.push(Vec::new());
-                } else if let Some(inner_instructions) = outer_instructions.last_mut() {
-                    let stack_height = u8::try_from(stack_height).unwrap_or(u8::MAX);
-                    let instruction = CompiledInstruction::new_from_raw_parts(
-                        u8::try_from(
-                            instruction_context
-                                .get_index_of_program_account_in_transaction(
-                                    instruction_context
-                                        .get_number_of_program_accounts()
-                                        .saturating_sub(1),
-                                )
-                                .unwrap_or_default(),
-                        )
-                        .unwrap_or(u8::MAX),
-                        instruction_context.get_instruction_data().to_vec(),
-                        (0..instruction_context.get_number_of_instruction_accounts())
-                            .map(|instruction_account_index| {
-                                u8::try_from(
-                                    instruction_context
-                                        .get_index_of_instruction_account_in_transaction(
-                                            instruction_account_index,
-                                        )
-                                        .unwrap_or_default(),
-                                )
-                                .unwrap_or(u8::MAX)
-                            })
-                            .collect(),
-                    );
-                    inner_instructions.push(InnerInstruction {
-                        instruction,
-                        stack_height,
-                    });
-                } else {
-                    debug_assert!(false);
-                }
-            } else {
-                debug_assert!(false);
-            }
-        }
-        outer_instructions
-    }
-
-    #[allow(clippy::cast_possible_truncation)]
-    fn build_program_indices(
-        tx: &SanitizedTransaction,
-        transaction_accounts: &mut Vec<(Pubkey, AccountSharedData)>,
-    ) -> Vec<Vec<IndexOfAccount>> {
-        let builtins_start_index = transaction_accounts.len();
-        tx.message()
-            .instructions()
-            .iter()
-            .map(|instruction| {
-                let mut account_indices: Vec<IndexOfAccount> = Vec::with_capacity(2);
-
-                let program_index = instruction.program_id_index as usize;
-                let (program_id, program_account) = &transaction_accounts[program_index];
-
-                if solana_sdk::native_loader::check_id(program_id) {
-                    return account_indices;
-                }
-
-                account_indices.insert(0, program_index as IndexOfAccount);
-
-                let owner = program_account.owner();
-                if solana_sdk::native_loader::check_id(owner) {
-                    return account_indices;
-                }
-
-                if let Some(owner_index) = transaction_accounts[builtins_start_index..]
-                    .iter()
-                    .position(|(key, _)| key == owner)
-                {
-                    let owner_index = owner_index + builtins_start_index;
-                    account_indices.insert(0, owner_index as IndexOfAccount);
-                } else {
-                    let _builtin = BUILTINS
-                        .iter()
-                        .find(|builtin| builtin.program_id == *owner)
-                        .unwrap();
-
-                    let owner_account =
-                        AccountSharedData::new(100, 100, &solana_sdk::native_loader::id());
-                    transaction_accounts.push((*owner, owner_account));
-
-                    let owner_index = transaction_accounts.len() - 1;
-                    account_indices.insert(0, owner_index as IndexOfAccount);
-                }
-
-                account_indices
-            })
-            .collect()
-    }
-
-    fn load_programs(
-        &self,
-        tx: &SanitizedTransaction,
-        compute_budget: &ComputeBudget,
-        clock: &Arc<Clock>,
-    ) -> ProgramCacheForTxBatch {
-        let program_runtime_environments = ProgramRuntimeEnvironments {
-            program_runtime_v1: Arc::new(
-                create_program_runtime_environment_v1(
-                    &self.feature_set,
-                    compute_budget,
-                    true,
-                    true,
-                )
-                .unwrap(),
-            ),
-            program_runtime_v2: Arc::new(create_program_runtime_environment_v2(
-                compute_budget,
-                true,
-            )),
-        };
-
-        let mut loaded_programs = ProgramCacheForTxBatch::new(
-            clock.slot,
-            program_runtime_environments.clone(),
-            None,
-            clock.epoch,
-        );
-
-        tx.message().account_keys().iter().for_each(|key| {
-            if loaded_programs.find(key).is_none() {
-                let account = self.accounts_db.get(key).cloned().unwrap_or_default();
-                if PROGRAM_OWNERS.iter().any(|owner| account.owner() == owner) {
-                    let mut load_program_metrics = LoadProgramMetrics {
-                        program_id: key.to_string(),
-                        ..LoadProgramMetrics::default()
-                    };
-                    let loaded_program = match self.load_program_accounts(account) {
-                        ProgramAccountLoadResult::InvalidAccountData => {
-                            ProgramCacheEntry::new_tombstone(
-                                0,
-                                ProgramCacheEntryOwner::NativeLoader,
-                                ProgramCacheEntryType::Closed,
-                            )
-                        }
-
-                        ProgramAccountLoadResult::ProgramOfLoaderV1orV2(program_account) => {
-                            ProgramCacheEntry::new(
-                                program_account.owner(),
-                                program_runtime_environments.program_runtime_v1.clone(),
-                                0,
-                                0,
-                                program_account.data(),
-                                program_account.data().len(),
-                                &mut load_program_metrics,
-                            )
-                            .unwrap()
-                        }
-
-                        ProgramAccountLoadResult::ProgramOfLoaderV3(
-                            program_account,
-                            programdata_account,
-                            _slot,
-                        ) => {
-                            let programdata = programdata_account
-                                .data()
-                                .get(UpgradeableLoaderState::size_of_programdata_metadata()..)
-                                .unwrap();
-                            ProgramCacheEntry::new(
-                                program_account.owner(),
-                                program_runtime_environments.program_runtime_v1.clone(),
-                                0,
-                                0,
-                                programdata,
-                                program_account
-                                    .data()
-                                    .len()
-                                    .saturating_add(programdata_account.data().len()),
-                                &mut load_program_metrics,
-                            )
-                            .unwrap()
-                        }
-
-                        ProgramAccountLoadResult::ProgramOfLoaderV4(program_account, _slot) => {
-                            let elf_bytes = program_account
-                                .data()
-                                .get(LoaderV4State::program_data_offset()..)
-                                .unwrap();
-                            ProgramCacheEntry::new(
-                                program_account.owner(),
-                                program_runtime_environments.program_runtime_v2.clone(),
-                                0,
-                                0,
-                                elf_bytes,
-                                program_account.data().len(),
-                                &mut load_program_metrics,
-                            )
-                            .unwrap()
-                        }
-                    };
-                    loaded_programs.replenish(*key, Arc::new(loaded_program));
-                }
-            }
-        });
-
-        for builtin in BUILTINS {
-            // create_loadable_account_with_fields
-            let program = ProgramCacheEntry::new_builtin(0, builtin.name.len(), builtin.entrypoint);
-            loaded_programs.replenish(builtin.program_id, Arc::new(program));
-        }
-
-        loaded_programs
-    }
-
-    pub fn process_legacy_transaction(
+    #[must_use]
+    pub fn process_instruction_chain(
         &mut self,
-        tx: solana_sdk::transaction::Transaction,
-    ) -> Result<TransactionSimulationResult, Error> {
-        let versioned_transaction = VersionedTransaction::from(tx);
-        self.process_transaction(
-            *versioned_transaction.message.recent_blockhash(),
-            &self.sanitize_transaction(versioned_transaction, false)?,
-        )
-    }
+        instructions: &[Instruction],
+    ) -> (ContextResult, Vec<String>) {
+        let log_collector = LogCollector::new_ref_with_limit(None);
+        self.mollusk_context.mollusk.logger = Some(Rc::clone(&log_collector));
 
-    fn load_program_accounts(
-        &self,
-        program_account: AccountSharedData,
-    ) -> ProgramAccountLoadResult {
-        debug_assert!(solana_bpf_loader_program::check_loader_id(
-            program_account.owner()
-        ));
+        let result = self.mollusk_context.process_instruction_chain(instructions);
+        let logs = log_collector.borrow().get_recorded_content().to_vec();
 
-        if loader_v4::check_id(program_account.owner()) {
-            return solana_loader_v4_program::get_state(program_account.data())
-                .ok()
-                .and_then(|state| {
-                    (!matches!(state.status, LoaderV4Status::Retracted)).then_some(state.slot)
-                })
-                .map_or(ProgramAccountLoadResult::InvalidAccountData, |slot| {
-                    ProgramAccountLoadResult::ProgramOfLoaderV4(program_account, slot)
-                });
-        }
-
-        if !bpf_loader_upgradeable::check_id(program_account.owner()) {
-            return ProgramAccountLoadResult::ProgramOfLoaderV1orV2(program_account);
-        }
-
-        if let Ok(UpgradeableLoaderState::Program {
-            programdata_address,
-        }) = program_account.state()
-        {
-            if let Some(programdata_account) = self.accounts_db.get(&programdata_address).cloned() {
-                if let Ok(UpgradeableLoaderState::ProgramData {
-                    slot,
-                    upgrade_authority_address: _,
-                }) = programdata_account.state()
-                {
-                    return ProgramAccountLoadResult::ProgramOfLoaderV3(
-                        program_account,
-                        programdata_account,
-                        slot,
-                    );
-                }
-            }
-        }
-        ProgramAccountLoadResult::InvalidAccountData
-    }
-}
-
-enum ProgramAccountLoadResult {
-    InvalidAccountData,
-    ProgramOfLoaderV1orV2(AccountSharedData),
-    ProgramOfLoaderV3(AccountSharedData, AccountSharedData, Slot),
-    ProgramOfLoaderV4(AccountSharedData, Slot),
-}
-
-fn transaction_accounts_lamports_sum(
-    accounts: &[(Pubkey, AccountSharedData)],
-    message: &SanitizedMessage,
-) -> Option<u128> {
-    let mut lamports_sum = 0u128;
-    for i in 0..message.account_keys().len() {
-        let (_, account) = accounts.get(i)?;
-        lamports_sum = lamports_sum.checked_add(u128::from(account.lamports()))?;
-    }
-    Some(lamports_sum)
-}
-
-impl AddressLoader for &SolanaSimulator {
-    fn load_addresses(
-        self,
-        lookups: &[MessageAddressTableLookup],
-    ) -> Result<LoadedAddresses, AddressLoaderError> {
-        lookups
-            .iter()
-            .map(|address_table_lookup| {
-                let table_account = self
-                    .get_shared_account(&address_table_lookup.account_key)
-                    .ok_or(AddressLoaderError::LookupTableAccountNotFound)?;
-
-                if table_account.owner() != &address_lookup_table::program::id() {
-                    return Err(AddressLoaderError::InvalidAccountOwner);
-                }
-
-                let current_slot = self
-                    .slot()
-                    .map_err(|_| AddressLoaderError::LookupTableAccountNotFound)?;
-
-                let slot_hashes = self
-                    .sysvar_cache
-                    .get_slot_hashes()
-                    .map_err(|_| AddressLoaderError::LookupTableAccountNotFound)?;
-
-                let lookup_table = AddressLookupTable::deserialize(table_account.data())
-                    .map_err(|_| AddressLoaderError::InvalidAccountData)?;
-
-                Ok(LoadedAddresses {
-                    writable: lookup_table
-                        .lookup(
-                            current_slot,
-                            &address_table_lookup.writable_indexes,
-                            &slot_hashes,
-                        )
-                        .map_err(|err| map_address_lookup_to_loader_error(&err))?,
-                    readonly: lookup_table
-                        .lookup(
-                            current_slot,
-                            &address_table_lookup.readonly_indexes,
-                            &slot_hashes,
-                        )
-                        .map_err(|err| map_address_lookup_to_loader_error(&err))?,
-                })
-            })
-            .collect::<Result<_, AddressLoaderError>>()
-    }
-}
-
-const fn map_address_lookup_to_loader_error(err: &AddressLookupError) -> AddressLoaderError {
-    match err {
-        AddressLookupError::LookupTableAccountNotFound => {
-            AddressLoaderError::LookupTableAccountNotFound
-        }
-        AddressLookupError::InvalidAccountOwner => AddressLoaderError::InvalidAccountOwner,
-        AddressLookupError::InvalidAccountData => AddressLoaderError::InvalidAccountData,
-        AddressLookupError::InvalidLookupIndex => AddressLoaderError::InvalidLookupIndex,
-    }
-}
-
-fn construct_instructions_account(message: &SanitizedMessage) -> AccountSharedData {
-    AccountSharedData::from(Account {
-        data: construct_instructions_data(&message.decompile_instructions()),
-        owner: sysvar::id(),
-        ..Account::default()
-    })
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_hex_encode_tx() {
-        let bytes = [
-            1, 58, 23, 68, 33, 87, 114, 44, 125, 7, 236, 250, 189, 152, 80, 109, 13, 162, 107, 101,
-            124, 216, 66, 80, 213, 40, 53, 51, 182, 30, 255, 233, 81, 173, 129, 169, 64, 34, 99,
-            244, 26, 97, 234, 36, 224, 159, 246, 251, 59, 49, 38, 37, 93, 186, 243, 244, 21, 130,
-            128, 72, 105, 242, 160, 60, 7, 1, 0, 12, 17, 231, 21, 48, 207, 152, 236, 233, 187, 223,
-            100, 82, 93, 7, 113, 26, 194, 124, 70, 245, 140, 6, 215, 63, 170, 178, 46, 130, 201,
-            93, 40, 215, 178, 87, 173, 47, 151, 71, 81, 72, 73, 80, 156, 165, 181, 37, 178, 136,
-            180, 35, 74, 234, 62, 83, 114, 123, 149, 139, 225, 217, 56, 147, 131, 206, 45, 105,
-            208, 134, 80, 73, 140, 123, 117, 252, 233, 38, 133, 137, 99, 77, 55, 167, 149, 85, 24,
-            36, 45, 148, 20, 106, 29, 21, 63, 99, 229, 104, 209, 135, 106, 102, 83, 227, 22, 170,
-            173, 106, 135, 14, 233, 81, 75, 157, 216, 252, 53, 197, 36, 130, 119, 213, 126, 95, 12,
-            254, 107, 149, 132, 193, 66, 216, 86, 105, 62, 222, 21, 157, 45, 17, 10, 178, 124, 189,
-            91, 143, 219, 219, 104, 133, 196, 14, 129, 66, 215, 247, 28, 36, 71, 221, 69, 99, 94,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 3, 6, 70, 111, 229, 33, 23, 50, 255, 236, 173, 186, 114, 195, 155, 231, 188,
-            140, 229, 187, 197, 247, 18, 107, 44, 67, 155, 58, 64, 0, 0, 0, 7, 215, 243, 216, 48,
-            133, 75, 3, 197, 149, 83, 168, 150, 114, 90, 186, 70, 253, 177, 48, 225, 211, 142, 191,
-            241, 13, 77, 252, 188, 202, 215, 228, 40, 226, 52, 125, 171, 215, 127, 195, 1, 133, 3,
-            55, 38, 152, 124, 161, 200, 77, 29, 38, 158, 98, 147, 173, 205, 87, 50, 86, 244, 38,
-            253, 251, 60, 0, 57, 43, 120, 125, 56, 168, 83, 209, 36, 5, 118, 52, 196, 60, 113, 51,
-            198, 18, 70, 29, 116, 254, 177, 127, 66, 72, 21, 82, 134, 192, 90, 72, 243, 77, 170,
-            80, 23, 118, 170, 39, 23, 58, 58, 106, 22, 11, 26, 111, 175, 251, 186, 179, 49, 60, 52,
-            157, 46, 126, 243, 174, 139, 107, 91, 173, 150, 43, 91, 46, 211, 20, 76, 212, 62, 196,
-            7, 39, 240, 9, 4, 65, 17, 249, 203, 197, 140, 181, 38, 196, 213, 83, 115, 120, 145, 11,
-            94, 103, 100, 49, 70, 40, 205, 74, 224, 203, 66, 252, 113, 38, 143, 168, 244, 184, 32,
-            23, 8, 184, 93, 133, 24, 57, 107, 236, 123, 117, 13, 177, 115, 140, 234, 18, 14, 113,
-            230, 247, 22, 144, 89, 29, 2, 140, 149, 150, 43, 254, 247, 11, 251, 18, 99, 69, 131,
-            32, 152, 113, 83, 125, 6, 8, 196, 54, 180, 68, 255, 57, 153, 93, 12, 42, 185, 242, 64,
-            126, 36, 91, 71, 227, 19, 94, 244, 179, 157, 76, 97, 249, 91, 53, 39, 250, 133, 28,
-            197, 116, 21, 173, 61, 163, 236, 185, 166, 242, 81, 61, 9, 179, 63, 76, 24, 114, 82,
-            18, 182, 138, 185, 121, 251, 101, 108, 251, 132, 89, 201, 201, 238, 34, 115, 103, 121,
-            227, 23, 147, 27, 162, 42, 67, 149, 80, 211, 223, 101, 182, 167, 128, 216, 67, 155, 21,
-            245, 228, 13, 178, 54, 172, 119, 171, 72, 106, 157, 37, 107, 127, 172, 209, 12, 110,
-            173, 6, 145, 14, 187, 127, 145, 195, 53, 103, 119, 182, 129, 49, 170, 8, 237, 99, 87,
-            32, 152, 64, 4, 6, 0, 9, 3, 2, 0, 0, 0, 0, 0, 0, 0, 6, 0, 5, 1, 0, 0, 4, 0, 6, 0, 5, 2,
-            192, 92, 21, 0, 9, 15, 2, 0, 3, 4, 5, 7, 8, 1, 10, 11, 12, 13, 14, 15, 16, 122, 52, 14,
-            0, 0, 0, 88, 49, 0, 0, 12, 0, 0, 0, 248, 107, 1, 132, 119, 53, 148, 0, 132, 9, 61, 92,
-            128, 148, 163, 222, 235, 37, 106, 70, 13, 34, 201, 224, 71, 134, 58, 94, 231, 159, 237,
-            188, 62, 73, 128, 132, 52, 103, 185, 80, 130, 1, 2, 160, 244, 180, 133, 103, 74, 93,
-            21, 159, 64, 57, 219, 13, 44, 152, 135, 226, 169, 32, 159, 38, 122, 70, 119, 143, 47,
-            187, 8, 70, 187, 84, 246, 50, 160, 37, 44, 189, 121, 39, 163, 64, 35, 212, 96, 114,
-            159, 112, 19, 137, 242, 122, 153, 40, 66, 91, 58, 177, 212, 56, 211, 173, 170, 83, 13,
-            176, 85,
-        ];
-        eprintln!("{}", hex::encode(bytes));
-        // assert_eq!(true, false);
-    }
-
-    #[test]
-    fn test_hex_encode_v0_tx() {
-        let bytes = [
-            1, 195, 51, 167, 150, 247, 55, 53, 248, 87, 145, 226, 107, 103, 143, 215, 85, 62, 100,
-            128, 254, 136, 249, 2, 68, 10, 226, 181, 117, 197, 116, 123, 10, 25, 188, 7, 130, 56,
-            16, 164, 148, 238, 144, 40, 1, 29, 213, 36, 243, 153, 42, 247, 46, 74, 245, 246, 187,
-            202, 223, 137, 176, 212, 204, 198, 6, 128, 1, 0, 3, 4, 129, 250, 211, 63, 136, 192,
-            175, 63, 138, 71, 161, 34, 135, 75, 55, 3, 149, 61, 84, 23, 252, 239, 203, 80, 170,
-            175, 222, 166, 136, 217, 173, 126, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 6, 70, 111, 229, 33, 23, 50, 255, 236,
-            173, 186, 114, 195, 155, 231, 188, 140, 229, 187, 197, 247, 18, 107, 44, 67, 155, 58,
-            64, 0, 0, 0, 60, 0, 57, 43, 120, 125, 56, 168, 83, 209, 36, 5, 118, 52, 196, 60, 113,
-            51, 198, 18, 70, 29, 116, 254, 177, 127, 66, 72, 21, 82, 134, 192, 120, 25, 149, 73,
-            158, 141, 39, 109, 12, 97, 90, 180, 212, 130, 149, 30, 62, 56, 197, 80, 116, 62, 58, 5,
-            27, 10, 213, 206, 39, 141, 199, 83, 4, 2, 0, 9, 3, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 5, 1,
-            0, 0, 4, 0, 2, 0, 5, 2, 192, 92, 21, 0, 3, 32, 24, 0, 29, 17, 1, 6, 28, 26, 33, 16, 18,
-            31, 8, 12, 11, 25, 13, 32, 30, 15, 14, 4, 10, 22, 9, 27, 23, 21, 5, 19, 20, 7, 5, 51,
-            29, 0, 0, 0, 1, 35, 227, 136, 54, 194, 46, 23, 104, 208, 155, 167, 222, 101, 18, 44,
-            98, 220, 121, 194, 180, 176, 19, 46, 226, 47, 225, 188, 124, 123, 18, 197, 81, 26, 0,
-            1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 19, 20, 21, 22, 24, 25, 26, 27,
-            28, 29, 4, 2, 3, 18, 23,
-        ];
-        eprintln!("{}", hex::encode(bytes));
-        // assert_eq!(true, false);
+        (result, logs)
     }
 }

--- a/evm_loader/lib/src/solana_simulator/utils.rs
+++ b/evm_loader/lib/src/solana_simulator/utils.rs
@@ -1,8 +1,7 @@
 use agave_feature_set::FeatureSet;
-use agave_reserved_account_keys::ReservedAccountKeys;
 use mollusk_svm::sysvar::Sysvars;
 use solana_loader_v3_interface::state::UpgradeableLoaderState;
-use solana_sdk::{account::Account, pubkey::Pubkey};
+use solana_sdk::account::Account;
 
 use super::error::Error;
 use crate::rpc::Rpc;
@@ -77,12 +76,4 @@ pub async fn extract_elf(rpc: &impl Rpc, account: Account) -> Result<Vec<u8>, Er
         }
         _ => Err(Error::AccountIsNotProgram),
     }
-}
-
-pub fn filter_reserved_accounts(keys: &[Pubkey]) -> Vec<Pubkey> {
-    let reserved_accounts = ReservedAccountKeys::new_all_activated();
-    keys.iter()
-        .copied()
-        .filter(|key| !reserved_accounts.is_reserved(key))
-        .collect::<Vec<Pubkey>>()
 }

--- a/evm_loader/lib/src/solana_simulator/utils.rs
+++ b/evm_loader/lib/src/solana_simulator/utils.rs
@@ -1,19 +1,10 @@
-use super::error::Error;
-use log::debug;
-use solana_program_runtime::sysvar_cache::SysvarCache;
-use solana_sdk::{
-    account::Account,
-    account_utils::StateMut,
-    address_lookup_table::{
-        self,
-        state::{AddressLookupTable, LookupTableMeta},
-    },
-    bpf_loader_upgradeable::{self, UpgradeableLoaderState},
-    pubkey::Pubkey,
-    reserved_account_keys::ReservedAccountKeys,
-    sysvar,
-};
+use agave_feature_set::FeatureSet;
+use agave_reserved_account_keys::ReservedAccountKeys;
+use mollusk_svm::sysvar::Sysvars;
+use solana_loader_v3_interface::state::UpgradeableLoaderState;
+use solana_sdk::{account::Account, pubkey::Pubkey};
 
+use super::error::Error;
 use crate::rpc::Rpc;
 
 #[derive(Eq, PartialEq, Copy, Clone)]
@@ -22,98 +13,76 @@ pub enum SyncState {
     Yes,
 }
 
-pub async fn sync_sysvar_accounts(
-    rpc: &impl Rpc,
-    sysvar_cache: &mut SysvarCache,
-) -> Result<(), Error> {
-    let keys: Vec<Pubkey> = ReservedAccountKeys::default().active.into_iter().collect();
-    let mut accounts = rpc.get_multiple_accounts(&keys).await?;
+pub async fn download_sysvar_accounts(rpc: &impl Rpc) -> Result<Sysvars, Error> {
+    let sysvar_ids = [
+        solana_sdk_ids::sysvar::clock::ID,
+        solana_sdk_ids::sysvar::epoch_rewards::ID,
+        solana_sdk_ids::sysvar::epoch_schedule::ID,
+        solana_sdk_ids::sysvar::last_restart_slot::ID,
+        solana_sdk_ids::sysvar::rent::ID,
+        solana_sdk_ids::sysvar::slot_hashes::ID,
+        solana_sdk_ids::sysvar::stake_history::ID,
+    ];
 
-    sysvar_cache.reset();
-
-    for (account, key) in accounts.iter_mut().zip(keys) {
-        let Some(account) = account else {
-            continue;
-        };
-
-        sysvar_cache.fill_missing_entries(|pubkey, setter| match *pubkey {
-            sysvar::clock::ID
-            | sysvar::rent::ID
-            | sysvar::epoch_rewards::ID
-            | sysvar::epoch_schedule::ID
-            | sysvar::slot_hashes::ID
-            | sysvar::stake_history::ID
-            | sysvar::last_restart_slot::ID => {
-                if key == *pubkey {
-                    setter(account.data.as_mut());
-                }
-            }
-            #[allow(deprecated)]
-            id if { sysvar::fees::check_id(&id) || sysvar::recent_blockhashes::check_id(&id) } => {
-                if key == *pubkey {
-                    setter(account.data.as_mut());
-                }
-            }
-            _ => {}
-        });
+    let accounts = rpc.get_multiple_accounts(&sysvar_ids).await?;
+    if accounts.iter().any(Option::is_none) {
+        return Err(Error::SysvarError);
     }
 
-    Ok(())
+    let accounts = accounts.into_iter().map(|a| a.unwrap()).collect::<Vec<_>>();
+
+    Ok(Sysvars {
+        clock: bincode::deserialize(&accounts[0].data)?,
+        epoch_rewards: bincode::deserialize(&accounts[1].data)?,
+        epoch_schedule: bincode::deserialize(&accounts[2].data)?,
+        last_restart_slot: bincode::deserialize(&accounts[3].data)?,
+        rent: bincode::deserialize(&accounts[4].data)?,
+        slot_hashes: bincode::deserialize(&accounts[5].data)?,
+        stake_history: bincode::deserialize(&accounts[6].data)?,
+    })
 }
 
-pub fn program_data_address(account: &Account) -> Result<Pubkey, Error> {
-    assert!(account.executable);
-    assert_eq!(account.owner, bpf_loader_upgradeable::id());
+pub async fn download_feature_set(rpc: &impl Rpc) -> Result<FeatureSet, Error> {
+    let mut feature_set = FeatureSet::all_enabled();
 
-    let UpgradeableLoaderState::Program {
-        programdata_address,
-        ..
-    } = account.state()?
-    else {
-        return Err(Error::ProgramAccountError);
-    };
+    let deactivated_features = rpc.get_deactivated_solana_features().await?;
+    for feature_id in deactivated_features {
+        feature_set.deactivate(&feature_id);
+    }
 
-    Ok(programdata_address)
+    Ok(feature_set)
 }
 
-pub fn reset_program_data_slot(account: &mut Account) -> Result<(), Error> {
-    assert_eq!(account.owner, bpf_loader_upgradeable::id());
+pub async fn extract_elf(rpc: &impl Rpc, account: Account) -> Result<Vec<u8>, Error> {
+    if !account.executable {
+        return Err(Error::AccountIsNotProgram);
+    }
 
-    let UpgradeableLoaderState::ProgramData {
-        slot,
-        upgrade_authority_address,
-    } = account.state()?
-    else {
-        return Err(Error::ProgramAccountError);
-    };
+    match account.owner {
+        solana_sdk_ids::bpf_loader::ID => Ok(account.data),
+        solana_sdk_ids::bpf_loader_upgradeable::ID => {
+            let UpgradeableLoaderState::Program {
+                programdata_address,
+            } = bincode::deserialize(&account.data)?
+            else {
+                return Err(Error::AccountIsNotProgram);
+            };
 
-    debug!(
-        "slot_before_update: slot={slot} upgrade_authority_address={upgrade_authority_address:?}"
-    );
+            let Some(program_data_account) = rpc.get_account(&programdata_address).await? else {
+                return Err(Error::AccountIsNotProgram);
+            };
 
-    let new_state = UpgradeableLoaderState::ProgramData {
-        slot: 0,
-        upgrade_authority_address,
-    };
-    account.set_state(&new_state)?;
-
-    debug!(
-        "slot_after_update: slot={slot} upgrade_authority_address={upgrade_authority_address:?}"
-    );
-
-    Ok(())
+            let start = UpgradeableLoaderState::size_of_programdata_metadata();
+            Ok(program_data_account.data[start..].to_vec())
+        }
+        _ => Err(Error::AccountIsNotProgram),
+    }
 }
 
-pub fn reset_alt_slot(account: &mut Account) -> Result<(), Error> {
-    assert_eq!(account.owner, address_lookup_table::program::id());
-
-    let lookup_table = AddressLookupTable::deserialize(&account.data)?;
-    let metadata = LookupTableMeta {
-        last_extended_slot: 0,
-        ..lookup_table.meta
-    };
-
-    AddressLookupTable::overwrite_meta_data(&mut account.data, metadata)?;
-
-    Ok(())
+pub fn filter_reserved_accounts(keys: &[Pubkey]) -> Vec<Pubkey> {
+    let reserved_accounts = ReservedAccountKeys::new_all_activated();
+    keys.iter()
+        .copied()
+        .filter(|key| !reserved_accounts.is_reserved(key))
+        .collect::<Vec<Pubkey>>()
 }

--- a/evm_loader/lib/src/solana_simulator/utils.rs
+++ b/evm_loader/lib/src/solana_simulator/utils.rs
@@ -1,7 +1,10 @@
+use std::fmt::Display;
+
 use agave_feature_set::FeatureSet;
 use mollusk_svm::sysvar::Sysvars;
+use num_traits::FromPrimitive;
 use solana_loader_v3_interface::state::UpgradeableLoaderState;
-use solana_sdk::account::Account;
+use solana_sdk::{account::Account, instruction::InstructionError, pubkey::Pubkey};
 
 use super::error::Error;
 use crate::rpc::Rpc;
@@ -75,5 +78,28 @@ pub async fn extract_elf(rpc: &impl Rpc, account: Account) -> Result<Vec<u8>, Er
             Ok(program_data_account.data[start..].to_vec())
         }
         _ => Err(Error::AccountIsNotProgram),
+    }
+}
+
+#[must_use]
+fn error_code_to_string<E: FromPrimitive + Display>(code: u32) -> String {
+    let Some(error) = E::from_u32(code) else {
+        return format!("unknown error: {code:#x}");
+    };
+    error.to_string()
+}
+
+#[must_use]
+pub fn instruction_error_to_string(program_id: Pubkey, error: InstructionError) -> String {
+    use solana_system_interface::error::SystemError;
+    use spl_token_interface::error::TokenError;
+
+    match error {
+        InstructionError::Custom(code) => match program_id {
+            solana_sdk_ids::system_program::ID => error_code_to_string::<SystemError>(code),
+            spl_token_interface::ID => error_code_to_string::<TokenError>(code),
+            _ => format!("custom program error: {code:#x}"),
+        },
+        error => error.to_string(),
     }
 }

--- a/evm_loader/lib/src/types/deactivated_features.rs
+++ b/evm_loader/lib/src/types/deactivated_features.rs
@@ -58,10 +58,7 @@ static DEACTIVATED_FEATURES: Lazy<Arc<Mutex<DeactivatedFeaturesCache>>> =
     Lazy::new(|| Arc::new(Mutex::new(DeactivatedFeaturesCache::default())));
 
 async fn get_multiple_features(rpc: &dyn BoxRpc) -> ClientResult<HashMap<Pubkey, Option<u64>>> {
-    let feature_keys: Vec<Pubkey> = solana_sdk::feature_set::FEATURE_NAMES
-        .keys()
-        .copied()
-        .collect();
+    let feature_keys: Vec<Pubkey> = agave_feature_set::FEATURE_NAMES.keys().copied().collect();
 
     let features = Rpc::get_multiple_accounts(rpc, &feature_keys).await?;
 

--- a/evm_loader/lib/src/types/mod.rs
+++ b/evm_loader/lib/src/types/mod.rs
@@ -22,7 +22,7 @@ use evm_loader::types::Transaction;
 use evm_loader::types::{ExecutionMap, TransactionType};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
-use serde_with::{hex::Hex, serde_as, DisplayFromStr, OneOrMany};
+use serde_with::{hex::Hex, serde_as, DefaultOnNull, DisplayFromStr, OneOrMany};
 use solana_sdk::account::{AccountSharedData, ReadableAccount};
 
 use crate::rpc::SliceConfig;
@@ -312,8 +312,9 @@ pub struct SerializedAccountMeta {
 pub struct SerializedInstruction {
     #[serde_as(as = "DisplayFromStr")]
     pub program_id: Pubkey,
+    #[serde_as(as = "DefaultOnNull")]
     pub accounts: Vec<SerializedAccountMeta>,
-    #[serde_as(as = "Hex")]
+    #[serde_as(as = "DefaultOnNull<Hex>")]
     pub data: Vec<u8>,
 }
 

--- a/evm_loader/lib/src/types/mod.rs
+++ b/evm_loader/lib/src/types/mod.rs
@@ -278,7 +278,7 @@ impl std::fmt::Debug for TxParams {
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SerializedAccount {
     pub lamports: u64,
     #[serde_as(as = "DisplayFromStr")]
@@ -287,6 +287,60 @@ pub struct SerializedAccount {
     pub rent_epoch: u64,
     #[serde_as(as = "Hex")]
     pub data: Vec<u8>,
+}
+
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SerializedProgram {
+    #[serde_as(as = "DisplayFromStr")]
+    pub loader: Pubkey,
+    #[serde_as(as = "Hex")]
+    pub elf: Vec<u8>,
+}
+
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SerializedAccountMeta {
+    #[serde_as(as = "DisplayFromStr")]
+    pub pubkey: Pubkey,
+    pub is_signer: bool,
+    pub is_writable: bool,
+}
+
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SerializedInstruction {
+    #[serde_as(as = "DisplayFromStr")]
+    pub program_id: Pubkey,
+    pub accounts: Vec<SerializedAccountMeta>,
+    #[serde_as(as = "Hex")]
+    pub data: Vec<u8>,
+}
+
+impl From<SerializedAccountMeta> for solana_sdk::instruction::AccountMeta {
+    fn from(s: SerializedAccountMeta) -> Self {
+        Self {
+            pubkey: s.pubkey,
+            is_signer: s.is_signer,
+            is_writable: s.is_writable,
+        }
+    }
+}
+
+impl From<SerializedInstruction> for solana_sdk::instruction::Instruction {
+    fn from(s: SerializedInstruction) -> Self {
+        let accounts = s
+            .accounts
+            .into_iter()
+            .map(solana_sdk::instruction::AccountMeta::from)
+            .collect();
+
+        Self {
+            program_id: s.program_id,
+            accounts,
+            data: s.data,
+        }
+    }
 }
 
 impl From<&SerializedAccount> for Account {
@@ -496,15 +550,12 @@ pub struct GetHolderRequest {
 pub struct SimulateSolanaRequest {
     pub compute_units: Option<u64>,
     pub heap_size: Option<u32>,
-    pub account_limit: Option<usize>,
-    pub verify: Option<bool>,
-    #[serde_as(as = "Hex")]
-    pub blockhash: [u8; 32],
-    #[serde_as(as = "Vec<Hex>")]
-    pub transactions: Vec<Vec<u8>>,
+    pub instructions: Vec<SerializedInstruction>,
     pub id: Option<String>,
     #[serde_as(as = "Option<HashMap<DisplayFromStr,_>>")]
-    pub solana_overrides: Option<HashMap<Pubkey, Option<SerializedAccount>>>,
+    pub accounts_overrides: Option<HashMap<Pubkey, SerializedAccount>>,
+    #[serde_as(as = "Option<HashMap<DisplayFromStr,_>>")]
+    pub programs_overrides: Option<HashMap<Pubkey, SerializedProgram>>,
 }
 
 #[cfg(test)]

--- a/evm_loader/lib/src/types/programs_cache.rs
+++ b/evm_loader/lib/src/types/programs_cache.rs
@@ -1,6 +1,7 @@
 // use crate::tracing::tracers::state_diff::Account;
 use crate::rpc::Rpc;
 use async_trait::async_trait;
+use solana_sdk_ids::bpf_loader_upgradeable;
 
 use crate::commands::get_config::GetConfigResponse;
 use bincode::deserialize;
@@ -275,12 +276,11 @@ impl Rpc for FakeRpc {
         Ok(Vec::new())
     }
 }
-use evm_loader::solana_program::bpf_loader_upgradeable;
-use tokio;
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio;
 
     #[tokio::test]
     async fn test_acc_slice() {

--- a/evm_loader/program/Cargo.toml
+++ b/evm_loader/program/Cargo.toml
@@ -42,8 +42,10 @@ default = ["custom-heap"]
 linked_list_allocator = { version = "0.10", default-features = false }
 evm-loader-macro = { path = "../program-macro" }
 solana-program.workspace = true
+solana-sdk-ids.workspace = true
 solana-account.workspace = true
 solana-bn254.workspace = true
+solana-system-interface = { workspace = true, features = ["bincode"] }
 solana-compute-budget-interface = {workspace = true, features = ["borsh"]}
 spl-token.workspace = true
 spl-associated-token-account.workspace = true

--- a/evm_loader/program/src/account/abstraction.rs
+++ b/evm_loader/program/src/account/abstraction.rs
@@ -6,7 +6,7 @@ use std::{
 
 use enum_dispatch::enum_dispatch;
 use solana_account::ReadableAccount;
-use solana_program::{account_info::AccountInfo, pubkey::Pubkey, system_program};
+use solana_program::{account_info::AccountInfo, pubkey::Pubkey};
 
 use crate::error::{Error, Result};
 
@@ -104,12 +104,6 @@ pub enum Account<'a> {
     SharedAccount(SharedAccount),
 }
 
-#[derive(PartialEq, Eq)]
-pub enum ZeroInit {
-    Zero,
-    Uninit,
-}
-
 pub trait AccountHeader {
     const VERSION: u8;
 }
@@ -134,7 +128,7 @@ pub trait AccountDispatch<'a> {
     fn rent_epoch(&self) -> u64;
     fn is_executable(&self) -> bool;
 
-    fn reallocate(&mut self, new_size: usize, zero_init: ZeroInit) -> Result<()>;
+    fn reallocate(&mut self, new_size: usize) -> Result<()>;
 
     fn tag(&self, program_id: Pubkey) -> Result<u8> {
         if self.owner() != program_id {
@@ -279,7 +273,7 @@ pub trait AccountDispatch<'a> {
         let required_len = ACCOUNT_PREFIX_LEN + to_len + data_len;
         assert!(required_len >= data_len);
 
-        self.reallocate(required_len, ZeroInit::Uninit)?;
+        self.reallocate(required_len)?;
 
         {
             let mut account_data = self.data_mut();
@@ -324,7 +318,7 @@ impl<'a> AccountDispatch<'a> for AccountInfo<'a> {
     }
 
     fn is_system_owned(&self) -> bool {
-        system_program::check_id(self.owner)
+        solana_sdk_ids::system_program::check_id(self.owner)
     }
 
     fn lamports(&self) -> u64 {
@@ -339,8 +333,8 @@ impl<'a> AccountDispatch<'a> for AccountInfo<'a> {
         self.executable
     }
 
-    fn reallocate(&mut self, new_size: usize, zero_init: ZeroInit) -> Result<()> {
-        self.realloc(new_size, zero_init == ZeroInit::Zero)?;
+    fn reallocate(&mut self, new_size: usize) -> Result<()> {
+        self.resize(new_size)?;
         Ok(())
     }
 }
@@ -396,7 +390,7 @@ impl AccountDispatch<'_> for SharedAccount {
         account.executable
     }
 
-    fn reallocate(&mut self, new_size: usize, _: ZeroInit) -> Result<()> {
+    fn reallocate(&mut self, new_size: usize) -> Result<()> {
         self.modified.set(true);
 
         let mut account = self.account.borrow_mut();

--- a/evm_loader/program/src/account/ether_contract.rs
+++ b/evm_loader/program/src/account/ether_contract.rs
@@ -14,9 +14,7 @@ use std::{
 
 use crate::config::STORAGE_ENTRIES_IN_CONTRACT_ACCOUNT;
 
-use super::{
-    Account, AccountDispatch, AccountHeader, ZeroInit, ACCOUNT_PREFIX_LEN, TAG_ACCOUNT_CONTRACT,
-};
+use super::{Account, AccountDispatch, AccountHeader, ACCOUNT_PREFIX_LEN, TAG_ACCOUNT_CONTRACT};
 
 #[derive(Eq, PartialEq)]
 pub enum AllocateResult {
@@ -208,7 +206,7 @@ impl<'a> ContractAccount<'a> {
 
         let max_size = self.account.original_data_len() + MAX_PERMITTED_DATA_INCREASE;
         let new_space = required_size.min(max_size);
-        self.account.reallocate(new_space, ZeroInit::Uninit)?;
+        self.account.reallocate(new_space)?;
 
         if new_space >= required_size {
             Ok(AllocateResult::Ready)
@@ -223,7 +221,7 @@ impl<'a> ContractAccount<'a> {
             return Ok(());
         }
 
-        self.account.reallocate(required_size, ZeroInit::Uninit)
+        self.account.reallocate(required_size)
     }
 
     pub fn set_code(&mut self, code: &[u8]) -> Result<()> {

--- a/evm_loader/program/src/account/ether_storage.rs
+++ b/evm_loader/program/src/account/ether_storage.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 use std::mem::size_of;
 
 use super::{
-    Account, AccountDispatch, AccountHeader, NoHeader, ZeroInit, ACCOUNT_PREFIX_LEN, TAG_EMPTY,
+    Account, AccountDispatch, AccountHeader, NoHeader, ACCOUNT_PREFIX_LEN, TAG_EMPTY,
     TAG_STORAGE_CELL,
 };
 use crate::error::{Error, Result};
@@ -219,7 +219,7 @@ impl<'a> StorageCell<'a> {
 
     fn allocate_cell(&mut self) -> Result<RefMut<Cell>> {
         let new_len = self.account.data_len() + size_of::<Cell>(); // new_len <= 8.25 kb
-        self.account.reallocate(new_len, ZeroInit::Uninit)?;
+        self.account.reallocate(new_len)?;
 
         let cells = self.cells_mut();
         let filter_result = RefMut::filter_map(cells, <[Cell]>::last_mut);

--- a/evm_loader/program/src/account/mod.rs
+++ b/evm_loader/program/src/account/mod.rs
@@ -5,7 +5,7 @@ use crate::error::Result;
 use solana_program::account_info::AccountInfo;
 
 pub use abstraction::{
-    Account, AccountDispatch, AccountHeader, NoHeader, SharedAccount, ZeroInit, ACCOUNT_PREFIX_LEN,
+    Account, AccountDispatch, AccountHeader, NoHeader, SharedAccount, ACCOUNT_PREFIX_LEN,
 };
 pub use ether_balance::{BalanceAccount, Header as BalanceHeader};
 pub use ether_contract::{AllocateResult, ContractAccount, Header as ContractHeader};
@@ -72,7 +72,7 @@ pub unsafe fn delete_with_treasury(account: &AccountInfo, treasury: &Treasury) -
     **account.lamports.borrow_mut() = 0;
 
     account.data.borrow_mut().fill(0);
-    account.realloc(0, false)?;
+    account.resize(0)?;
     account.assign(&solana_program::system_program::ID);
 
     Ok(())

--- a/evm_loader/program/src/account/operator.rs
+++ b/evm_loader/program/src/account/operator.rs
@@ -1,6 +1,6 @@
 use crate::error::{Error, Result};
 use solana_program::account_info::AccountInfo;
-use solana_program::system_program;
+use solana_sdk_ids::system_program;
 use std::ops::Deref;
 
 #[derive(Clone)]

--- a/evm_loader/program/src/account/program.rs
+++ b/evm_loader/program/src/account/program.rs
@@ -3,8 +3,9 @@ use crate::error::{Error, Result};
 use solana_program::account_info::AccountInfo;
 use solana_program::program::{invoke_signed_unchecked, invoke_unchecked};
 use solana_program::pubkey::Pubkey;
-use solana_program::system_program;
-use solana_program::{rent::Rent, system_instruction};
+use solana_program::rent::Rent;
+use solana_sdk_ids::system_program;
+use solana_system_interface::instruction as system_instruction;
 use std::convert::From;
 use std::ops::Deref;
 

--- a/evm_loader/program/src/account/state_root.rs
+++ b/evm_loader/program/src/account/state_root.rs
@@ -4,7 +4,7 @@ use maybe_async::maybe_async;
 use solana_program::clock::Clock;
 use solana_program::instruction::{AccountMeta, Instruction};
 use solana_program::pubkey::Pubkey;
-use solana_program::{bpf_loader, system_program};
+use solana_sdk_ids::{bpf_loader, system_program};
 
 use crate::account::{Account, AccountDispatch};
 use crate::allocator::StateAllocator;

--- a/evm_loader/program/src/account/transaction_tree.rs
+++ b/evm_loader/program/src/account/transaction_tree.rs
@@ -15,8 +15,7 @@ use crate::evm::ExitStatus;
 use crate::types::{Address, ScheduledTransaction};
 use ethnum::U256;
 use solana_program::{
-    account_info::AccountInfo, clock::Clock, pubkey::Pubkey, rent::Rent, system_program,
-    sysvar::Sysvar,
+    account_info::AccountInfo, clock::Clock, pubkey::Pubkey, rent::Rent, sysvar::Sysvar,
 };
 
 #[repr(u8)]
@@ -144,7 +143,7 @@ impl<'a> TransactionTree<'a> {
             return Err(Error::AccountInvalidKey(*account.key, pubkey));
         }
 
-        if account.owner != &system_program::ID {
+        if !account.is_system_owned() {
             return Err(Error::TreeAccountAlreadyExists);
         }
 

--- a/evm_loader/program/src/error.rs
+++ b/evm_loader/program/src/error.rs
@@ -258,7 +258,7 @@ pub enum Error {
     #[error("Program not allowed to call itself")]
     RecursiveCall,
 
-    #[error("External call fails {0}: {1}")]
+    #[error("CPI fails {0}: {1}")]
     ExternalCallFailed(Pubkey, String),
 
     #[error("Operator Balance - invalid owner {0}, expected = {1}")]

--- a/evm_loader/program/src/error.rs
+++ b/evm_loader/program/src/error.rs
@@ -258,7 +258,7 @@ pub enum Error {
     #[error("Program not allowed to call itself")]
     RecursiveCall,
 
-    #[error("CPI fails {0}: {1}")]
+    #[error("{0}: {1}")]
     ExternalCallFailed(Pubkey, String),
 
     #[error("Operator Balance - invalid owner {0}, expected = {1}")]

--- a/evm_loader/program/src/executor/owned_account.rs
+++ b/evm_loader/program/src/executor/owned_account.rs
@@ -1,4 +1,4 @@
-use solana_program::{account_info::AccountInfo, pubkey::Pubkey, system_program};
+use solana_program::{account_info::AccountInfo, pubkey::Pubkey};
 use std::{cell::RefCell, rc::Rc};
 
 use crate::{
@@ -48,7 +48,7 @@ impl OwnedAccountInfo {
             is_writable: true,
             lamports: 100 * 1_000_000_000,
             data: vec![],
-            owner: system_program::ID,
+            owner: solana_sdk_ids::system_program::ID,
             executable: false,
             rent_epoch: u64::MAX,
         }

--- a/evm_loader/program/src/executor/precompile_extension/call_solana.rs
+++ b/evm_loader/program/src/executor/precompile_extension/call_solana.rs
@@ -12,8 +12,8 @@ use maybe_async::maybe_async;
 use solana_program::{
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
-    system_instruction,
 };
+use solana_system_interface::instruction as system_instruction;
 
 use super::PrecompileDatabase;
 

--- a/evm_loader/program/src/executor/precompile_extension/mod.rs
+++ b/evm_loader/program/src/executor/precompile_extension/mod.rs
@@ -9,8 +9,9 @@ use crate::{
 use ethnum::U256;
 use maybe_async::maybe_async;
 use solana_program::instruction::Instruction;
+use solana_program::pubkey::Pubkey;
 use solana_program::rent::Rent;
-use solana_program::{pubkey::Pubkey, system_instruction};
+use solana_system_interface::instruction as system_instruction;
 
 use super::owned_account::OwnedAccountInfo;
 

--- a/evm_loader/program/src/executor/precompile_extension/spl_token.rs
+++ b/evm_loader/program/src/executor/precompile_extension/spl_token.rs
@@ -2,9 +2,8 @@ use std::convert::{Into, TryInto};
 
 use ethnum::U256;
 use maybe_async::maybe_async;
-use solana_program::{
-    program_error::ProgramError, program_pack::Pack, pubkey::Pubkey, system_program,
-};
+use solana_program::{program_error::ProgramError, program_pack::Pack, pubkey::Pubkey};
+use solana_sdk_ids::system_program;
 
 use super::{create_account, PrecompileDatabase};
 use crate::{

--- a/evm_loader/program/src/external_programs/system.rs
+++ b/evm_loader/program/src/external_programs/system.rs
@@ -3,8 +3,9 @@
 use crate::{executor::OwnedAccountInfo, types::vector::VectorMap};
 use solana_program::{
     entrypoint::ProgramResult, instruction::AccountMeta, program_error::ProgramError,
-    pubkey::Pubkey, system_instruction::SystemInstruction, system_program,
+    pubkey::Pubkey, system_instruction::SystemInstruction,
 };
+use solana_sdk_ids::system_program;
 
 pub fn emulate(
     instruction: &[u8],

--- a/evm_loader/program/src/platform/mod.rs
+++ b/evm_loader/program/src/platform/mod.rs
@@ -9,7 +9,7 @@ use solana_program::{
 
 use crate::account::{
     pda, Account, AccountDispatch, AllocateResult, BalanceAccount, ContractAccount, Root,
-    StorageCell, StorageCellSeed, ZeroInit, TAG_EMPTY,
+    StorageCell, StorageCellSeed, TAG_EMPTY,
 };
 use crate::error::Result;
 use crate::types::{Address, Transaction};
@@ -137,7 +137,7 @@ pub trait Platform<'a>: Sized {
         let mut account = self.assign_account(seeds).await?;
         if account.data_len() == 0 {
             let required_len = BalanceAccount::required_account_size(false);
-            account.reallocate(required_len, ZeroInit::Uninit)?;
+            account.reallocate(required_len)?;
 
             BalanceAccount::initialize(account, program_id, address, chain_id)
         } else {
@@ -160,7 +160,7 @@ pub trait Platform<'a>: Sized {
         let mut account = self.assign_account(seeds).await?;
         if account.data_len() == 0 {
             let required_len = BalanceAccount::required_account_size(true);
-            account.reallocate(required_len, ZeroInit::Uninit)?;
+            account.reallocate(required_len)?;
 
             BalanceAccount::initialize_for_solana_user(account, program_id, user_pubkey, chain.id)
         } else {
@@ -200,7 +200,7 @@ pub trait Platform<'a>: Sized {
         let mut account = self.assign_account(seeds).await?;
         if account.data_len() == 0 {
             let required_len = ContractAccount::required_account_size(&[]);
-            account.reallocate(required_len, ZeroInit::Uninit)?;
+            account.reallocate(required_len)?;
 
             ContractAccount::initialize(account, program_id, address, chain_id, &[])
         } else {
@@ -228,7 +228,7 @@ pub trait Platform<'a>: Sized {
 
         let max_size = account.original_data_len() + MAX_PERMITTED_DATA_INCREASE;
         let new_space = required_size.min(max_size);
-        account.reallocate(new_space, ZeroInit::Uninit)?;
+        account.reallocate(new_space)?;
 
         if new_space >= required_size {
             Ok(AllocateResult::Ready)
@@ -279,7 +279,7 @@ pub trait Platform<'a>: Sized {
 
         if account.data_len() == 0 {
             let required_len = StorageCell::required_account_size(0);
-            account.reallocate(required_len, ZeroInit::Uninit)?;
+            account.reallocate(required_len)?;
 
             StorageCell::initialize(account, program_id)
         } else {

--- a/evm_loader/program/src/platform/solana.rs
+++ b/evm_loader/program/src/platform/solana.rs
@@ -2,9 +2,10 @@
 use ethnum::U256;
 use solana_program::{
     account_info::AccountInfo, instruction::Instruction, log::sol_log_data,
-    program::invoke_signed_unchecked, pubkey::Pubkey, rent::Rent, system_instruction,
-    system_program, sysvar::Sysvar,
+    program::invoke_signed_unchecked, pubkey::Pubkey, rent::Rent, sysvar::Sysvar,
 };
+use solana_sdk_ids::system_program;
+use solana_system_interface::instruction as system_instruction;
 use std::collections::HashMap;
 
 use crate::{

--- a/evm_loader/tracerdb-api/Cargo.toml
+++ b/evm_loader/tracerdb-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 
-jsonrpsee = { version = ">=0.20", features = ["server", "ws-client", "macros"] }
+jsonrpsee = { version = "=0.20.4", features = ["server", "ws-client", "macros"] }
 solana-sdk.version = ">=1.15.0"
 serde = ">=1.0"
 serde_with = { version = ">=3.9", features = ["hex","base64"] }


### PR DESCRIPTION
Use Mollusk as a Solana simulator.
Change request and response format of `simulate_solana` neon-api/rpc.

Request: 
```json
{
   "id": 1
   "compute_units": 1400000,
   "heap_size": 262144,
   "instructions": [
      {
         "program_id": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         "accounts": [
            {
               "pubkey": "GS4CU59F31iL7aR2Q8zVS8DRrcRnXX1yjQ66TqNVQnaR"
               "is_signer": true,
               "is_writable": true
            }
         ],
         "data": "FF16A0"
      }
   ],
   "accounts_overrides": null,
   "programs_overrides": null,
}
```