### PR TITLE
Remove dependency on `static_assertions`

### DIFF
--- a/evm_loader/Cargo.lock
+++ b/evm_loader/Cargo.lock
@@ -1636,8 +1636,6 @@ checksum = "85078445a8dbd2e1bd21f04a816f352db8d333643f0c9b78ca7c3d1df71063e7"
 dependencies = [
  "dashu-base",
  "dashu-int",
- "num-modular",
- "num-order",
  "rustversion",
  "static_assertions",
 ]
@@ -1651,7 +1649,6 @@ dependencies = [
  "cfg-if",
  "dashu-base",
  "num-modular",
- "num-order",
  "rustversion",
  "static_assertions",
 ]
@@ -1681,8 +1678,6 @@ dependencies = [
  "dashu-base",
  "dashu-float",
  "dashu-int",
- "num-modular",
- "num-order",
  "rustversion",
 ]
 
@@ -2131,7 +2126,6 @@ dependencies = [
  "solana-program",
  "spl-associated-token-account 6.0.0",
  "spl-token 7.0.0",
- "static_assertions",
  "strum 0.26.3",
  "thiserror 1.0.69",
 ]
@@ -4146,15 +4140,6 @@ name = "num-modular"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
-
-[[package]]
-name = "num-order"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
-dependencies = [
- "num-modular",
-]
 
 [[package]]
 name = "num-rational"

--- a/evm_loader/program/Cargo.toml
+++ b/evm_loader/program/Cargo.toml
@@ -53,7 +53,6 @@ arrayref = "0.3.8"
 hex = "0.4.3"
 ripemd = "0.1"
 alloy-rlp = { version = "0.3", features = ["derive"] }
-static_assertions = "1"
 borsh = "1.5.2"
 borsh010 = { version = "0.10.4", package = "borsh" }
 bincode = "1"
@@ -65,7 +64,7 @@ strum = { version = "0.26.3", features = ["derive"] }
 maybe-async = "0.2.10"
 async-trait = { version = "0.1.81", optional = true }
 allocator-api2 = "0.3"
-dashu = "0.4.2"
+dashu =  { version = "0.4.2", default-features = false }
 enum_dispatch = "0.3"
 
 [target.'cfg(target_os = "solana")'.dependencies.maybe-async]

