### PR TITLE
NDEV-3883 Use SerializedAccount instead of AccountData

### DIFF
--- a/evm_loader/lib/src/commands/emulate.rs
+++ b/evm_loader/lib/src/commands/emulate.rs
@@ -11,7 +11,7 @@ use crate::tracing::{AccountOverride, BlockOverrides, TraceCallConfig, TraceConf
 use crate::types::{AccountInfoLevel, EmulateFromHolderApiRequest, EmulateRequest};
 use crate::types::{FromAddress, TracerDb};
 
-use crate::{errors::NeonError, NeonResult, types::SerializedAccount};
+use crate::{errors::NeonError, types::SerializedAccount, NeonResult};
 use ethnum::U256;
 use evm_loader::error::build_revert_message;
 use evm_loader::evm::database::Database;

--- a/evm_loader/lib/src/commands/emulate.rs
+++ b/evm_loader/lib/src/commands/emulate.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use crate::account_data::AccountData;
 use crate::commands::get_config::BuildConfigSimulator;
 use crate::config::DbConfig;
 use crate::emulator_platform::EmulatorPlatform;
@@ -12,7 +11,7 @@ use crate::tracing::{AccountOverride, BlockOverrides, TraceCallConfig, TraceConf
 use crate::types::{AccountInfoLevel, EmulateFromHolderApiRequest, EmulateRequest};
 use crate::types::{FromAddress, TracerDb};
 
-use crate::{errors::NeonError, NeonResult};
+use crate::{errors::NeonError, NeonResult, types::SerializedAccount};
 use ethnum::U256;
 use evm_loader::error::build_revert_message;
 use evm_loader::evm::database::Database;
@@ -59,7 +58,7 @@ pub struct EmulateResponse {
     pub iterations: u64,
     pub solana_accounts: Vec<SolanaAccount>,
     pub logs: Vec<Log>,
-    pub accounts_data: Option<Vec<AccountData>>,
+    pub accounts_data: Option<Vec<(Pubkey, SerializedAccount)>>,
 }
 
 #[derive(Clone)]

--- a/evm_loader/lib/src/commands/emulate_multiple.rs
+++ b/evm_loader/lib/src/commands/emulate_multiple.rs
@@ -83,8 +83,8 @@ pub async fn execute(
         .await?;
 
         let accounts = response.accounts_data.take().unwrap_or_default();
-        for account in accounts {
-            overrides.insert(account.pubkey, Some(account.into()));
+        for (pubkey, account) in accounts {
+            overrides.insert(pubkey, Some(account));
         }
 
         responses.push(response);

--- a/evm_loader/lib/src/emulator_platform.rs
+++ b/evm_loader/lib/src/emulator_platform.rs
@@ -207,7 +207,10 @@ impl<R: Rpc> EmulatorPlatform<R> {
             .collect()
     }
 
-    pub fn provide_account_data(&self, level: AccountInfoLevel) -> NeonResult<Vec<(Pubkey, SerializedAccount)>> {
+    pub fn provide_account_data(
+        &self,
+        level: AccountInfoLevel,
+    ) -> NeonResult<Vec<(Pubkey, SerializedAccount)>> {
         let mut result = Vec::new();
 
         for account in &self.used_accounts() {

--- a/evm_loader/lib/src/emulator_platform.rs
+++ b/evm_loader/lib/src/emulator_platform.rs
@@ -21,7 +21,6 @@ use solana_sdk::sysvar::SysvarId;
 use solana_sdk::transaction_context::TransactionReturnData;
 use solana_sdk::{instruction::Instruction, pubkey::Pubkey, sysvar::Sysvar};
 
-use crate::account_data::AccountData;
 use crate::commands::emulate::SolanaAccount;
 use crate::commands::get_config::ChainInfo;
 use crate::emulator_account::SharedAccount;
@@ -29,7 +28,7 @@ use crate::rpc::{CachedRpc, Rpc};
 use crate::solana_simulator::{instruction_error_to_string, SolanaSimulator};
 use crate::sysvar::get_sysvar;
 use crate::tracing::{AccountOverride, BlockOverrides};
-use crate::types::AccountInfoLevel;
+use crate::types::{AccountInfoLevel, SerializedAccount};
 use crate::{NeonError, NeonResult};
 
 #[must_use]
@@ -208,7 +207,7 @@ impl<R: Rpc> EmulatorPlatform<R> {
             .collect()
     }
 
-    pub fn provide_account_data(&self, level: AccountInfoLevel) -> NeonResult<Vec<AccountData>> {
+    pub fn provide_account_data(&self, level: AccountInfoLevel) -> NeonResult<Vec<(Pubkey, SerializedAccount)>> {
         let mut result = Vec::new();
 
         for account in &self.used_accounts() {
@@ -217,8 +216,7 @@ impl<R: Rpc> EmulatorPlatform<R> {
             }
 
             let sdk_account: solana_sdk::account::Account = account.into();
-            let account_data = AccountData::new_from_account(account.pubkey(), &sdk_account);
-            result.push(account_data);
+            result.push((account.pubkey(), SerializedAccount::from(sdk_account)));
         }
 
         Ok(result)


### PR DESCRIPTION
`AccountData` structure is used inside the emulator and has an empty "room" in 10kBytes to extend accounts.
It's better to use another structure and avoid sending the unused 10kBytes of overhead.