--- a/evm_loader/program/src/account/container.rs
+++ b/evm_loader/program/src/account/container.rs
@@ -161,7 +161,7 @@ impl<'a> ContainerAccount<'a> {
         let data: Ref<[u8]> = self.account.data_get(range);
 
         Ref::map(data, |bytes| {
-            static_assertions::assert_eq_align!(Key, u8);
+            const { assert!(align_of::<Key>() == 1) }
             assert_eq!(bytes.len() % size_of::<Key>(), 0);
 
             // SAFETY: Key has the same alignment as bytes
@@ -179,7 +179,7 @@ impl<'a> ContainerAccount<'a> {
         let data: RefMut<[u8]> = self.account.data_get_mut(range);
 
         RefMut::map(data, |bytes| {
-            static_assertions::assert_eq_align!(Key, u8);
+            const { assert!(align_of::<Key>() == 1) }
             assert_eq!(bytes.len() % size_of::<Key>(), 0);
 
             // SAFETY: Key has the same alignment as bytes

--- a/evm_loader/program/src/account/ether_storage.rs
+++ b/evm_loader/program/src/account/ether_storage.rs
@@ -159,7 +159,7 @@ impl<'a> StorageCell<'a> {
         let data = Ref::map(data, |d| &d[cells_offset..]);
 
         Ref::map(data, |bytes| {
-            static_assertions::assert_eq_align!(Cell, u8);
+            const { assert!(std::mem::align_of::<Cell>() == 1) };
             assert_eq!(bytes.len() % size_of::<Cell>(), 0);
 
             // SAFETY: Cell has the same alignment as bytes
@@ -179,7 +179,7 @@ impl<'a> StorageCell<'a> {
         let data = RefMut::map(data, |d| &mut d[cells_offset..]);
 
         RefMut::map(data, |bytes| {
-            static_assertions::assert_eq_align!(Cell, u8);
+            const { assert!(std::mem::align_of::<Cell>() == 1) };
             assert_eq!(bytes.len() % size_of::<Cell>(), 0);
 
             // SAFETY: Cell has the same alignment as bytes

--- a/evm_loader/program/src/account/state_root.rs
+++ b/evm_loader/program/src/account/state_root.rs
@@ -215,9 +215,11 @@ pub struct Root<A: Allocator + Copy = StateAllocator> {
 }
 
 // to be sure that solana and x86 size/alignment match
-// const_assert_eq!(std::mem::align_of::<PlainData>(), 0x8);
-// const_assert_eq!(std::mem::size_of::<PlainData>(), 0x1A0);
-// const_assert_eq!(std::mem::offset_of!(Root, revisions), 0x1A0);
+const _: () = {
+    assert!(std::mem::align_of::<Root>() == 0x8);
+    assert!(std::mem::size_of::<Root>() == 0x5A0);
+    assert!(std::mem::offset_of!(Root, revisions) == 0xE0);
+};
 
 #[maybe_async]
 impl<A: Allocator + Copy> Root<A> {

--- a/evm_loader/program/src/account/transaction_tree.rs
+++ b/evm_loader/program/src/account/transaction_tree.rs
@@ -46,7 +46,7 @@ pub struct Node {
     pub success_execute_limit: u16,
     pub parent_count: u16,
 }
-static_assertions::assert_eq_size!(Node, [u8; 155]);
+const _: () = assert!(std::mem::size_of::<Node>() == 155);
 
 pub const NO_CHILD_TRANSACTION: u16 = u16::MAX;
 
@@ -60,7 +60,7 @@ pub struct HeaderV0 {
     balance: U256,
     last_index: u16,
 }
-static_assertions::assert_eq_size!(HeaderV0, [u8; 134]);
+const _: () = assert!(std::mem::size_of::<HeaderV0>() == 134);
 
 impl AccountHeader for HeaderV0 {
     const VERSION: u8 = 0;
@@ -638,7 +638,7 @@ impl<'a> TransactionTree<'a> {
         let data = Ref::map(data, |d| &d[nodes_offset..]);
 
         Ref::map(data, |bytes| {
-            static_assertions::assert_eq_align!(Node, u8);
+            const { assert!(std::mem::align_of::<Node>() == 1) };
             assert_eq!(bytes.len() % size_of::<Node>(), 0);
 
             // SAFETY: Node has the same alignment as bytes
@@ -658,7 +658,7 @@ impl<'a> TransactionTree<'a> {
         let data = RefMut::map(data, |d| &mut d[nodes_offset..]);
 
         RefMut::map(data, |bytes| {
-            static_assertions::assert_eq_align!(Node, u8);
+            const { assert!(std::mem::align_of::<Node>() == 1) };
             assert_eq!(bytes.len() % size_of::<Node>(), 0);
 
             // SAFETY: Node has the same alignment as bytes

--- a/evm_loader/program/src/allocator/solana_allocator.rs
+++ b/evm_loader/program/src/allocator/solana_allocator.rs
@@ -3,7 +3,6 @@ use std::slice;
 
 use linked_list_allocator::Heap;
 use solana_program::entrypoint::HEAP_START_ADDRESS;
-use static_assertions::{const_assert, const_assert_eq};
 
 use std::alloc::Layout;
 use std::ptr::NonNull;
@@ -26,8 +25,10 @@ const SOLANA_HEAP_RANGE: Range<usize> = Range {
     end: SOLANA_HEAP_START_ADDRESS + SOLANA_HEAP_SIZE,
 };
 
-const_assert!(HEAP_START_ADDRESS < (usize::MAX as u64));
-const_assert_eq!(SOLANA_HEAP_START_ADDRESS % std::mem::align_of::<Heap>(), 0);
+const _: () = {
+    assert!(HEAP_START_ADDRESS < (usize::MAX as u64));
+    assert!((SOLANA_HEAP_START_ADDRESS % std::mem::align_of::<Heap>()) == 0);
+};
 
 #[derive(Copy, Clone)]
 pub struct SolanaAllocator {

--- a/evm_loader/program/src/evm/memory.rs
+++ b/evm_loader/program/src/evm/memory.rs
@@ -13,7 +13,7 @@ const MAX_MEMORY_SIZE: usize = 64 * 1024;
 const MEMORY_CAPACITY: usize = 1024;
 const MEMORY_ALIGN: usize = 1;
 
-static_assertions::const_assert!(MEMORY_ALIGN.is_power_of_two());
+const _: () = assert!(MEMORY_ALIGN.is_power_of_two());
 
 #[repr(C)]
 pub struct Memory<A: Allocator> {

--- a/evm_loader/program/src/evm/stack.rs
+++ b/evm_loader/program/src/evm/stack.rs
@@ -119,8 +119,10 @@ impl<A: Allocator> Stack<A> {
 
     #[inline(always)]
     pub fn pop_address(&mut self) -> Result<Address, Error> {
-        static_assertions::assert_eq_align!(Address, u8);
-        static_assertions::assert_eq_size!(Address, [u8; 20]);
+        const {
+            assert!(std::mem::align_of::<Address>() == 1);
+            assert!(std::mem::size_of::<Address>() == 20);
+        };
 
         self.pop()?;
 


### PR DESCRIPTION
`static_assertions` library brings rust-analyzer to it's knee.
Replace it by standard rust `assert!` within const context.